### PR TITLE
Add Visual Studio's .vs folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+
+# Visual Studio 2015 cache/options directory
+.vs/


### PR DESCRIPTION
May I suggest you include .vs as an ignore pattern in .gitignore? Otherwise git clients start to pick up on the .vs folder which should not live under version control.