### PR TITLE
Corrected hint path to nunit.framework.dll

### DIFF
--- a/ServiceBusExplorer.Tests/ServiceBusExplorer.Tests.csproj
+++ b/ServiceBusExplorer.Tests/ServiceBusExplorer.Tests.csproj
@@ -30,7 +30,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\ServiceBusExplorer2\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.util">


### PR DESCRIPTION
Seems there was an incorrect hint path in the unit test project file - sorry about that.