### PR TITLE
Single.TryParse with InvariantCulture for Font 

### DIFF
--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -3779,14 +3779,14 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
             
             var logFontSizeValue = ConfigurationManager.AppSettings[ConfigurationParameters.LogFontSize];
             float tempFloat;
-            if (float.TryParse(logFontSizeValue, out  tempFloat))
+            if (Single.TryParse(logFontSizeValue, NumberStyles.Any, CultureInfo.InvariantCulture, out tempFloat))
             {
                 logFontSize = tempFloat;
                 lstLog.Font = new Font(lstLog.Font.FontFamily, logFontSize);
             }
 
             var treeViewFontSizeValue = ConfigurationManager.AppSettings[ConfigurationParameters.TreeViewFontSize];
-            if (float.TryParse(treeViewFontSizeValue, out  tempFloat))
+            if (Single.TryParse(treeViewFontSizeValue, NumberStyles.Any, CultureInfo.InvariantCulture, out  tempFloat))
             {
                 treeViewFontSize = tempFloat;
                 serviceBusTreeView.Font = new Font(serviceBusTreeView.Font.FontFamily, treeViewFontSize);


### PR DESCRIPTION
With certain cultures the decimal symbol is different from "." and that can wrongly influence the interpretation of the font size. This happens only when a value is wirtten to the .config file.
I changed Float.TryParse(value, out valueFloat) to Single.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out  valueFloat).
