### PR TITLE
add Chocolatey package creation files

### DIFF
--- a/Chocolatey/AzureServiceBusExplorer.nuspec
+++ b/Chocolatey/AzureServiceBusExplorer.nuspec
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>AzureServiceBusExplorer</id>
+        <version>2.6.1.0</version>
+        <authors>paolosalvatori</authors>
+        <owners>LCHarold</owners>
+        <licenseUrl>https://github.com/paolosalvatori/ServiceBusExplorer/blob/master/LICENSE.txt</licenseUrl>
+        <projectUrl>https://github.com/paolosalvatori/ServiceBusExplorer</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>The Azure Service Bus Explorer allows users to connect to an Azure Service Bus namespace and administer messaging entities in an easy manner. The tool provides advanced features like import/export functionality or the ability to test topic, queues, subscriptions, relay services, notification hubs and events hubs.</description>
+        <summary>GUI for Azure Service Bus</summary>
+        <tags>azure service bus explorer</tags>
+    </metadata>
+    <files>
+        <file src="tools\chocolateyInstall.ps1" target="tools\chocolateyInstall.ps1" />
+    </files>
+</package>

--- a/Chocolatey/tools/chocolateyInstall.ps1
+++ b/Chocolatey/tools/chocolateyInstall.ps1
@@ -1,0 +1,5 @@
+﻿$name   = "AzureServiceBusExplorer"
+$url    = "https://code.msdn.microsoft.com/windowsazure/Service-Bus-Explorer-f2abca5a/file/134519/2/Service%20Bus%20Explorer.zip"
+$unzipLocation = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+Install-ChocolateyZipPackage $name $url $unzipLocation


### PR DESCRIPTION
Every time there's an update to Service Bus Explorer I look for the Chocolatey package and it's never there.  So I decided to do it myself.

Run `nuget.exe pack AzureServiceBusExplorer.nuspec` to generate the Chocolatey package.

To install, run `choco install AzureServiceBusExplorer -source path\to\folder`.

I can build and upload the package to Chocolatey.org if you want, or you can do it yourself if you'd prefer that.