### PR TITLE
Removed ConfigureAwait and UseWaitCursor calls to fix #174 and #176

### DIFF
--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -432,7 +432,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                     return 0;
                 }
             }
-            try {
+            try
+            {
                 Application.UseWaitCursor = true;
                 var stopwatch = new Stopwatch();
                 int count;
@@ -440,11 +441,11 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                 var messagingFactory = MessagingFactory.CreateFromConnectionString(serviceBusHelper.ConnectionString);
                 if (queueDescription.RequiresSession)
                 {
-                    count = await PurgeSessionedQueue(messagingFactory).ConfigureAwait(false);
+                    count = await PurgeSessionedQueue(messagingFactory);
                 }
                 else
                 {
-                    count = await PurgeNonSessionedQueue(messagingFactory).ConfigureAwait(false);
+                    count = await PurgeNonSessionedQueue(messagingFactory);
                 }
                 stopwatch.Stop();
                 MainForm.SingletonMainForm.refreshEntity_Click(null, null);

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -4724,28 +4724,12 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
 
         private async void btnPurgeMessages_Click(object sender, EventArgs e)
         {
-            try
-            {
-                Application.UseWaitCursor = true;
-                await PurgeMessagesAsync();
-            }
-            finally
-            {
-                Application.UseWaitCursor = false;
-            }
+            await PurgeMessagesAsync();
         }
         
         private async void btnPurgeDeadletterQueueMessages_Click(object sender, EventArgs e)
         {
-            try
-            {
-                Application.UseWaitCursor = true;
-                await PurgeDeadletterQueueMessagesAsync();
-            }
-            finally
-            {
-                Application.UseWaitCursor = false;
-            }
+            await PurgeDeadletterQueueMessagesAsync();
         }
         #endregion
     }

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -417,7 +417,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                 }
             }
 
-            try {
+            try
+            {
                 Application.UseWaitCursor = true;
                 var stopwatch = new Stopwatch();
                 stopwatch.Start();
@@ -427,11 +428,11 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                 var messagingFactory = MessagingFactory.CreateFromConnectionString(serviceBusHelper.ConnectionString);
                 if (subscriptionWrapper.SubscriptionDescription.RequiresSession)
                 {
-                    count = await PurgeSessionedTopic(subscriptionWrapper.SubscriptionDescription.TopicPath, subscriptionWrapper.SubscriptionDescription.Name, messagingFactory).ConfigureAwait(false);
+                    count = await PurgeSessionedTopic(subscriptionWrapper.SubscriptionDescription.TopicPath, subscriptionWrapper.SubscriptionDescription.Name, messagingFactory);
                 }
                 else
                 {
-                    count = await PurgeNonSessionedTopic(entityPath, messagingFactory).ConfigureAwait(false);
+                    count = await PurgeNonSessionedTopic(entityPath, messagingFactory);
                 }
                 stopwatch.Stop();
                 MainForm.SingletonMainForm.refreshEntity_Click(null, null);

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -3385,28 +3385,12 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
 
         private async void btnPurgeMessages_Click(object sender, EventArgs e)
         {
-            try
-            {
-                Application.UseWaitCursor = true;
-                await PurgeMessagesAsync();
-            }
-            finally
-            {
-                Application.UseWaitCursor = false;
-            }
+            await PurgeMessagesAsync();
         }
 
         private async void btnPurgeDeadletterQueueMessages_Click(object sender, EventArgs e)
         {
-            try
-            {
-                Application.UseWaitCursor = true;
-                await PurgeDeadletterQueueMessagesAsync();
-            }
-            finally
-            {
-                Application.UseWaitCursor = false;
-            }
+            await PurgeDeadletterQueueMessagesAsync();
         }
         #endregion
     }


### PR DESCRIPTION
Fixes #174 and #176 

Removed some ConfigureAwait(false) calls to keep the synchronization context since it is required to interact with the UI components in the later parts of the Purge methods.

Also removed the UseWaitCursor calls when purging from the MainForm.