### PR TITLE
Added support for EntityPath in the connection string

### DIFF
--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -214,6 +214,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
         private const string ConnectionStringSharedSecretIssuer = "sharedsecretissuer";
         private const string ConnectionStringSharedSecretValue = "sharedsecretvalue";
         private const string ConnectionStringTransportType = "transporttype";
+        private const string ConnectionStringEntityPath = "entitypath";
 
         //***************************
         // Icons
@@ -3408,7 +3409,13 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                     Enum.TryParse(parameters[ConnectionStringTransportType], true, out transportType);
                 }
 
-                return new ServiceBusNamespace(ServiceBusNamespaceType.Cloud, connectionString, endpoint, ns, null, sharedAccessKeyName, sharedAccessKey, stsEndpoint, transportType, true);
+                string entityPath = string.Empty;
+                if (parameters.ContainsKey(ConnectionStringEntityPath))
+                {
+                    entityPath = parameters[ConnectionStringEntityPath];
+                }
+
+                return new ServiceBusNamespace(ServiceBusNamespaceType.Cloud, connectionString, endpoint, ns, null, sharedAccessKeyName, sharedAccessKey, stsEndpoint, transportType, true, entityPath);
             }
 
             if (toLower.Contains(ConnectionStringRuntimePort) ||

--- a/src/ServiceBusExplorer/Helpers/ServiceBusNamespace.cs
+++ b/src/ServiceBusExplorer/Helpers/ServiceBusNamespace.cs
@@ -93,7 +93,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                                    string key,
                                    string stsEndpoint,
                                    TransportType transportType,
-                                   bool isSas = false)
+                                   bool isSas = false,
+                                   string entityPath = "")
         {
             ConnectionStringType = connectionStringType;
             Uri = string.IsNullOrWhiteSpace(uri) ? 
@@ -125,6 +126,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
             WindowsDomain = default(string);
             WindowsUserName = default(string);
             WindowsPassword = default(string);
+            EntityPath = entityPath;
         }
 
         /// <summary>
@@ -268,6 +270,11 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
         /// Gets or sets the SharedAccessKey.
         /// </summary>
         public string SharedAccessKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the EntityPath
+        /// </summary>
+        public string EntityPath { get; set; }
         #endregion
     }
 }


### PR DESCRIPTION
I'd like to close #139 (Access individual entities w/o permission to the entire namespace) with this PR.

I've added a check for the entitypath when parsing the connection string. This then flows into additional checks in the ServiceBusHelper class so that it doesn't try to query for all Topics or Queues when an EntityPath has been provided (otherwise a permissions exception is thrown). 

The logic for getting queues and topics have been placed into separate methods (GetQueueUsingEntityPath and GetTopicUsingEntityPath),

I've tested the changes against Azure Service Bus with a full Administrative connection string and one that is limited to a single topic and one that is limited to a single queue. I've not been able to test the application against Windows Service Bus as I don't have access to an instance.