### PR TITLE
Reflect entity size correctly

### DIFF
--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -1482,13 +1482,16 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
 
             // MaxQueueSizeInBytes
             trackBarMaxQueueSize.Value = serviceBusHelper.IsCloudNamespace
-                ? (int)
-                (queueDescription.EnablePartitioning
-                    ? queueDescription.MaxSizeInMegabytes/16384
-                    : queueDescription.MaxSizeInMegabytes/1024)
+                ? queueDescription.MaxSizeInGigabytes()
                 : queueDescription.MaxSizeInMegabytes == SeviceBusForWindowsServerMaxQueueSize
-                    ? 11
-                    : (int) queueDescription.MaxSizeInMegabytes/1024;
+                ? 11 : queueDescription.MaxSizeInGigabytes();
+
+            // Update maximum and value if Maximum size is more than 5 Gigs (either premium or partitioned)
+            if (queueDescription.MaxSizeInGigabytes() > 5)
+            {
+                trackBarMaxQueueSize.Maximum = queueDescription.MaxSizeInGigabytes();
+                trackBarMaxQueueSize.Value = queueDescription.MaxSizeInGigabytes();
+            }
 
             // MaxDeliveryCount
             txtMaxDeliveryCount.Text = queueDescription.MaxDeliveryCount.ToString(CultureInfo.InvariantCulture);

--- a/src/ServiceBusExplorer/Controls/HandleTopicControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleTopicControl.cs
@@ -564,10 +564,16 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
 
             // MaxQueueSizeInBytes
             trackBarMaxTopicSize.Value = serviceBusHelper.IsCloudNamespace
-                                             ? (int)(topicDescription.EnablePartitioning ? topicDescription.MaxSizeInMegabytes / 16384 : topicDescription.MaxSizeInMegabytes / 1024)
+                                             ? topicDescription.MaxSizeInGigabytes()
                                              : topicDescription.MaxSizeInMegabytes == SeviceBusForWindowsServerMaxTopicSize
-                                                   ? 11
-                                                   : (int)topicDescription.MaxSizeInMegabytes / 1024;
+                                             ? 11 : topicDescription.MaxSizeInGigabytes();
+
+            // Update maximum and value if Maximum size is more than 5 Gigs (either premium or partitioned)
+            if (topicDescription.MaxSizeInGigabytes() > 5)
+            {
+                trackBarMaxTopicSize.Maximum = topicDescription.MaxSizeInGigabytes();
+                trackBarMaxTopicSize.Value = topicDescription.MaxSizeInGigabytes();
+            }
 
             // DefaultMessageTimeToLive
             txtDefaultMessageTimeToLiveDays.Text = topicDescription.DefaultMessageTimeToLive.Days.ToString(CultureInfo.InvariantCulture);

--- a/src/ServiceBusExplorer/Helpers/QueueDescriptionExtensions.cs
+++ b/src/ServiceBusExplorer/Helpers/QueueDescriptionExtensions.cs
@@ -1,0 +1,12 @@
+﻿namespace Microsoft.Azure.ServiceBusExplorer.Helpers
+{
+    using ServiceBus.Messaging;
+
+    static class QueueDescriptionExtensions
+    {
+        public static int MaxSizeInGigabytes(this QueueDescription queueDescription)
+        {
+            return (int) (queueDescription.MaxSizeInMegabytes / 1024);
+        }
+    }
+}

--- a/src/ServiceBusExplorer/Helpers/SimpleSite.cs
+++ b/src/ServiceBusExplorer/Helpers/SimpleSite.cs
@@ -29,7 +29,7 @@ using System.ComponentModel;
 
 namespace Microsoft.Azure.ServiceBusExplorer.Helpers
 {
-    internal sealed class SimpleSite : ISite, IServiceProvider
+    internal sealed class SimpleSite : ISite
     {
         #region Private Fields
         private readonly IContainer container = new Container();

--- a/src/ServiceBusExplorer/Helpers/TopicDescriptionExtensions.cs
+++ b/src/ServiceBusExplorer/Helpers/TopicDescriptionExtensions.cs
@@ -1,0 +1,12 @@
+﻿namespace Microsoft.Azure.ServiceBusExplorer.Helpers
+{
+    using ServiceBus.Messaging;
+
+    static class TopicDescriptionExtensions
+    {
+        public static int MaxSizeInGigabytes(this TopicDescription topicDescription)
+        {
+            return (int) (topicDescription.MaxSizeInMegabytes / 1024);
+        }
+    }
+}

--- a/src/ServiceBusExplorer/ServiceBusExplorer.csproj
+++ b/src/ServiceBusExplorer/ServiceBusExplorer.csproj
@@ -413,6 +413,8 @@
     <Compile Include="Helpers\NotificationHubAuthorizationRuleWrapper.cs" />
     <Compile Include="Helpers\OnOffDeviceBrokeredMessageGenerator.cs" />
     <Compile Include="Helpers\PropertyComparer.cs" />
+    <Compile Include="Helpers\TopicDescriptionExtensions.cs" />
+    <Compile Include="Helpers\QueueDescriptionExtensions.cs" />
     <Compile Include="Helpers\ReadOnlyEditor.cs" />
     <Compile Include="Helpers\ReadOnlyList.cs" />
     <Compile Include="Helpers\RegistrationInfo.cs" />


### PR DESCRIPTION
Part of future 4.0.92 release

Fixes #120 and #97 
- Reflects premium tier entity size correctly (1, 2, 3, 4, 5, 10, 20, 40, 80 GB).
- Reflects standard tier entity size correctly (1, 2, 3, 4, 5 for non-partitioned and 16, 32, 48, 64, 80 GB for partitioned).

Note: creation is still not reflecting sizes as there's no way to know what namespace it is.