### PR TITLE
Closes #166 by setting ContentType and Label

### DIFF
--- a/src/ServiceBusExplorer/Helpers/BrokeredMessageExtensions.cs
+++ b/src/ServiceBusExplorer/Helpers/BrokeredMessageExtensions.cs
@@ -97,6 +97,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
             message.TimeToLive = originalMessage.TimeToLive;
             message.ScheduledEnqueueTimeUtc = originalMessage.ScheduledEnqueueTimeUtc;
             message.ViaPartitionKey = originalMessage.ViaPartitionKey;
+            message.ContentType = originalMessage.ContentType;
+            message.Label = originalMessage.Label;
 
             return message;
         }


### PR DESCRIPTION
This solves #166, the issue with ContentType being lost when resubmitting message with body type byteArray.

I have tested that it works as intended, but I am unsure how to test if it breaks any existing behavior.