### PR TITLE
Fix mapping from custom property of type Guid when resubmitting a message

### DIFF
--- a/Helpers/ConversionHelper.cs
+++ b/Helpers/ConversionHelper.cs
@@ -123,7 +123,7 @@ namespace Microsoft.WindowsAzure.CAT.ServiceBusExplorer
                 case "Decimal":
                     return Convert.ChangeType(value, typeof(decimal));
                 case "Guid":
-                    return new Guid(value as string);
+                    return new Guid(value.ToString());
             }
             throw new NotSupportedException(string.Format(TypeNotSupported, type));
         }


### PR DESCRIPTION
Currently when a message wil be resubmitted and the originl message contains an custom property (aka header) of type Guid, the conversion of the values into the new message failes. This is because that in situation the datatype of the value is already a System.Guid. Converting to System.String will result in a null which will cause an exception. This fix is already done in the masterbranch.