### PR TITLE
Trim whitespace from ConnectionString and clear SessionState when null

### DIFF
--- a/Controls/HandleQueueControl.cs
+++ b/Controls/HandleQueueControl.cs
@@ -2877,6 +2877,7 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
             var stream = messageSession.GetState();
             if (stream == null)
             {
+                txtSessionState.Text = string.Empty;
                 return;
             }
             using (stream)

--- a/Forms/ConnectForm.cs
+++ b/Forms/ConnectForm.cs
@@ -164,7 +164,7 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
 
             if (cboServiceBusNamespace.Text == EnterConnectionString || connectionStringType == ServiceBusNamespaceType.OnPremises || containsStsEndpoint)
             {
-                ConnectionString = txtUri.Text;
+                ConnectionString = txtUri.Text.Trim();
                 if (string.IsNullOrWhiteSpace(ConnectionString))
                 {
                     MainForm.StaticWriteToLog(ConnectionStringCannotBeNull);


### PR DESCRIPTION
* trim whitespace from the entered ConnectionString to avoid problems when connecting
* clear the field for SessionState when switching to another session where SessionState is null