### PR TITLE
Event Hub "Save Selected Events" improvements

### DIFF
--- a/Controls/PartitionListenerControl.cs
+++ b/Controls/PartitionListenerControl.cs
@@ -109,7 +109,7 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
         private const string DefaultConsumerGroupName = "$Default";
         private const string SaveAsTitle = "Save File As";
         private const string JsonExtension = "json";
-        private const string JsonFilter = "JSON Files|*.json|Text Documents|*.txt";
+        private const string JsonFilter = "JSON Files|*.json|JSON Files With Unserialized Body|*.json|Text Documents|*.txt";
         private const string MessageFileFormat = "EventData_{0}_{1}.json";
         #endregion
 
@@ -1522,9 +1522,10 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
                 {
                     File.Delete(saveFileDialog.FileName);
                 }
+                bool doNotSerializeBody = saveFileDialog.FilterIndex == 2;
                 using (var writer = new StreamWriter(saveFileDialog.FileName))
                 {
-                    writer.Write(MessageSerializationHelper.Serialize(bindingList[currentMessageRowIndex], txtMessageText.Text));
+                    writer.Write(MessageSerializationHelper.Serialize(bindingList[currentMessageRowIndex], txtMessageText.Text, doNotSerializeBody));
                 }
             }
             catch (Exception ex)
@@ -1560,11 +1561,13 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
                 {
                     File.Delete(saveFileDialog.FileName);
                 }
+                bool doNotSerializeBody = saveFileDialog.FilterIndex == 2;
+
                 using (var writer = new StreamWriter(saveFileDialog.FileName))
                 {
                     BodyType bodyType;
-                    var bodies = brokeredMessages.Select(bm => serviceBusHelper.GetMessageText(bm, out bodyType));
-                    writer.Write(MessageSerializationHelper.Serialize(brokeredMessages, bodies));
+                    var bodies = brokeredMessages.Select(bm => serviceBusHelper.GetMessageText(bm, out bodyType, doNotSerializeBody));
+                    writer.Write(MessageSerializationHelper.Serialize(brokeredMessages, bodies, doNotSerializeBody));
                 }
             }
             catch (Exception ex)

--- a/Helpers/MessageSerializationHelper.cs
+++ b/Helpers/MessageSerializationHelper.cs
@@ -63,7 +63,21 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
                 var entityDictionary = new SortedDictionary<string, object>();
                 if (JsonSerializerHelper.IsJson(bodyEnumerable[i]))
                 {
-                    entityDictionary.Add("body", JObject.Parse(bodyEnumerable[i]));
+                    try
+                    {
+                        entityDictionary.Add("body", JObject.Parse(bodyEnumerable[i]));
+                    }
+                    catch (Exception)
+                    {
+                        try
+                        {
+                            entityDictionary.Add("body", JArray.Parse(bodyEnumerable[i]));
+                        }
+                        catch (Exception)
+                        {
+                            entityDictionary.Add("body", bodyEnumerable[i]);
+                        }
+                    }
                 }
                 else
                 {
@@ -106,7 +120,21 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
             var entityDictionary = new SortedDictionary<string, object>();
             if (JsonSerializerHelper.IsJson(body))
             {
-                entityDictionary.Add("body", JObject.Parse(body));
+                try
+                {
+                    entityDictionary.Add("body", JObject.Parse(body));
+                }
+                catch (Exception)
+                {
+                    try
+                    {
+                        entityDictionary.Add("body", JArray.Parse(body));
+                    }
+                    catch (Exception)
+                    {
+                        entityDictionary.Add("body", body);
+                    }
+                }
             }
             else
             {

--- a/Helpers/MessageSerializationHelper.cs
+++ b/Helpers/MessageSerializationHelper.cs
@@ -41,7 +41,7 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
 
         #region Public Static Methods
 
-        public static string Serialize(IEnumerable<object> entities, IEnumerable<string> bodies)
+        public static string Serialize(IEnumerable<object> entities, IEnumerable<string> bodies, bool doNotSerializeBody = false)
         {
             var entityEnumerable = entities as object[] ?? entities.ToArray();
             var bodyEnumerable = bodies as string[] ?? bodies.ToArray();
@@ -61,7 +61,7 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
             for (var i = 0; i < entityEnumerable.Length; i++)
             {
                 var entityDictionary = new SortedDictionary<string, object>();
-                if (JsonSerializerHelper.IsJson(bodyEnumerable[i]))
+                if (!doNotSerializeBody && JsonSerializerHelper.IsJson(bodyEnumerable[i]))
                 {
                     try
                     {
@@ -104,7 +104,7 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
             return JsonSerializerHelper.Serialize(entityList.ToArray(), Formatting.Indented);
         }
 
-        public static string Serialize(object entity, string body)
+        public static string Serialize(object entity, string body, bool doNotSerializeBody = false)
         {
             if (entity == null)
             {
@@ -118,7 +118,7 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
             }
             var propertyDictionary = propertyCache[type.FullName];
             var entityDictionary = new SortedDictionary<string, object>();
-            if (JsonSerializerHelper.IsJson(body))
+            if (!doNotSerializeBody && JsonSerializerHelper.IsJson(body))
             {
                 try
                 {


### PR DESCRIPTION
# Improvement 1: Event Save silently fails for JSON Arrays payloads
Example: 
```json
[
      {
        "time": "2015-09-03T16:12:54.8040267Z",
        "name": "PostCounter",
        "value": 69445
      },
      {
        "time": "2015-09-03T16:12:54.8040267Z",
        "name": "Value_114779289",
        "value": 13.94
      }
]
```
**Reason:** JObject.Parse rejects JSON arrays for some reason. 
**Fix:** Attempt parsing with JArray.Parse if JObject.Parse fails. 
Commit: MarkusHorstmann/ServiceBusExplorer@011e1d948d30e1fd5591736d2441c78f70d2b441

# Improvement 2: Saving large number (100s) of events with JSON Array payload takes a fairly long time (minutes)
**Reason:** Multiple attempts of deserializing as XML etc. for each event, with JSON being the last one.
**Fix:** Add option to not reserialize the payload at all and instead always embed it as a string, which also come in handy as a feature when debugging payload formatting/syntax issues.
Commit: MarkusHorstmann/ServiceBusExplorer@a5aff23bdf2089afb0a615099a11f901e05d8290. 
