### PR TITLE
Allow a single entity deletion with Delete key

### DIFF
--- a/Forms/MainForm.Designer.cs
+++ b/Forms/MainForm.Designer.cs
@@ -576,6 +576,7 @@
             this.serviceBusTreeView.Size = new System.Drawing.Size(362, 537);
             this.serviceBusTreeView.TabIndex = 13;
             this.serviceBusTreeView.NodeMouseClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.serviceBusTreeView_NodeMouseClick);
+            this.serviceBusTreeView.KeyUp += new System.Windows.Forms.KeyEventHandler(this.serviceBusTreeView_KeyUp);
             // 
             // panelMain
             // 

--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -2091,6 +2091,14 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
             }
         }
 
+        private void serviceBusTreeView_KeyUp(object sender, KeyEventArgs keyEventArgs)
+        {
+            if (keyEventArgs.KeyCode == Keys.Delete)
+            {
+                deleteEntity_Click(sender, keyEventArgs);
+            }
+        }
+
         private void deleteEntity_Click(object sender, EventArgs e)
         {
             try


### PR DESCRIPTION
Currently one needs to use context menu and select delete option to remove a single entity.
This change allows deletion with a single delete key for convenience. 