### PR TITLE
Chocolatey Verification - Use template and only hash ServiceBusExplorer.exe

### DIFF
--- a/Generate-VerificationFile.ps1
+++ b/Generate-VerificationFile.ps1
@@ -12,7 +12,7 @@ param(
 Write-Output "Creating VERIFICATION.txt based on template '$($TemplateFilePath)' for '$($ExePath)'"
 
 # Get content of template
-$rawTemplate = Get-Content $TemplateFilePath
+$rawTemplate = Get-Content $TemplateFilePath | Out-String
 Write-Output "VERIFICATION.txt template: $($rawTemplate)"
 
 # Hash ServiceBusExplorer.exe

--- a/Generate-VerificationFile.ps1
+++ b/Generate-VerificationFile.ps1
@@ -13,6 +13,7 @@ Write-Output "Creating VERIFICATION.txt based on template '$($TemplateFilePath)'
 
 # Get content of template
 $rawTemplate = Get-Content $TemplateFilePath
+Write-Output "VERIFICATION.txt template: $($rawTemplate)"
 
 # Hash ServiceBusExplorer.exe
 $hashResult = Get-FileHash $ExePath -Algorithm MD5

--- a/Generate-VerificationFile.ps1
+++ b/Generate-VerificationFile.ps1
@@ -1,30 +1,31 @@
 param(
+    [Parameter(Mandatory=$true, HelpMessage="Released version of ServiceBusExplorer")]
+    [string] $Version,
+    [Parameter(Mandatory=$true, HelpMessage="Path to the ServiceBusExplorer exe")]
+    [string] $ExePath,
+    [Parameter(Mandatory=$true, HelpMessage="Location of the VERIFICATION.txt template")]
+    [string] $TemplateFilePath,
     [Parameter(Mandatory=$true, HelpMessage="Location to output the result to")]
     [string] $OutputFilePath
 )
 
-# Store original location and move to output
-$originalLocation = Get-Location
-Set-Location "$($env:APPVEYOR_BUILD_FOLDER)\src\ServiceBusExplorer\bin\Release"
+Write-Output "Creating VERIFICATION.txt based on template '$($TemplateFilePath)' for '$($ExePath)'"
 
-# Get all files
-$files = Get-ChildItem -File
+# Get content of template
+$rawTemplate = Get-Content $TemplateFilePath
 
-# Create a string builder to append all checksums
-$verificationBuilder = New-Object System.Text.StringBuilder
+# Hash ServiceBusExplorer.exe
+$hashResult = Get-FileHash $ExePath -Algorithm MD5
+Write-Output "Created hash '$($hashResult.Hash)'"
 
-# Loop all files to hash and append to string builder
-foreach ($file in $files) {
-    $hashResult = Get-FileHash $file -Algorithm MD5
-    $verificationBuilder.AppendLine("- $($file.Name) - $($hashResult.Hash)")
+# Update template with checksum
+$rawTemplate = $rawTemplate.Replace('%CHECKSUM%', $hashResult.Hash)
+Write-Output "Replaced checksum in template with '$($hashResult.Hash)'"
 
-    Write-Host "Processed $($file.Name)"
-}
+# Updating template with version
+$rawTemplate = $rawTemplate.Replace('%VERSION%', $Version)
+Write-Output "Replaced version in template with '$($Version)'"
 
 # Store output in VERIFICATION file
-New-Item -Path $OutputFilePath -Value $verificationBuilder.ToString() -Force
-
-# Move back to original location
-Set-Location $originalLocation
-
+New-Item -Path $OutputFilePath -Value $rawTemplate -Force
 Write-Host "Wrote results to $($OutputFilePath)"

--- a/VERIFICATION-Template.txt
+++ b/VERIFICATION-Template.txt
@@ -1,0 +1,17 @@
+VERIFICATION
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+
+The installer have been downloaded from their official download link listed on <https://github.com/paolosalvatori/ServiceBusExplorer/releases>
+and can be verified like this:
+
+1. Download the following installers:
+  64-Bit: <https://github.com/paolosalvatori/ServiceBusExplorer/releases/download/%VERSION%/ServiceBusExplorer-%VERSION%.zip>
+2. You can use one of the following methods to obtain the checksum
+  - Use powershell function 'Get-Filehash'
+  - Use chocolatey utility 'checksum.exe'
+
+  checksum type:
+  checksum64: %CHECKSUM%
+
+File 'LICENSE.txt' is obtained from <https://github.com/paolosalvatori/ServiceBusExplorer/blob/master/LICENSE.txt>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,7 @@ after_build:
   - ps: >-
       # Reset VERIFICATION file.
       (Set-Content -Value "VERIFICATION=MD5" -Path $env:APPVEYOR_BUILD_FOLDER\VERIFICATION.txt)
-  - ps: .\Generate-VerificationFile.ps1 -OutputFilePath "$($env:APPVEYOR_BUILD_FOLDER)\src\ServiceBusExplorer\bin\Release\VERIFICATION.txt"
+  - ps: .\Generate-VerificationFile.ps1 -Version $env:GitVersion_MajorMinorPatch -TemplatePath VERIFICATION-Template.txt -ExePath "$($env:APPVEYOR_BUILD_FOLDER)\src\ServiceBusExplorer\bin\Release\ServiceBusExplorer.exe" -OutputFilePath "$($env:APPVEYOR_BUILD_FOLDER)\src\ServiceBusExplorer\bin\Release\VERIFICATION.txt"
   - 7z a ServiceBusExplorer-%GitVersion_MajorMinorPatch%.zip %APPVEYOR_BUILD_FOLDER%\src\ServiceBusExplorer\bin\Release\*.*
   - ps: (Get-Content $env:APPVEYOR_BUILD_FOLDER\src\ServiceBusExplorer\ServiceBusExplorer.nuspec).Replace("`$version`$", "$env:GitVersion_MajorMinorPatch") | Set-Content $env:APPVEYOR_BUILD_FOLDER\src\ServiceBusExplorer\ServiceBusExplorer.nuspec
   - choco pack %APPVEYOR_BUILD_FOLDER%\src\ServiceBusExplorer\ServiceBusExplorer.nuspec

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ assembly_info:
   patch: false
 
 environment:
+  choco_version: 4.0.102
   choco_token:
     secure: 68Fr+kbT0ilhb84AyU/kKVWJw74urnreRDCpZ2L89v0cJeuEGcOchKGIFsy4Hp+V
 
@@ -59,7 +60,7 @@ after_build:
       (Set-Content -Value "VERIFICATION=MD5" -Path $env:APPVEYOR_BUILD_FOLDER\VERIFICATION.txt)
   - ps: .\Generate-VerificationFile.ps1 -Version $env:GitVersion_MajorMinorPatch -TemplateFilePath VERIFICATION-Template.txt -ExePath "$($env:APPVEYOR_BUILD_FOLDER)\src\ServiceBusExplorer\bin\Release\ServiceBusExplorer.exe" -OutputFilePath "$($env:APPVEYOR_BUILD_FOLDER)\src\ServiceBusExplorer\bin\Release\VERIFICATION.txt"
   - 7z a ServiceBusExplorer-%GitVersion_MajorMinorPatch%.zip %APPVEYOR_BUILD_FOLDER%\src\ServiceBusExplorer\bin\Release\*.*
-  - ps: (Get-Content $env:APPVEYOR_BUILD_FOLDER\src\ServiceBusExplorer\ServiceBusExplorer.nuspec).Replace("`$version`$", "$env:GitVersion_MajorMinorPatch") | Set-Content $env:APPVEYOR_BUILD_FOLDER\src\ServiceBusExplorer\ServiceBusExplorer.nuspec
+  - ps: (Get-Content $env:APPVEYOR_BUILD_FOLDER\src\ServiceBusExplorer\ServiceBusExplorer.nuspec).Replace("`$version`$", "$env:choco_version") | Set-Content $env:APPVEYOR_BUILD_FOLDER\src\ServiceBusExplorer\ServiceBusExplorer.nuspec
   - choco pack %APPVEYOR_BUILD_FOLDER%\src\ServiceBusExplorer\ServiceBusExplorer.nuspec
 
 #---------------------------------#
@@ -67,7 +68,7 @@ after_build:
 #---------------------------------#
 
 on_success:
-  - IF '%APPVEYOR_REPO_BRANCH%'=='master' IF '%APPVEYOR_PULL_REQUEST_NUMBER%'=='' choco push ServiceBusExplorer.%GitVersion_MajorMinorPatch%.nupkg -k="'%choco_token%'"
+  - IF '%APPVEYOR_REPO_BRANCH%'=='develop' IF '%APPVEYOR_PULL_REQUEST_NUMBER%'=='' choco push ServiceBusExplorer.%choco_version%.nupkg -k="'%choco_token%'"
 
 #---------------------------------#
 #      artifacts configuration    #
@@ -77,7 +78,7 @@ artifacts:
   - path: '*.zip'  # bin\$(configuration)\*.*
     name: 'ServiceBusExplorer-%GitVersion_MajorMinorPatch%'
   - path: '*.nupkg'
-    name: 'ServiceBusExplorer-Chocolatey-%GitVersion_MajorMinorPatch%'
+    name: 'ServiceBusExplorer-Chocolatey-%choco_version%'
 
 #---------------------------------#
 #     GitHub PR notifications     #

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,7 @@ after_build:
   - ps: >-
       # Reset VERIFICATION file.
       (Set-Content -Value "VERIFICATION=MD5" -Path $env:APPVEYOR_BUILD_FOLDER\VERIFICATION.txt)
-  - ps: .\Generate-VerificationFile.ps1 -Version $env:GitVersion_MajorMinorPatch -TemplatePath VERIFICATION-Template.txt -ExePath "$($env:APPVEYOR_BUILD_FOLDER)\src\ServiceBusExplorer\bin\Release\ServiceBusExplorer.exe" -OutputFilePath "$($env:APPVEYOR_BUILD_FOLDER)\src\ServiceBusExplorer\bin\Release\VERIFICATION.txt"
+  - ps: .\Generate-VerificationFile.ps1 -Version $env:GitVersion_MajorMinorPatch -TemplateFilePath VERIFICATION-Template.txt -ExePath "$($env:APPVEYOR_BUILD_FOLDER)\src\ServiceBusExplorer\bin\Release\ServiceBusExplorer.exe" -OutputFilePath "$($env:APPVEYOR_BUILD_FOLDER)\src\ServiceBusExplorer\bin\Release\VERIFICATION.txt"
   - 7z a ServiceBusExplorer-%GitVersion_MajorMinorPatch%.zip %APPVEYOR_BUILD_FOLDER%\src\ServiceBusExplorer\bin\Release\*.*
   - ps: (Get-Content $env:APPVEYOR_BUILD_FOLDER\src\ServiceBusExplorer\ServiceBusExplorer.nuspec).Replace("`$version`$", "$env:GitVersion_MajorMinorPatch") | Set-Content $env:APPVEYOR_BUILD_FOLDER\src\ServiceBusExplorer\ServiceBusExplorer.nuspec
   - choco pack %APPVEYOR_BUILD_FOLDER%\src\ServiceBusExplorer\ServiceBusExplorer.nuspec


### PR DESCRIPTION
- Use template to include pointer to license & release
- Only hash ServiceBusExplorer.exe instead of all contents
- Currently only push to Chocolatey from develop branch with fixed 4.0.102 version until we pass validation via environment variable `choco_version`.

Relates to #137.

Example of VERIFICATION.txt:
```
VERIFICATION
Verification is intended to assist the Chocolatey moderators and community
in verifying that this package's contents are trustworthy.

The installer have been downloaded from their official download link listed on <https://github.com/paolosalvatori/ServiceBusExplorer/releases>
and can be verified like this:

1. Download the following installers:
  64-Bit: <https://github.com/paolosalvatori/ServiceBusExplorer/releases/download/4.0.104/ServiceBusExplorer-4.0.104.zip>
2. You can use one of the following methods to obtain the checksum
  - Use powershell function 'Get-Filehash'
  - Use chocolatey utility 'checksum.exe'

  checksum type:
  checksum64: 728D4268F5BBB6F185FF3355A0E039CF

File 'LICENSE.txt' is obtained from <https://github.com/paolosalvatori/ServiceBusExplorer/blob/master/LICENSE.txt>
```