### PR TITLE
Added .editorconfig to project #160

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,17 @@
+# top-most EditorConfig file
+root = true
+
+# Windows-style newlines with a newline ending every file
+[*]
+end_of_line = crlf
+insert_final_newline = true
+
+# 4 space indentation
+[*.cs]
+indent_style = space
+indent_size = 4
+
+# 2 space indentation
+[*.config]
+indent_style = space
+indent_size = 2

--- a/src/ServiceBusExplorer.sln
+++ b/src/ServiceBusExplorer.sln
@@ -1,12 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.13
+VisualStudioVersion = 15.0.27004.2005
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceBusExplorer", "ServiceBusExplorer\ServiceBusExplorer.csproj", "{32754F39-E353-4607-94FE-B9B9ACFD58EF}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B59933A5-4AE0-4340-9102-578619A93341}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		..\appveyor.yml = ..\appveyor.yml
 		..\GitVersion.yml = ..\GitVersion.yml
 		..\LICENSE.txt = ..\LICENSE.txt
@@ -42,5 +43,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C4F44BEA-0E43-45A8-9708-A8A0E6EF3EC5}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Resolve #160 by adding an `.editorconfig` file. This will instruct the editor (VS2017, previous VS versions require a plugin installed) to use 4 spaces for indenting `.CS` files and 2 spaces for indenting `.config` files.