### PR TITLE
Keep eventual root $type property in Json indentation

### DIFF
--- a/Helpers/JsonSerializerHelper.cs
+++ b/Helpers/JsonSerializerHelper.cs
@@ -41,7 +41,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
         {
             try
             {
-                return JsonConvert.SerializeObject(JsonConvert.DeserializeObject(json), Formatting.Indented);
+                return JsonConvert
+                    .SerializeObject(JsonConvert.DeserializeObject(json.Replace("$type", "%%$type%%")), Formatting.Indented)
+                    .Replace("%%$type%%", "$type");
             }
             catch (Exception)
             {

--- a/ServiceBusExplorer.Tests/Helpers/JsonSerializerHelperTest.cs
+++ b/ServiceBusExplorer.Tests/Helpers/JsonSerializerHelperTest.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.Azure.ServiceBusExplorer.Helpers;
+using NUnit.Framework;
+
+namespace Microsoft.Azure.ServiceBusExplorer.Tests.Helpers
+{
+    [TestFixture]
+    public class JsonSerializerHelperTest
+    {
+        [Test]
+        public void IndentJson_ValueIsNotJson_ReturnsOriginalString()
+        {
+            var myOriginalString = "This is a full text string that is not a JSON";
+            var indented = JsonSerializerHelper.Indent(myOriginalString);
+
+            Assert.AreEqual(indented, myOriginalString);
+        }
+
+        [Test]
+        public void IndentJson_ValueIsXml_ReturnsOriginalString()
+        {
+            var myOriginalString = "<sample><title>XML tile</title><alternate language=\"en\">A tile made from some classical XML content.</language></sample>";
+            var indented = JsonSerializerHelper.Indent(myOriginalString);
+
+            Assert.AreEqual(indented, myOriginalString);
+        }
+
+        [Test]
+        public void IndentJson_ValueIsJson_ReturnsIndentedString()
+        {
+            var json = "{prop1:\"val1\",prop2:2,\"prop3\":[1, 2, 3],prop4:{subProp1:1,subProp2:\"string\",subProp3:[\"a\",\"b\",\"c\"]}}";
+            var expectedResult = @"{
+  ""prop1"": ""val1"",
+  ""prop2"": 2,
+  ""prop3"": [
+    1,
+    2,
+    3
+  ],
+  ""prop4"": {
+    ""subProp1"": 1,
+    ""subProp2"": ""string"",
+    ""subProp3"": [
+      ""a"",
+      ""b"",
+      ""c""
+    ]
+  }
+}";
+            var indented = JsonSerializerHelper.Indent(json);
+
+            Assert.AreEqual(indented, expectedResult);
+        }
+
+        [Test]
+        public void IndentJson_ValueHasTypeHandling_ReturnsIndentedStringWithTypeHandling()
+        {
+            var json = "{\"$type\":\"MyAwesomeLibrary.MyAwesomeClass\",prop1:1,prop2:2,obj:{\"$type\":\"MyAwesomeLibrary.MyOtherAwesomeClass\",default:true}}";
+            var expectedResult = @"{
+  ""$type"": ""MyAwesomeLibrary.MyAwesomeClass"",
+  ""prop1"": 1,
+  ""prop2"": 2,
+  ""obj"": {
+    ""$type"": ""MyAwesomeLibrary.MyOtherAwesomeClass"",
+    ""default"": true
+  }
+}";
+            var indented = JsonSerializerHelper.Indent(json);
+
+            Assert.AreEqual(indented, expectedResult);
+        }
+    }
+}

--- a/ServiceBusExplorer.Tests/ServiceBusExplorer.Tests.csproj
+++ b/ServiceBusExplorer.Tests/ServiceBusExplorer.Tests.csproj
@@ -36,6 +36,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Helpers\ConversionHelperTests.cs" />
+    <Compile Include="Helpers\JsonSerializerHelperTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
If the message sent to the service bus used Newtonsoft with TypeHandling defined, when indenting the string the `$type` property is dismissed by ServiceBusExplorer in Message Text components.

As we cannot use TypeHandling (ServiceBusExplorer does not know about user classes) I propose here to search and replace `$type` keyword during deserialization / serialization process.

Fix tested and approved on Service Bus Queues