### PR TITLE
Fix selected entities initializing

### DIFF
--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -3969,18 +3969,16 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
             parameter = ConfigurationManager.AppSettings[ConfigurationParameters.SelectedEntitiesParameter];
             if (!string.IsNullOrEmpty(parameter))
             {
-                var items = parameter.Split(',');
-                if (items.Length == 0)
+                var items = parameter.Split(',').Select(item => item.Trim()).ToList();
+                if (items.Count == 0)
                 {
                     GetDefaultSelectedEntities();
                 }
                 else
                 {
-                    var lowerCaseEntities = entities.Select(e => e.ToLower());
-                    var list = lowerCaseEntities as IList<string> ?? lowerCaseEntities.ToList();
                     foreach (var item in items)
                     {
-                        if (list.Contains(item.ToLower()))
+                        if (entities.Contains(item, StringComparer.OrdinalIgnoreCase))
                         {
                             selectedEntites.Add(item);
                         }


### PR DESCRIPTION
At the startup of list of the selected entities is initialized only with the first item even more the one entity is saved in the configuration file. The configured entities are prefixed with a single space so they do not match the predefined entity names. The fix contains config values trim and a little simplification in selected list creation.