### PR TITLE
Version should not be hardcoded from the code

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.4.6.0")]
-[assembly: AssemblyFileVersion("3.4.6.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
 
 


### PR DESCRIPTION
Version is set by appveyor in [appveyor.xml](https://github.com/paolosalvatori/ServiceBusExplorer/blob/master/appveyor.yml#L23). Version is always is using ASBmajor.ASBminor.BuildNumber. `BuildNumber` is managed by appveyor to uniquely identify each build. Locally build versions are always 1.0.0.0

This exact issue #71 was fixed before and not it has been re-introduced in commit 7dd0063463d40213b1686fc0afcdc79a77202a94 ([line](https://github.com/paolosalvatori/ServiceBusExplorer/commit/7dd0063463d40213b1686fc0afcdc79a77202a94#diff-bd54859a3ac1af0ed67607c0767acc72R35) and [line](https://github.com/paolosalvatori/ServiceBusExplorer/commit/7dd0063463d40213b1686fc0afcdc79a77202a94#diff-bd54859a3ac1af0ed67607c0767acc72R36)).

@paolosalvatori please see above