### PR TITLE
Read connection string from user environment variable AzureServiceBus…

### DIFF
--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -319,6 +319,7 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
             eventClickFieldInfo = typeof(ToolStripItem).GetField(EventClick, BindingFlags.NonPublic | BindingFlags.Static);
             eventsPropertyInfo = typeof(Component).GetProperty(EventsProperty, BindingFlags.NonPublic | BindingFlags.Instance);
             GetServiceBusNamespacesFromConfiguration();
+            GetServiceBusNamespaceFromEnvironmentVariable();
             GetBrokeredMessageInspectorsFromConfiguration();
             GetEventDataInspectorsFromConfiguration();
             GetBrokeredMessageGeneratorsFromConfiguration();
@@ -3478,6 +3479,16 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
             catch (Exception ex)
             {
                 HandleException(ex);
+            }
+        }
+
+        private void GetServiceBusNamespaceFromEnvironmentVariable()
+        {
+            var connectionString = Environment.GetEnvironmentVariable("AzureServiceBus.ConnectionString", EnvironmentVariableTarget.User);
+            if (!string.IsNullOrWhiteSpace(connectionString))
+            {
+                const string key = @"HKEY_CURRENT_USER\Environment connection string";
+                serviceBusHelper.ServiceBusNamespaces.Add(key, GetServiceBusNamespace(key, connectionString));
             }
         }
 


### PR DESCRIPTION
## Change

Allow reading of connection string from an environment variable scoped to the current user (`HKCU\Environment` `"AzureServiceBus.ConnectionString"`) to survive app.config resets

## Purpose of this change

Each time a new version is available, app.config is reset and changes are lost. It's easier to keep an environment variable to keep default connection out of app.config and safe from accidental commits. 