### PR TITLE
Fix NullReferenceException when resubmitting a BrokeredMessage

### DIFF
--- a/Controls/ListenerControl.cs
+++ b/Controls/ListenerControl.cs
@@ -620,7 +620,7 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
             messagePropertyGrid.SelectedObject = brokeredMessage;
             BodyType bodyType;
             txtMessageText.Text = XmlHelper.Indent(serviceBusHelper.GetMessageText(brokeredMessage, out bodyType));
-            var listViewItems = brokeredMessage.Properties.Select(p => new ListViewItem(new[] { p.Key, p.Value.ToString() })).ToArray();
+            var listViewItems = brokeredMessage.Properties.Select(p => new ListViewItem(new[] { p.Key, (p.Value ?? "").ToString() })).ToArray();
             messagePropertyListView.Items.Clear();
             messagePropertyListView.Items.AddRange(listViewItems);
         }


### PR DESCRIPTION
When you go to re-submit a message from in the DeadLetter queue, if the message contains a property that has a null value, a NullReferenceException would be thrown when the call is made to ToString()

Let me know if there are any questions,

Thanks!