### PR TITLE
Allow Custom DateTime Properties when re-submitting

### DIFF
--- a/Helpers/ConversionHelper.cs
+++ b/Helpers/ConversionHelper.cs
@@ -126,6 +126,8 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
                     return Convert.ChangeType(value, typeof(bool));
                 case "Decimal":
                     return Convert.ChangeType(value, typeof(decimal));
+                case "DateTime":
+                    return Convert.ChangeType(value, typeof(DateTime));
                 case "Guid":
                     return new Guid(value as string);
             }


### PR DESCRIPTION
We have a custom property of type DateTime on our messages, so when resubmitting from the Dead Letter queue, we need that property to go along with the message. 