### PR TITLE
Support purge from queues and subscriptions that require a session

### DIFF
--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -473,10 +473,11 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                     {
                         var messages = await session.ReceiveBatchAsync(1000, TimeSpan.FromMilliseconds(100))
                                                     .ConfigureAwait(false);
-                        if (0 < messages.Count())
+                        var messagesCount = messages.Count();
+                        if (0 < messagesCount)
                         {
-                            var locktokens = messages.Select(m => m.LockToken).ToArray();
-                            totalMessagesPurged += locktokens.Length;
+                            totalMessagesPurged += messagesCount;
+                            var locktokens = messages.Select(m => m.LockToken);
                             await session.CompleteBatchAsync(locktokens)
                                          .ConfigureAwait(false);
                         }

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -438,10 +438,12 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                 int count = 0;
                 stopwatch.Start();
                 var messagingFactory = MessagingFactory.CreateFromConnectionString(serviceBusHelper.ConnectionString);
-                if (queueDescription.RequiresSession) {
+                if (queueDescription.RequiresSession)
+                {
                     count = await PurgeSessionedQueue(messagingFactory).ConfigureAwait(false);
                 }
-                else {
+                else
+                {
                     count = await PurgeNonSessionedQueue(messagingFactory).ConfigureAwait(false);
                 }
                 stopwatch.Stop();
@@ -455,26 +457,31 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
             }
         }
 
-        private async Task<int> PurgeSessionedQueue(MessagingFactory messagingFactory) {
+        private async Task<int> PurgeSessionedQueue(MessagingFactory messagingFactory)
+        {
             var totalMessagesPurged = 0;
-
             var client = messagingFactory.CreateQueueClient(queueDescription.Path);
 
-            try {
-                while (true) {
+            try
+            {
+                while (true)
+                {
                     var session = await client.AcceptMessageSessionAsync(TimeSpan.FromMilliseconds(100))
                                               .ConfigureAwait(false);
 
-                    while (true) {
+                    while (true)
+                    {
                         var messages = await session.ReceiveBatchAsync(1000, TimeSpan.FromMilliseconds(100))
                                                     .ConfigureAwait(false);
-                        if (0 < messages.Count()) {
+                        if (0 < messages.Count())
+                        {
                             var locktokens = messages.Select(m => m.LockToken).ToArray();
                             totalMessagesPurged += locktokens.Length;
                             await session.CompleteBatchAsync(locktokens)
                                          .ConfigureAwait(false);
                         }
-                        else {
+                        else
+                        {
                             break;
                         }
                     }
@@ -482,35 +489,43 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                     await session.CloseAsync().ConfigureAwait(false);
                 }
             }
-            catch ( TimeoutException ) {
+            catch (TimeoutException)
+            {
                 // ignore the exception, the AcceptMessageSessionAsync throws when no more sessions
             }
-            finally {
+            finally
+            {
                 await client.CloseAsync().ConfigureAwait(false);
             }
 
             return totalMessagesPurged;
         }
 
-        private async Task<int> PurgeNonSessionedQueue(MessagingFactory messagingFactory) {
-
+        private async Task<int> PurgeNonSessionedQueue(MessagingFactory messagingFactory)
+        {
             var totalMessagesPurged = 0;
-
             var receiver = await messagingFactory.CreateMessageReceiverAsync(queueDescription.Path, ReceiveMode.ReceiveAndDelete).ConfigureAwait(false);
 
-            try {
-                while (true) {
+            try
+            {
+                while (true)
+                {
                     var messages = await receiver.ReceiveBatchAsync(1000, TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
                     var messagesCount = messages.Count();
                     totalMessagesPurged += messagesCount;
-                    if (messagesCount == 0) {
-                        if (queueDescription.EnablePartitioning) {
-                            while (true) {
+                    if (messagesCount == 0)
+                    {
+                        if (queueDescription.EnablePartitioning)
+                        {
+                            while (true)
+                            {
                                 var message = await receiver.ReceiveAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
-                                if (message != null) {
+                                if (message != null)
+                                {
                                     totalMessagesPurged++;
                                 }
-                                else {
+                                else
+                                {
                                     break;
                                 }
                             }
@@ -519,7 +534,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                     }
                 }
             }
-            finally {
+            finally
+            {
                 await receiver.CloseAsync().ConfigureAwait(false);
             }
 

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -461,10 +461,11 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                     {
                         var messages = await session.ReceiveBatchAsync(1000, TimeSpan.FromMilliseconds(100))
                                                     .ConfigureAwait(false);
-                        if (0 < messages.Count())
+                        var messagesCount = messages.Count();
+                        if (0 < messagesCount)
                         {
-                            var locktokens = messages.Select(m => m.LockToken).ToArray();
-                            totalMessagesPurged += locktokens.Length;
+                            totalMessagesPurged += messagesCount;
+                            var locktokens = messages.Select(m => m.LockToken);
                             await session.CompleteBatchAsync(locktokens)
                                          .ConfigureAwait(false);
                         }

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -417,44 +417,19 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                 }
             }
 
-            try
-            {
+            try {
                 Application.UseWaitCursor = true;
                 var stopwatch = new Stopwatch();
                 stopwatch.Start();
 
+                var count = 0;
                 var entityPath = SubscriptionClient.FormatSubscriptionPath(subscriptionWrapper.SubscriptionDescription.TopicPath, subscriptionWrapper.SubscriptionDescription.Name);
                 var messagingFactory = MessagingFactory.CreateFromConnectionString(serviceBusHelper.ConnectionString);
-                var receiver = await messagingFactory.CreateMessageReceiverAsync(entityPath, ReceiveMode.ReceiveAndDelete);
-                var count = 0;
-                while (true)
-                {
-                    var messages = await receiver.ReceiveBatchAsync(1000, TimeSpan.FromMilliseconds(100));
-                    // ReSharper disable once PossibleMultipleEnumeration
-                    if (messages.Any())
-                    {
-                        // ReSharper disable once PossibleMultipleEnumeration
-                        count += messages.Count();
-                    }
-                    else
-                    {
-                        if (subscriptionWrapper.TopicDescription.EnablePartitioning)
-                        {
-                            while (true)
-                            {
-                                var message = await receiver.ReceiveAsync(TimeSpan.FromMilliseconds(100));
-                                if (message != null)
-                                {
-                                    count++;
-                                }
-                                else
-                                {
-                                    break;
-                                }
-                            }
-                        }
-                        break;
-                    }
+                if (subscriptionWrapper.SubscriptionDescription.RequiresSession) {
+                    count = await PurgeSessionedTopic(subscriptionWrapper.SubscriptionDescription.TopicPath, subscriptionWrapper.SubscriptionDescription.Name, messagingFactory);
+                }
+                else {
+                    count = await PurgeNonSessionedTopic(entityPath, messagingFactory);
                 }
                 stopwatch.Stop();
                 MainForm.SingletonMainForm.refreshEntity_Click(null, null);
@@ -465,6 +440,70 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
             {
                 Application.UseWaitCursor = false;
             }
+        }
+
+        private async Task<int> PurgeSessionedTopic(string topicPath, string subscriptionName, MessagingFactory messagingFactory) {
+            var count = 0;
+
+            var client = messagingFactory.CreateSubscriptionClient(topicPath, subscriptionName);
+
+            try {
+                while (true) {
+                    // use a larger timeout because sometimes the session was just not received
+                    var session = await client.AcceptMessageSessionAsync(TimeSpan.FromMilliseconds(250));
+
+                    while (true) {
+                        var messages = await session.ReceiveBatchAsync(1000, TimeSpan.FromMilliseconds(100));
+                        if (messages.Any()) {
+                            var locktokens = messages.Select(m => m.LockToken).ToArray();
+                            count += locktokens.Length;
+                            await session.CompleteBatchAsync(locktokens);
+                        }
+                        else {
+                            break;
+                        }
+                    }
+
+                    session.Close();
+                }
+            }
+            catch (TimeoutException) {
+                // ignore the exception, the AcceptMessageSessionAsync throws when no more sessions
+            }
+
+            return count;
+        }
+
+        private async Task<int> PurgeNonSessionedTopic(string entityPath, MessagingFactory messagingFactory) {
+
+            int count = 0;
+
+            var receiver = await messagingFactory.CreateMessageReceiverAsync(entityPath, ReceiveMode.ReceiveAndDelete);
+
+            while (true) {
+                var messages = await receiver.ReceiveBatchAsync(1000, TimeSpan.FromMilliseconds(100));
+                // ReSharper disable once PossibleMultipleEnumeration
+                if (messages.Any()) {
+                    // ReSharper disable once PossibleMultipleEnumeration
+                    count += messages.Count();
+                }
+                else {
+                    if (subscriptionWrapper.TopicDescription.EnablePartitioning) {
+                        while (true) {
+                            var message = await receiver.ReceiveAsync(TimeSpan.FromMilliseconds(100));
+                            if (message != null) {
+                                count++;
+                            }
+                            else {
+                                break;
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+
+            return count;
         }
 
         public async Task<long> PurgeDeadletterQueueMessagesAsync()


### PR DESCRIPTION
Fixes #96 where purging failed from a subscription that requires a session. The bug also mentions queues, and this PR also fixes the issue with queues. 