### PR TITLE
More reliable and faster purging of messaging entities, fix for #60

### DIFF
--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -345,8 +345,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
             "SharedAccessKey"
         };
 
-        private static readonly List<string> Operators = new List<string> {"ge", "gt", "le", "lt", "eq", "ne"};
-        private static readonly List<string> TimeGranularityList = new List<string> {"PT5M", "PT1H", "P1D", "P7D"};
+        private static readonly List<string> Operators = new List<string> { "ge", "gt", "le", "lt", "eq", "ne" };
+        private static readonly List<string> TimeGranularityList = new List<string> { "PT5M", "PT1H", "P1D", "P7D" };
 
         #endregion
 
@@ -436,17 +436,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
             {
                 Application.UseWaitCursor = true;
                 var stopwatch = new Stopwatch();
-                int count;
                 stopwatch.Start();
-                var messagingFactory = MessagingFactory.CreateFromConnectionString(serviceBusHelper.ConnectionString);
-                if (queueDescription.RequiresSession)
-                {
-                    count = await PurgeSessionedQueue(messagingFactory);
-                }
-                else
-                {
-                    count = await PurgeNonSessionedQueue(messagingFactory);
-                }
+                var messagingPurger = new MessagingPurger(serviceBusHelper, queueDescription);
+                var count = await messagingPurger.Purge();
                 stopwatch.Stop();
                 MainForm.SingletonMainForm.refreshEntity_Click(null, null);
                 writeToLog($"[{count}] messages have been purged from the [{queueDescription.Path}] queue in [{stopwatch.ElapsedMilliseconds}] milliseconds.");
@@ -458,91 +450,6 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
             }
         }
 
-        private async Task<int> PurgeSessionedQueue(MessagingFactory messagingFactory)
-        {
-            var totalMessagesPurged = 0;
-            var client = messagingFactory.CreateQueueClient(queueDescription.Path);
-
-            try
-            {
-                while (true)
-                {
-                    var session = await client.AcceptMessageSessionAsync(TimeSpan.FromMilliseconds(100))
-                                              .ConfigureAwait(false);
-
-                    while (true)
-                    {
-                        var messages = await session.ReceiveBatchAsync(1000, TimeSpan.FromMilliseconds(100))
-                                                    .ConfigureAwait(false);
-                        var messagesCount = messages.Count();
-                        if (0 < messagesCount)
-                        {
-                            totalMessagesPurged += messagesCount;
-                            var locktokens = messages.Select(m => m.LockToken);
-                            await session.CompleteBatchAsync(locktokens)
-                                         .ConfigureAwait(false);
-                        }
-                        else
-                        {
-                            break;
-                        }
-                    }
-
-                    await session.CloseAsync().ConfigureAwait(false);
-                }
-            }
-            catch (TimeoutException)
-            {
-                // ignore the exception, the AcceptMessageSessionAsync throws when no more sessions
-            }
-            finally
-            {
-                await client.CloseAsync().ConfigureAwait(false);
-            }
-
-            return totalMessagesPurged;
-        }
-
-        private async Task<int> PurgeNonSessionedQueue(MessagingFactory messagingFactory)
-        {
-            var totalMessagesPurged = 0;
-            var receiver = await messagingFactory.CreateMessageReceiverAsync(queueDescription.Path, ReceiveMode.ReceiveAndDelete).ConfigureAwait(false);
-
-            try
-            {
-                while (true)
-                {
-                    var messages = await receiver.ReceiveBatchAsync(1000, TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
-                    var messagesCount = messages.Count();
-                    totalMessagesPurged += messagesCount;
-                    if (messagesCount == 0)
-                    {
-                        if (queueDescription.EnablePartitioning)
-                        {
-                            while (true)
-                            {
-                                var message = await receiver.ReceiveAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
-                                if (message != null)
-                                {
-                                    totalMessagesPurged++;
-                                }
-                                else
-                                {
-                                    break;
-                                }
-                            }
-                        }
-                        break;
-                    }
-                }
-            }
-            finally
-            {
-                await receiver.CloseAsync().ConfigureAwait(false);
-            }
-
-            return totalMessagesPurged;
-        }
 
         public async Task<long> PurgeDeadletterQueueMessagesAsync()
         {
@@ -554,44 +461,13 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                     return 0;
                 }
             }
-
             try
             {
                 Application.UseWaitCursor = true;
                 var stopwatch = new Stopwatch();
                 stopwatch.Start();
-                var messagingFactory = MessagingFactory.CreateFromConnectionString(serviceBusHelper.ConnectionString);
-                var receiver = await messagingFactory.CreateMessageReceiverAsync(dlqPath, ReceiveMode.ReceiveAndDelete);
-                var count = 0;
-                while (true)
-                {
-                    var messages = await receiver.ReceiveBatchAsync(1000, TimeSpan.FromMilliseconds(100));
-                    // ReSharper disable once PossibleMultipleEnumeration
-                    if (messages.Any())
-                    {
-                        // ReSharper disable once PossibleMultipleEnumeration
-                        count += messages.Count();
-                    }
-                    else
-                    {
-                        if (queueDescription.EnablePartitioning)
-                        {
-                            while (true)
-                            {
-                                var message = await receiver.ReceiveAsync(TimeSpan.FromMilliseconds(100));
-                                if (message != null)
-                                {
-                                    count++;
-                                }
-                                else
-                                {
-                                    break;
-                                }
-                            }
-                        }
-                        break;
-                    }
-                }
+                var messagingPurger = new MessagingPurger(serviceBusHelper, queueDescription);
+                var count = await messagingPurger.Purge(purgeDeadLetterQueueInstead: true);
                 stopwatch.Stop();
                 MainForm.SingletonMainForm.refreshEntity_Click(null, null);
                 writeToLog($"[{count}] messages have been purged from the deadletter queue of the [{queueDescription.Path}] queue in [{stopwatch.ElapsedMilliseconds}] milliseconds.");
@@ -703,7 +579,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                                                           GrouperMessagePropertiesWith -
                                                           sessionsSplitContainer.SplitterWidth;
                 sessionListTextPropertiesSplitContainer.SplitterDistance =
-                    sessionListTextPropertiesSplitContainer.Size.Height/2 - 8;
+                    sessionListTextPropertiesSplitContainer.Size.Height / 2 - 8;
 
                 if (mainTabControl.TabPages[SessionsTabPage] != null)
                 {
@@ -1499,7 +1375,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                 },
                 new[] {MessageCount, queueDescription.MessageCount.ToString("N0", CultureInfo.CurrentCulture)}
             });
-            
+
             propertyListView.Items.Clear();
             foreach (var array in propertyList)
             {
@@ -1728,9 +1604,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                                                           GrouperMessagePropertiesWith -
                                                           messagesSplitContainer.SplitterWidth;
                 messageListTextPropertiesSplitContainer.SplitterDistance =
-                    messageListTextPropertiesSplitContainer.Size.Height/2 - 8;
+                    messageListTextPropertiesSplitContainer.Size.Height / 2 - 8;
                 messagesCustomPropertiesSplitContainer.SplitterDistance =
-                    messagesCustomPropertiesSplitContainer.Size.Width/2 - 8;
+                    messagesCustomPropertiesSplitContainer.Size.Width / 2 - 8;
 
                 if (!peek)
                 {
@@ -1839,9 +1715,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                                                           GrouperMessagePropertiesWith -
                                                           messagesSplitContainer.SplitterWidth;
                 messageListTextPropertiesSplitContainer.SplitterDistance =
-                    messageListTextPropertiesSplitContainer.Size.Height/2 - 8;
+                    messageListTextPropertiesSplitContainer.Size.Height / 2 - 8;
                 messagesCustomPropertiesSplitContainer.SplitterDistance =
-                    messagesCustomPropertiesSplitContainer.Size.Width/2 - 8;
+                    messagesCustomPropertiesSplitContainer.Size.Width / 2 - 8;
                 if (!peek)
                 {
                     OnRefresh?.Invoke();
@@ -1955,9 +1831,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                                                             GrouperMessagePropertiesWith -
                                                             deadletterSplitContainer.SplitterWidth;
                 deadletterListTextPropertiesSplitContainer.SplitterDistance =
-                    deadletterListTextPropertiesSplitContainer.Size.Height/2 - 8;
+                    deadletterListTextPropertiesSplitContainer.Size.Height / 2 - 8;
                 deadletterCustomPropertiesSplitContainer.SplitterDistance =
-                    deadletterCustomPropertiesSplitContainer.Size.Width/2 - 8;
+                    deadletterCustomPropertiesSplitContainer.Size.Width / 2 - 8;
 
                 if (!peek)
                 {
@@ -2176,8 +2052,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                 deadletterSplitContainer.SplitterDistance = deadletterSplitContainer.Width -
                                                             GrouperMessagePropertiesWith -
                                                             deadletterSplitContainer.SplitterWidth;
-                deadletterListTextPropertiesSplitContainer.SplitterDistance = deadletterListTextPropertiesSplitContainer.Size.Height/2 - 8;
-                deadletterCustomPropertiesSplitContainer.SplitterDistance = deadletterCustomPropertiesSplitContainer.Size.Width/2 - 8;
+                deadletterListTextPropertiesSplitContainer.SplitterDistance = deadletterListTextPropertiesSplitContainer.Size.Height / 2 - 8;
+                deadletterCustomPropertiesSplitContainer.SplitterDistance = deadletterCustomPropertiesSplitContainer.Size.Width / 2 - 8;
 
                 if (!peek)
                 {
@@ -2334,10 +2210,10 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                         ForwardTo = txtForwardTo.Text,
                         ForwardDeadLetteredMessagesTo = txtForwardDeadLetteredMessagesTo.Text,
                         MaxSizeInMegabytes = serviceBusHelper.IsCloudNamespace
-                            ? trackBarMaxQueueSize.Value*1024
+                            ? trackBarMaxQueueSize.Value * 1024
                             : trackBarMaxQueueSize.Value == trackBarMaxQueueSize.Maximum
                                 ? SeviceBusForWindowsServerMaxQueueSize
-                                : trackBarMaxQueueSize.Value*1024
+                                : trackBarMaxQueueSize.Value * 1024
                     };
 
                     if (!string.IsNullOrWhiteSpace(txtMaxDeliveryCount.Text))
@@ -2609,7 +2485,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                             var rightList = new List<AccessRights>();
                             if (rule.Manage)
                             {
-                                rightList.AddRange(new[] {AccessRights.Manage, AccessRights.Send, AccessRights.Listen});
+                                rightList.AddRange(new[] { AccessRights.Manage, AccessRights.Send, AccessRights.Listen });
                             }
                             else
                             {
@@ -3157,8 +3033,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                 e.Bounds.Height - 1);
             // Right vertical line
             e.Graphics.DrawLine(new Pen(SystemColors.ControlDark), endX, -1, endX, e.Bounds.Height + 1);
-            var roundedFontSize = (float) Math.Round(e.Font.SizeInPoints);
-            var bounds = new RectangleF(e.Bounds.X + 4, (e.Bounds.Height - 8 - roundedFontSize)/2, e.Bounds.Width,
+            var roundedFontSize = (float)Math.Round(e.Font.SizeInPoints);
+            var bounds = new RectangleF(e.Bounds.X + 4, (e.Bounds.Height - 8 - roundedFontSize) / 2, e.Bounds.Width,
                 roundedFontSize + 6);
             e.Graphics.DrawString(e.Header.Text, e.Font, new SolidBrush(SystemColors.ControlText), bounds);
         }
@@ -3303,8 +3179,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                         if (icon != null)
                         {
                             var startPoint =
-                                new Point(tabBackgroundRect.X + 2 + ((tabBackgroundRect.Height - size.Height)/2),
-                                    tabBackgroundRect.Y + 2 + ((tabBackgroundRect.Height - size.Height)/2));
+                                new Point(tabBackgroundRect.X + 2 + ((tabBackgroundRect.Height - size.Height) / 2),
+                                    tabBackgroundRect.Y + 2 + ((tabBackgroundRect.Height - size.Height) / 2));
                             e.Graphics.DrawImage(icon, new Rectangle(startPoint, size));
                             iconOffset = size.Width + 4;
                         }
@@ -3313,7 +3189,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                     // Draw out the label.
                     var labelRect = new Rectangle(tabBackgroundRect.X + iconOffset, tabBackgroundRect.Y + 5,
                         tabBackgroundRect.Width - iconOffset, tabBackgroundRect.Height - 3);
-                    using (var sf = new StringFormat {Alignment = StringAlignment.Center})
+                    using (var sf = new StringFormat { Alignment = StringAlignment.Center })
                     {
                         e.Graphics.DrawString(tabName, new Font(e.Font.FontFamily, 8.25F, e.Font.Style), foreBrush,
                             labelRect, sf);
@@ -3407,13 +3283,13 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                     {
                         width -= verticalScrollbar.Width;
                     }
-                    var columnWidth = width/4;
+                    var columnWidth = width / 4;
                     dataGridView.Columns[0].Width = columnWidth - 20;
                     dataGridView.Columns[3].Width = columnWidth;
-                    dataGridView.Columns[4].Width = columnWidth + (width - (columnWidth*4)) + 10;
+                    dataGridView.Columns[4].Width = columnWidth + (width - (columnWidth * 4)) + 10;
                     dataGridView.Columns[5].Width = columnWidth + 10;
                 }
-                if (dataGridView != sessionsDataGridView || 
+                if (dataGridView != sessionsDataGridView ||
                     dataGridView.ColumnCount != 4)
                 {
                     return;
@@ -3426,12 +3302,12 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                         width -= verticalScrollbar.Width;
                     }
                     const int columnNumber = 4;
-                    var columnWidth = width/columnNumber;
+                    var columnWidth = width / columnNumber;
                     for (var i = 0; i < 3; i++)
                     {
                         dataGridView.Columns[i].Width = columnWidth;
                     }
-                    dataGridView.Columns[3].Width = columnWidth + (width - (columnWidth*columnNumber));
+                    dataGridView.Columns[3].Width = columnWidth + (width - (columnWidth * columnNumber));
                 }
             }
             finally
@@ -3469,7 +3345,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
 
                 txtMessageText.Text = JsonSerializerHelper.Indent(XmlHelper.Indent(serviceBusHelper.GetMessageText(brokeredMessage, out _)));
                 var listViewItems =
-                    brokeredMessage.Properties.Select(p => new ListViewItem(new[] {p.Key, Convert.ToString(p.Value)}))
+                    brokeredMessage.Properties.Select(p => new ListViewItem(new[] { p.Key, Convert.ToString(p.Value) }))
                         .ToArray();
                 messagePropertyListView.Items.Clear();
                 messagePropertyListView.Items.AddRange(listViewItems);
@@ -3512,7 +3388,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
         private void grouperMessageList_CustomPaint(PaintEventArgs e)
         {
             messagesDataGridView.Size = new Size(
-                grouperMessageList.Size.Width - (messagesDataGridView.Location.X*2 + 2),
+                grouperMessageList.Size.Width - (messagesDataGridView.Location.X * 2 + 2),
                 grouperMessageList.Size.Height - messagesDataGridView.Location.Y - messagesDataGridView.Location.X - 2);
             e.Graphics.DrawRectangle(new Pen(SystemColors.ActiveBorder, 1),
                 messagesDataGridView.Location.X - 1,
@@ -3524,7 +3400,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
         private void grouperSessionList_CustomPaint(PaintEventArgs e)
         {
             sessionsDataGridView.Size = new Size(
-                grouperSessionList.Size.Width - (sessionsDataGridView.Location.X*2 + 2),
+                grouperSessionList.Size.Width - (sessionsDataGridView.Location.X * 2 + 2),
                 grouperSessionList.Size.Height - sessionsDataGridView.Location.Y - sessionsDataGridView.Location.X - 2);
             e.Graphics.DrawRectangle(new Pen(SystemColors.ActiveBorder, 1),
                 sessionsDataGridView.Location.X - 1,
@@ -3536,7 +3412,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
         private void grouperDeadletterList_CustomPaint(PaintEventArgs e)
         {
             deadletterDataGridView.Size =
-                new Size(grouperDeadletterList.Size.Width - (deadletterDataGridView.Location.X*2 + 2),
+                new Size(grouperDeadletterList.Size.Width - (deadletterDataGridView.Location.X * 2 + 2),
                     grouperDeadletterList.Size.Height - deadletterDataGridView.Location.Y -
                     deadletterDataGridView.Location.X - 2);
             e.Graphics.DrawRectangle(new Pen(SystemColors.ActiveBorder, 1),
@@ -3604,7 +3480,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
             deadletterMessage = bindingList[e.RowIndex];
             deadletterPropertyGrid.SelectedObject = deadletterMessage;
             txtDeadletterText.Text = JsonSerializerHelper.Indent(XmlHelper.Indent(serviceBusHelper.GetMessageText(deadletterMessage, out _)));
-            var listViewItems = deadletterMessage.Properties.Select(p => new ListViewItem(new[] {p.Key, Convert.ToString(p.Value)})).ToArray();
+            var listViewItems = deadletterMessage.Properties.Select(p => new ListViewItem(new[] { p.Key, Convert.ToString(p.Value) })).ToArray();
             deadletterPropertyListView.Items.Clear();
             deadletterPropertyListView.Items.AddRange(listViewItems);
         }
@@ -3696,8 +3572,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                 int columnWidth;
                 if (serviceBusHelper.IsCloudNamespace)
                 {
-                    columnWidth = width/8;
-                    authorizationRulesDataGridView.Columns["IssuerName"].Width = width - (7*columnWidth);
+                    columnWidth = width / 8;
+                    authorizationRulesDataGridView.Columns["IssuerName"].Width = width - (7 * columnWidth);
                     if (authorizationRulesDataGridView.Columns["KeyName"] != null &&
                         authorizationRulesDataGridView.Columns["PrimaryKey"] != null &&
                         authorizationRulesDataGridView.Columns["SecondaryKey"] != null)
@@ -3709,8 +3585,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                 }
                 else
                 {
-                    columnWidth = width/5;
-                    authorizationRulesDataGridView.Columns["IssuerName"].Width = width - (4*columnWidth);
+                    columnWidth = width / 5;
+                    authorizationRulesDataGridView.Columns["IssuerName"].Width = width - (4 * columnWidth);
                 }
                 authorizationRulesDataGridView.Columns["ClaimType"].Width = columnWidth;
                 authorizationRulesDataGridView.Columns["ClaimValue"].Width = columnWidth;
@@ -3746,7 +3622,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
         {
             if (authorizationRulesDataGridView.Columns[e.ColumnIndex].Name == "Manage")
             {
-                if (!(bool) authorizationRulesDataGridView.Rows[e.RowIndex].Cells[e.ColumnIndex].Value)
+                if (!(bool)authorizationRulesDataGridView.Rows[e.RowIndex].Cells[e.ColumnIndex].Value)
                 {
                     authorizationRulesDataGridView.Rows[e.RowIndex].Cells["Manage"].Value = true;
                     authorizationRulesDataGridView.Rows[e.RowIndex].Cells["Send"].Value = true;
@@ -3757,8 +3633,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
             if ((authorizationRulesDataGridView.Columns[e.ColumnIndex].Name == "Send" ||
                  authorizationRulesDataGridView.Columns[e.ColumnIndex].Name == "Listen"))
             {
-                if ((bool) authorizationRulesDataGridView.Rows[e.RowIndex].Cells[e.ColumnIndex].Value &&
-                    (bool) authorizationRulesDataGridView.Rows[e.RowIndex].Cells["Manage"].Value)
+                if ((bool)authorizationRulesDataGridView.Rows[e.RowIndex].Cells[e.ColumnIndex].Value &&
+                    (bool)authorizationRulesDataGridView.Rows[e.RowIndex].Cells["Manage"].Value)
                 {
                     authorizationRulesDataGridView.Rows[e.RowIndex].Cells[e.ColumnIndex].Value = false;
                     authorizationRulesDataGridView.Rows[e.RowIndex].Cells["Manage"].Value = false;
@@ -4023,33 +3899,33 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
 
         private void grouperMessageText_CustomPaint(PaintEventArgs obj)
         {
-            txtMessageText.Size = new Size(grouperMessageText.Size.Width - (txtMessageText.Location.X*2),
+            txtMessageText.Size = new Size(grouperMessageText.Size.Width - (txtMessageText.Location.X * 2),
                 grouperMessageText.Size.Height - txtMessageText.Location.Y - txtMessageText.Location.X);
         }
 
         private void grouperMessageCustomProperties_CustomPaint(PaintEventArgs obj)
         {
-            messagePropertyListView.Size = new Size(grouperMessageCustomProperties.Size.Width - messagePropertyListView.Location.X*2,
+            messagePropertyListView.Size = new Size(grouperMessageCustomProperties.Size.Width - messagePropertyListView.Location.X * 2,
                                                     grouperMessageCustomProperties.Size.Height - messagePropertyListView.Location.Y -
                                                     messagePropertyListView.Location.X);
         }
 
         private void grouperMessageProperties_CustomPaint(PaintEventArgs obj)
         {
-            messagePropertyGrid.Size = new Size(grouperMessageProperties.Size.Width - messagePropertyGrid.Location.X*2,
+            messagePropertyGrid.Size = new Size(grouperMessageProperties.Size.Width - messagePropertyGrid.Location.X * 2,
                                                 grouperMessageProperties.Size.Height - messagePropertyGrid.Location.Y - messagePropertyGrid.Location.X);
         }
 
         private void grouperDeadletterText_CustomPaint(PaintEventArgs obj)
         {
-            txtDeadletterText.Size = new Size(grouperDeadletterText.Size.Width - txtDeadletterText.Location.X*2,
+            txtDeadletterText.Size = new Size(grouperDeadletterText.Size.Width - txtDeadletterText.Location.X * 2,
                 grouperDeadletterText.Size.Height - txtDeadletterText.Location.Y - txtDeadletterText.Location.X);
         }
 
         private void grouperDeadletterCustomProperties_CustomPaint(PaintEventArgs obj)
         {
             deadletterPropertyListView.Size =
-                new Size(grouperDeadletterCustomProperties.Size.Width - deadletterPropertyListView.Location.X*2,
+                new Size(grouperDeadletterCustomProperties.Size.Width - deadletterPropertyListView.Location.X * 2,
                     grouperDeadletterCustomProperties.Size.Height - deadletterPropertyListView.Location.Y -
                     deadletterPropertyListView.Location.X);
         }
@@ -4057,7 +3933,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
         private void grouperDeadletterProperties_CustomPaint(PaintEventArgs obj)
         {
             deadletterPropertyGrid.Size =
-                new Size(grouperDeadletterProperties.Size.Width - deadletterPropertyGrid.Location.X*2,
+                new Size(grouperDeadletterProperties.Size.Width - deadletterPropertyGrid.Location.X * 2,
                     grouperDeadletterProperties.Size.Height - deadletterPropertyGrid.Location.Y -
                     deadletterPropertyGrid.Location.X);
         }
@@ -4087,14 +3963,14 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
 
         private void grouperSessionState_CustomPaint(PaintEventArgs obj)
         {
-            txtSessionState.Size = new Size(grouperSessionState.Size.Width - (txtSessionState.Location.X*2),
+            txtSessionState.Size = new Size(grouperSessionState.Size.Width - (txtSessionState.Location.X * 2),
                 grouperSessionState.Size.Height - txtSessionState.Location.Y - txtSessionState.Location.X);
         }
 
         private void grouperSessionProperties_CustomPaint(PaintEventArgs obj)
         {
             sessionPropertyGrid.Size = new Size(
-                grouperSessionProperties.Size.Width - (sessionPropertyGrid.Location.X*2),
+                grouperSessionProperties.Size.Width - (sessionPropertyGrid.Location.X * 2),
                 grouperSessionProperties.Size.Height - sessionPropertyGrid.Location.Y - sessionPropertyGrid.Location.X);
         }
 
@@ -4128,7 +4004,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                     return;
                 }
                 using (var form = new MessageForm(messagesDataGridView.SelectedRows.Cast<DataGridViewRow>()
-                    .Select(r => (BrokeredMessage) r.DataBoundItem), serviceBusHelper, writeToLog))
+                    .Select(r => (BrokeredMessage)r.DataBoundItem), serviceBusHelper, writeToLog))
                 {
                     form.ShowDialog();
                 }
@@ -4185,7 +4061,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                     return;
                 }
                 using (var form = new MessageForm(deadletterDataGridView.SelectedRows.Cast<DataGridViewRow>()
-                    .Select(r => (BrokeredMessage) r.DataBoundItem), serviceBusHelper, writeToLog))
+                    .Select(r => (BrokeredMessage)r.DataBoundItem), serviceBusHelper, writeToLog))
                 {
                     form.ShowDialog();
                 }
@@ -4712,7 +4588,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
             {
                 metricsManualResetEvent.WaitOne();
                 var dataGridViewComboBoxColumn =
-                    (DataGridViewComboBoxColumn) dataPointDataGridView.Columns[MetricProperty];
+                    (DataGridViewComboBoxColumn)dataPointDataGridView.Columns[MetricProperty];
                 if (dataGridViewComboBoxColumn != null)
                 {
                     dataGridViewComboBoxColumn.DataSource = MetricInfo.EntityMetricDictionary.ContainsKey(QueueEntity)
@@ -4726,7 +4602,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
         {
             await PurgeMessagesAsync();
         }
-        
+
         private async void btnPurgeDeadletterQueueMessages_Click(object sender, EventArgs e)
         {
             await PurgeDeadletterQueueMessagesAsync();

--- a/src/ServiceBusExplorer/Helpers/MessagingPurger.cs
+++ b/src/ServiceBusExplorer/Helpers/MessagingPurger.cs
@@ -139,6 +139,11 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                         {
                             Interlocked.Add(ref totalMessagesPurged, messages.Count());
                             consecutiveZeroBatchReceives = 0;
+
+                            foreach (var message in messages)
+                            {
+                                message.Dispose();
+                            }
                         }
                         else
                         {

--- a/src/ServiceBusExplorer/Helpers/MessagingPurger.cs
+++ b/src/ServiceBusExplorer/Helpers/MessagingPurger.cs
@@ -1,0 +1,372 @@
+﻿#region Copyright
+//=======================================================================================
+// Microsoft Azure Customer Advisory Team 
+//
+// This sample is supplemental to the technical guidance published on my personal
+// blog at http://blogs.msdn.com/b/paolos/. 
+// 
+// Author: Paolo Salvatori
+//=======================================================================================
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+// LICENSED UNDER THE APACHE LICENSE, VERSION 2.0 (THE "LICENSE"); YOU MAY NOT USE THESE 
+// FILES EXCEPT IN COMPLIANCE WITH THE LICENSE. YOU MAY OBTAIN A COPY OF THE LICENSE AT 
+// http://www.apache.org/licenses/LICENSE-2.0
+// UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, SOFTWARE DISTRIBUTED UNDER THE 
+// LICENSE IS DISTRIBUTED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
+// KIND, EITHER EXPRESS OR IMPLIED. SEE THE LICENSE FOR THE SPECIFIC LANGUAGE GOVERNING 
+// PERMISSIONS AND LIMITATIONS UNDER THE LICENSE.
+//=======================================================================================
+#endregion
+
+#region Using Directives
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ServiceBus.Messaging;
+using System.Threading.Tasks;
+using System.Threading;
+using System.Diagnostics;
+
+#endregion
+
+namespace Microsoft.Azure.ServiceBusExplorer.Helpers
+{
+    public class MessagingPurger
+    {
+        #region Private Fields
+        // Either queueDescription or subscriptWrapper is used - but never both.
+        private readonly QueueDescription queueDescription;
+        private readonly SubscriptionWrapper subscriptionWrapper;
+        private readonly ServiceBusHelper serviceBusHelper;
+        #endregion
+
+        #region Public Constructors
+        public MessagingPurger(ServiceBusHelper serviceBusHelper, QueueDescription queueDescription)
+        {
+            this.serviceBusHelper = serviceBusHelper;
+            this.queueDescription = queueDescription;
+        }
+
+        public MessagingPurger(ServiceBusHelper serviceBusHelper, SubscriptionWrapper subscriptionWrapper)
+        {
+            this.serviceBusHelper = serviceBusHelper;
+            this.subscriptionWrapper = subscriptionWrapper;
+        }
+        #endregion
+
+        #region Public methods
+        /// <summary>
+        /// Purges the messages from a queue, subscription or a dead letter queue. Handles all kinds of queues.
+        /// </summary>
+        /// <param name="purgeDeadLetterSubQueue">If false it will purge the queue, if true it will purge the 
+        /// dead letter queue instead.</param>
+        /// <returns>The number of messages purged</returns>
+        public async Task<long> Purge(bool purgeDeadLetterQueueInstead = false)
+        {
+            long totalMessagesPurged;
+
+            if (!purgeDeadLetterQueueInstead && EntityRequiresSession())
+            {
+                totalMessagesPurged = await PurgeSessionEntity();
+            }
+            else
+            {
+                totalMessagesPurged = await PurgeNonSessionEntity(purgeDeadLetterQueueInstead: purgeDeadLetterQueueInstead);
+            }
+
+            return totalMessagesPurged;
+        }
+        #endregion
+
+        #region Private methods
+        private async Task<long> PurgeSessionEntity()
+        {
+            GetEntityData(deadLetterQueueData: false,
+                messageCount: out long messagesToPurgeCount,
+                entityPath: out _);
+
+            return await DoPurgeSessionEntity(messagesToPurgeCount);
+        }
+
+        private async Task<long> DoPurgeSessionEntity(long messagesToPurgeCount)
+        {
+            long totalMessagesPurged = 0;
+            var messagingFactory = MessagingFactory.CreateFromConnectionString(serviceBusHelper.ConnectionString);
+
+            ClientEntity entityClient;
+
+            if (queueDescription != null)
+            {
+                entityClient = messagingFactory.CreateQueueClient(queueDescription.Path, ReceiveMode.ReceiveAndDelete);
+            }
+            else
+            {
+                entityClient = messagingFactory.CreateSubscriptionClient(subscriptionWrapper.SubscriptionDescription.TopicPath,
+                    subscriptionWrapper.SubscriptionDescription.Name, ReceiveMode.ReceiveAndDelete);
+            }
+
+            var consecutiveSessionTimeOuts = 0;
+
+            try
+            {
+                const int enoughZeroReceives = 3;
+
+                while (consecutiveSessionTimeOuts < enoughZeroReceives && totalMessagesPurged < messagesToPurgeCount)
+                {
+                    MessageSession session;
+
+                    if (queueDescription != null)
+                    {
+                        // Currently unable to use the isExclusiveMode parameter because then a MessagingException starting 
+                        // with the message "The service was unable to process the request; please retry the operation" is thrown.
+                        session = await ((QueueClient)entityClient).AcceptMessageSessionAsync(
+                            serverWaitTime: TimeSpan.FromMilliseconds(200 * (consecutiveSessionTimeOuts + 1)))
+                                .ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        session = await ((SubscriptionClient)entityClient).AcceptMessageSessionAsync(
+                            serverWaitTime: TimeSpan.FromMilliseconds(200 * (consecutiveSessionTimeOuts + 1)))
+                                .ConfigureAwait(false);
+                    }
+
+                    int consecutiveZeroBatchReceives = 0;
+
+                    while (consecutiveZeroBatchReceives < enoughZeroReceives
+                        && totalMessagesPurged < messagesToPurgeCount)
+                    {
+                        var messages = await session.ReceiveBatchAsync(1000, TimeSpan.FromMilliseconds(1000))
+                                                    .ConfigureAwait(false);
+
+                        if (messages.Any())
+                        {
+                            Interlocked.Add(ref totalMessagesPurged, messages.Count());
+                            consecutiveZeroBatchReceives = 0;
+                        }
+                        else
+                        {
+                            ++consecutiveZeroBatchReceives;
+                        }
+                    }
+
+                    await session.CloseAsync().ConfigureAwait(false);
+                }
+            }
+            catch (TimeoutException)
+            {
+                ++consecutiveSessionTimeOuts;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Got exception {ex}");
+                throw;
+            }
+            finally
+            {
+                await CloseClient(entityClient).ConfigureAwait(false);
+                await entityClient.CloseAsync().ConfigureAwait(false);
+            }
+
+            return totalMessagesPurged;
+        }
+
+        private async Task<long> PurgeNonSessionEntity(bool purgeDeadLetterQueueInstead)
+        {
+            GetEntityData(purgeDeadLetterQueueInstead, out long messagesToPurgeCount, out string entityPath);
+
+            long purgedMessagesCount = 0;
+            var messageCount = messagesToPurgeCount;
+            var retries = 0;
+
+            // Sometimes it does not start polling or quits polling while not done
+            while (purgedMessagesCount < messagesToPurgeCount && messageCount > 1 && retries < 3)
+            {
+                purgedMessagesCount += await DoPurgeNonSessionEntity(
+                    queue: purgeDeadLetterQueueInstead ? true : queueDescription != null,
+                    messagesToPurgeCount: messagesToPurgeCount,
+                    entityPath: entityPath);
+
+                GetEntityData(purgeDeadLetterQueueInstead, out messageCount, out _);
+                ++retries;
+            }
+
+            return purgedMessagesCount;
+        }
+
+        private void GetEntityData(bool deadLetterQueueData, out long messageCount, out string entityPath)
+        {
+            if (deadLetterQueueData)
+            {
+                if (queueDescription != null)
+                {
+                    var queueDescription2 = serviceBusHelper.GetQueue(queueDescription.Path);
+                    messageCount = queueDescription2.MessageCountDetails.DeadLetterMessageCount;
+                    entityPath = QueueClient.FormatDeadLetterPath(queueDescription.Path);
+                }
+                else
+                {
+                    var subscriptionDescription = serviceBusHelper.GetSubscription(subscriptionWrapper.TopicDescription.Path,
+                        subscriptionWrapper.SubscriptionDescription.Name);
+                    messageCount = subscriptionDescription.MessageCountDetails.DeadLetterMessageCount;
+                    entityPath = SubscriptionClient.FormatDeadLetterPath(subscriptionWrapper.SubscriptionDescription.TopicPath,
+                        subscriptionWrapper.SubscriptionDescription.Name);
+                }
+            }
+            else
+            {
+                if (queueDescription != null)
+                {
+                    var queueDescription2 = serviceBusHelper.GetQueue(queueDescription.Path);
+                    messageCount = queueDescription2.MessageCountDetails.ActiveMessageCount;
+                    entityPath = queueDescription.Path;
+                }
+                else
+                {
+                    var subscriptionDescription = serviceBusHelper.GetSubscription(subscriptionWrapper.TopicDescription.Path,
+                        subscriptionWrapper.SubscriptionDescription.Name);
+                    messageCount = subscriptionDescription.MessageCountDetails.ActiveMessageCount;
+                    entityPath = SubscriptionClient.FormatSubscriptionPath(subscriptionWrapper.SubscriptionDescription.TopicPath,
+                        subscriptionWrapper.SubscriptionDescription.Name);
+                }
+            }
+        }
+
+        private async Task<long> DoPurgeNonSessionEntity(bool queue, long messagesToPurgeCount,
+            string entityPath)
+        {
+            long totalMessagesPurged = 0;
+            int taskCount = Math.Min((int)messagesToPurgeCount / 1000 + 1, 20);
+            var tasks = new Task[taskCount];
+            var partitioned = EntityIsPartioned();
+
+            for (int taskIndex = 0; taskIndex < tasks.Length; taskIndex++)
+            {
+                tasks[taskIndex] = Task.Run(async () =>
+                {
+                    var localTaskIndex = taskIndex;
+                    var messagingFactory = MessagingFactory.CreateFromConnectionString(serviceBusHelper.ConnectionString);
+
+                    ClientEntity receiver;
+
+                    try
+                    {
+                        if (queue)  // The dead letter queue for a subscription is a queue
+                        {
+                            receiver = await messagingFactory.CreateMessageReceiverAsync(entityPath, ReceiveMode.ReceiveAndDelete)
+                               .ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            receiver = messagingFactory.CreateSubscriptionClient(subscriptionWrapper.SubscriptionDescription.TopicPath,
+                                subscriptionWrapper.SubscriptionDescription.Name, ReceiveMode.ReceiveAndDelete);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"Got an exception {ex}");
+                        throw;
+                    }
+
+                    try
+                    {
+                        var consecutiveZeroBatchReceives = 0;
+                        const int enoughZeroBatchReceives = 5;
+
+                        while (consecutiveZeroBatchReceives < enoughZeroBatchReceives
+                            && Interlocked.Read(ref totalMessagesPurged) < messagesToPurgeCount)
+                        {
+                            IEnumerable<BrokeredMessage> messages;
+
+                            if (queue)
+                            {
+                                messages = await ((MessageReceiver)receiver).ReceiveBatchAsync(1000,
+                                   TimeSpan.FromMilliseconds(20000 * (consecutiveZeroBatchReceives + 1)))
+                                   .ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                messages = await ((SubscriptionClient)receiver).ReceiveBatchAsync(1000,
+                                   TimeSpan.FromMilliseconds(500 * (consecutiveZeroBatchReceives + 1)))
+                                   .ConfigureAwait(false);
+                            }
+
+                            // ReSharper disable once PossibleMultipleEnumeration
+                            if (messages.Any())
+                            {
+                                // ReSharper disable once PossibleMultipleEnumeration
+                                consecutiveZeroBatchReceives = 0;
+                                long messageCount = messages.Count();
+                                Interlocked.Add(ref totalMessagesPurged, messageCount);
+
+                                foreach (var message in messages)
+                                {
+                                    message.Dispose();
+                                }
+                            }
+                            else
+                            {
+                                ++consecutiveZeroBatchReceives;
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"Got an exception in receiving lambda {ex}");
+                        throw;
+                    }
+                    finally
+                    {
+                        await CloseReceiver(receiver).ConfigureAwait(false);
+                        await messagingFactory.CloseAsync().ConfigureAwait(false);
+                    }
+
+                    return;
+                });  // End of lambda 
+            }
+
+            await Task.WhenAll(tasks);
+
+            return totalMessagesPurged;
+        }
+
+        private static async Task CloseReceiver(ClientEntity receiver)
+        {
+            // Currently there is no implementation of CloseAsync in the MessageReceiver nor in the
+            // SubscriptionClient class, only in their common base cless, but in case there appears 
+            // one we want to call it.
+            if (receiver is MessageReceiver)
+                await ((MessageReceiver)receiver).CloseAsync().ConfigureAwait(false);
+            else
+                await ((SubscriptionClient)receiver).CloseAsync().ConfigureAwait(false);
+        }
+
+        private static async Task CloseClient(ClientEntity clientEntity)
+        {
+            // Currently there is no implementation of CloseAsync in the QueueClient nor in the
+            // SubscriptionClient class, only in their common base cless, but in case there appears 
+            // one we want to call it.
+            if (clientEntity is QueueClient)
+                await ((QueueClient)clientEntity).CloseAsync().ConfigureAwait(false);
+            else
+                await ((SubscriptionClient)clientEntity).CloseAsync().ConfigureAwait(false);
+        }
+
+        private bool EntityIsPartioned()
+        {
+            if (queueDescription != null)
+                return queueDescription.EnablePartitioning;
+            else
+                return subscriptionWrapper.TopicDescription.EnablePartitioning;
+        }
+        private bool EntityRequiresSession()
+        {
+            if (queueDescription != null)
+                return queueDescription.RequiresSession;
+            else
+                return subscriptionWrapper.SubscriptionDescription.RequiresSession;
+        }
+        #endregion
+    }
+}

--- a/src/ServiceBusExplorer/Helpers/ServiceBusHelper.cs
+++ b/src/ServiceBusExplorer/Helpers/ServiceBusHelper.cs
@@ -268,8 +268,8 @@ namespace Microsoft.Azure.ServiceBusExplorer
                 string uri;
                 return namespaceUri != null &&
                        !string.IsNullOrWhiteSpace(uri = namespaceUri.ToString()) &&
-                       (uri.Contains(CloudServiceBusPostfix) || 
-                        uri.Contains(TestServiceBusPostFix) || 
+                       (uri.Contains(CloudServiceBusPostfix) ||
+                        uri.Contains(TestServiceBusPostFix) ||
                         uri.Contains(GermanyServiceBusPostfix) ||
                         uri.Contains(ChinaServiceBusPostfix));
             }
@@ -655,7 +655,7 @@ namespace Microsoft.Azure.ServiceBusExplorer
         /// Gets or sets the dictionary containing EventData generators.
         /// </summary>
         public Dictionary<string, Type> EventDataGenerators { get; set; }
-        
+
         #endregion
 
         #region Public Static Properties
@@ -744,9 +744,9 @@ namespace Microsoft.Azure.ServiceBusExplorer
         /// <param name="sharedAccessKeyName">The shared access key name.</param>
         /// <param name="sharedAccessKey">The shared access key.</param>
         /// <returns>True if the operation succeeds, false otherwise.</returns>
-        public bool Connect(string nameSpace, 
-                            string path, 
-                            string issuerName, 
+        public bool Connect(string nameSpace,
+                            string path,
+                            string issuerName,
                             string issuerSecret,
                             string sharedAccessKeyName,
                             string sharedAccessKey,
@@ -790,7 +790,7 @@ namespace Microsoft.Azure.ServiceBusExplorer
                 {
                     // ignored
                 }
-                
+
                 currentIssuerName = issuerName;
                 currentIssuerSecret = issuerSecret;
                 currentSharedAccessKeyName = sharedAccessKeyName;
@@ -876,8 +876,8 @@ namespace Microsoft.Azure.ServiceBusExplorer
         /// <param name="sharedAccessKeyName">The shared access key name.</param>
         /// <param name="sharedAccessKey">The shared access key.</param>
         /// <returns>True if the operation succeeds, false otherwise.</returns>
-        public bool Connect(string uri, 
-                            string issuerName, 
+        public bool Connect(string uri,
+                            string issuerName,
                             string issuerSecret,
                             string sharedAccessKeyName,
                             string sharedAccessKey,
@@ -931,7 +931,7 @@ namespace Microsoft.Azure.ServiceBusExplorer
                 {
                     // ignored
                 }
-                
+
                 currentIssuerName = issuerName;
                 currentIssuerSecret = issuerSecret;
                 currentSharedAccessKeyName = sharedAccessKeyName;
@@ -1120,9 +1120,12 @@ namespace Microsoft.Azure.ServiceBusExplorer
                 Task.WaitAny(taskList.ToArray());
                 if (task.IsCompleted)
                 {
-                    try {
+                    try
+                    {
                         return task.Result;
-                    } catch (AggregateException ex) {
+                    }
+                    catch (AggregateException ex)
+                    {
                         throw ex.InnerExceptions.First();
                     }
                 }
@@ -1856,13 +1859,15 @@ namespace Microsoft.Azure.ServiceBusExplorer
         {
             if (namespaceManager != null)
             {
-                if (string.IsNullOrEmpty(serviceBusNamespaceInstance.EntityPath)) {
+                if (string.IsNullOrEmpty(serviceBusNamespaceInstance.EntityPath))
+                {
                     var taskList = new List<Task>();
                     var task = string.IsNullOrWhiteSpace(filter) ? namespaceManager.GetQueuesAsync() : namespaceManager.GetQueuesAsync(filter);
                     taskList.Add(task);
                     taskList.Add(Task.Delay(TimeSpan.FromSeconds(MainForm.SingletonMainForm.ServerTimeout)));
                     Task.WaitAny(taskList.ToArray());
-                    if (task.IsCompleted) {
+                    if (task.IsCompleted)
+                    {
                         return task.Result;
                     }
                     throw new TimeoutException();
@@ -1878,16 +1883,21 @@ namespace Microsoft.Azure.ServiceBusExplorer
         /// <summary>
         /// Retrieves a queue in the service bus namespace that matches the entity path.
         /// </summary>
-        private QueueDescription GetQueueUsingEntityPath() {
+        private QueueDescription GetQueueUsingEntityPath()
+        {
             var taskList = new List<Task>();
             var getQueueTask = namespaceManager.GetQueueAsync(serviceBusNamespaceInstance.EntityPath);
             taskList.Add(getQueueTask);
             taskList.Add(Task.Delay(TimeSpan.FromSeconds(MainForm.SingletonMainForm.ServerTimeout)));
             Task.WaitAny(taskList.ToArray());
-            if (getQueueTask.IsCompleted) {
-                try {
+            if (getQueueTask.IsCompleted)
+            {
+                try
+                {
                     return getQueueTask.Result;
-                } catch (AggregateException ex) {
+                }
+                catch (AggregateException ex)
+                {
                     throw ex.InnerExceptions.First();
                 }
             }
@@ -1945,13 +1955,13 @@ namespace Microsoft.Azure.ServiceBusExplorer
             {
                 throw new ArgumentException(QueueDescriptionCannotBeNull);
             }
-            if (messagingFactory == null )
+            if (messagingFactory == null)
             {
                 throw new ApplicationException(ServiceBusIsDisconnected);
 
             }
             var queueClient = messagingFactory.CreateQueueClient(queue.Path);
-            return RetryHelper.RetryFunc(() => dateTime != null? queueClient.GetMessageSessions(dateTime.Value) : queueClient.GetMessageSessions(), writeToLog);
+            return RetryHelper.RetryFunc(() => dateTime != null ? queueClient.GetMessageSessions(dateTime.Value) : queueClient.GetMessageSessions(), writeToLog);
         }
 
         /// <summary>
@@ -1983,18 +1993,23 @@ namespace Microsoft.Azure.ServiceBusExplorer
             if (namespaceManager != null)
             {
                 var taskList = new List<Task>();
-                if (string.IsNullOrEmpty(serviceBusNamespaceInstance.EntityPath)) {
+                if (string.IsNullOrEmpty(serviceBusNamespaceInstance.EntityPath))
+                {
                     Task<IEnumerable<TopicDescription>> task;
-                    if (string.IsNullOrWhiteSpace(filter)) {
+                    if (string.IsNullOrWhiteSpace(filter))
+                    {
                         task = namespaceManager.GetTopicsAsync();
-                    } else {
+                    }
+                    else
+                    {
                         task = namespaceManager.GetTopicsAsync(filter);
                     }
 
                     taskList.Add(task);
                     taskList.Add(Task.Delay(TimeSpan.FromSeconds(MainForm.SingletonMainForm.ServerTimeout)));
                     Task.WaitAny(taskList.ToArray());
-                    if (task.IsCompleted) {
+                    if (task.IsCompleted)
+                    {
                         return task.Result;
                     }
                     throw new TimeoutException();
@@ -2010,16 +2025,21 @@ namespace Microsoft.Azure.ServiceBusExplorer
         /// <summary>
         /// Retrieves a topic in the service bus namespace that matches the entity path.
         /// </summary>
-        private TopicDescription GetTopicUsingEntityPath() {
+        private TopicDescription GetTopicUsingEntityPath()
+        {
             var taskList = new List<Task>();
             var getTopicTask = namespaceManager.GetTopicAsync(serviceBusNamespaceInstance.EntityPath);
             taskList.Add(getTopicTask);
             taskList.Add(Task.Delay(TimeSpan.FromSeconds(MainForm.SingletonMainForm.ServerTimeout)));
             Task.WaitAny(taskList.ToArray());
-            if (getTopicTask.IsCompleted) {
-                try {
+            if (getTopicTask.IsCompleted)
+            {
+                try
+                {
                     return getTopicTask.Result;
-                } catch (AggregateException ex) {
+                }
+                catch (AggregateException ex)
+                {
                     throw ex.InnerExceptions.First();
                 }
             }
@@ -3212,7 +3232,7 @@ namespace Microsoft.Azure.ServiceBusExplorer
                                     }
                                     if (updatePartitionKey)
                                     {
-                                        eventDataList[i].PartitionKey = partitionKey; 
+                                        eventDataList[i].PartitionKey = partitionKey;
                                     }
                                     if (noPartitionKey || !partitionIdIsNull)
                                     {
@@ -3606,7 +3626,7 @@ namespace Microsoft.Azure.ServiceBusExplorer
                 elapsedMilliseconds = stopwatch.ElapsedMilliseconds;
                 if (logging)
                 {
-                    builder.AppendLine(string.Format(CultureInfo.CurrentCulture, 
+                    builder.AppendLine(string.Format(CultureInfo.CurrentCulture,
                                                      EventDataSuccessfullySent,
                                                      taskId,
                                                      messageNumber,
@@ -3748,10 +3768,10 @@ namespace Microsoft.Azure.ServiceBusExplorer
                     outboundMessage = new BrokeredMessage(reader.ReadToEnd());
                 }
             }
-            
+
             outboundMessage.MessageId = updateMessageId ? Guid.NewGuid().ToString() : messageTemplate.MessageId;
             outboundMessage.SessionId = oneSessionPerTask ? taskId.ToString(CultureInfo.InvariantCulture) : messageTemplate.SessionId;
-            
+
             if (bodyType == BodyType.String || bodyType == BodyType.ByteArray || bodyType == BodyType.Stream)
             {
                 if (!string.IsNullOrWhiteSpace(messageTemplate.Label))
@@ -4009,7 +4029,7 @@ namespace Microsoft.Azure.ServiceBusExplorer
                                 var useWcf = bodyType == BodyType.Wcf;
                                 for (var i = 0; i < messageNumberList.Count; i++)
                                 {
-                                    messageList.Add(useWcf?
+                                    messageList.Add(useWcf ?
                                                     CreateMessageForWcfReceiver(
                                                         messageTemplateCircularList.Next,
                                                         taskId,
@@ -4276,7 +4296,7 @@ namespace Microsoft.Azure.ServiceBusExplorer
                                 using (var reader = XmlReader.Create(new StringReader(messageText)))
                                 {
                                     // The XmlWriter is used just to indent the XML message
-                                    var settings = new XmlWriterSettings {Indent = true};
+                                    var settings = new XmlWriterSettings { Indent = true };
                                     using (var writer = XmlWriter.Create(stringBuilder, settings))
                                     {
                                         writer.WriteNode(reader, true);
@@ -4284,7 +4304,7 @@ namespace Microsoft.Azure.ServiceBusExplorer
                                 }
                                 messageText = stringBuilder.ToString();
                             }
-                            builder.AppendLine(string.Format(MessageTextFormat, messageText.Contains('\n') ? messageText : 
+                            builder.AppendLine(string.Format(MessageTextFormat, messageText.Contains('\n') ? messageText :
                                                                                 messageText.Substring(0, Math.Min(messageText.Length, 128)) +
                                                                                 (messageText.Length >= 128 ? "..." : "")));
                             builder.AppendLine(SentMessagePropertiesHeader);
@@ -4992,7 +5012,7 @@ namespace Microsoft.Azure.ServiceBusExplorer
         {
             ImportExportHelper.DeserializeAndCreate(this, xml);
         }
-
+      
         /// <summary>
         /// Reads the content of the BrokeredMessage passed as argument.
         /// </summary>
@@ -5099,7 +5119,7 @@ namespace Microsoft.Azure.ServiceBusExplorer
                                         using (var reader = new StreamReader(stream))
                                         {
                                             messageText = reader.ReadToEnd();
-                                            if (!MainForm.SingletonMainForm.UseAscii && messageText.ToCharArray().GroupBy(c => c). 
+                                            if (!MainForm.SingletonMainForm.UseAscii && messageText.ToCharArray().GroupBy(c => c).
                                                 Where(g => char.IsControl(g.Key) && g.Key != '\t' && g.Key != '\n' && g.Key != '\r').
                                                 Select(g => g.First()).Any())
                                             {
@@ -5206,14 +5226,14 @@ namespace Microsoft.Azure.ServiceBusExplorer
                 }
                 catch (Exception)
                 {
-                        try
-                        {
-                            stream.Seek(0, SeekOrigin.Begin);
-                            var serializer = new CustomDataContractBinarySerializer(typeof(string));
-                            messageText = serializer.ReadObject(stream) as string;
-                        }
-                        catch (Exception)
-                        {
+                    try
+                    {
+                        stream.Seek(0, SeekOrigin.Begin);
+                        var serializer = new CustomDataContractBinarySerializer(typeof(string));
+                        messageText = serializer.ReadObject(stream) as string;
+                    }
+                    catch (Exception)
+                    {
                         try
                         {
                             stream.Seek(0, SeekOrigin.Begin);
@@ -5517,7 +5537,7 @@ namespace Microsoft.Azure.ServiceBusExplorer
 
         public string GetHostWithoutNamespace()
         {
-            if (namespaceUri == null || 
+            if (namespaceUri == null ||
                 string.IsNullOrWhiteSpace(namespaceUri.Host))
             {
                 return null;
@@ -5585,7 +5605,7 @@ namespace Microsoft.Azure.ServiceBusExplorer
                 messageTotal++;
                 var builder = new StringBuilder();
                 builder.AppendLine(string.Format(MessageSuccessfullyReceivedNoTask,
-                                                complete ? Read :Peeked,
+                                                complete ? Read : Peeked,
                                                 string.IsNullOrWhiteSpace(
                                                     inboundMessage.MessageId)
                                                     ? NullValue
@@ -5725,7 +5745,7 @@ namespace Microsoft.Azure.ServiceBusExplorer
             {
                 return;
             }
-            
+
             try
             {
                 var eventDataClone = inboundMessage.Clone();
@@ -5814,15 +5834,15 @@ namespace Microsoft.Azure.ServiceBusExplorer
         {
             switch (encodingType)
             {
-                case EncodingType.ASCII: 
+                case EncodingType.ASCII:
                     return Encoding.ASCII;
-                case EncodingType.UTF7: 
+                case EncodingType.UTF7:
                     return Encoding.UTF7;
-                case EncodingType.UTF8: 
+                case EncodingType.UTF8:
                     return Encoding.UTF8;
-                case EncodingType.UTF32: 
+                case EncodingType.UTF32:
                     return Encoding.UTF32;
-                case EncodingType.Unicode: 
+                case EncodingType.Unicode:
                     return Encoding.Unicode;
                 default:
                     return Encoding.UTF8;

--- a/src/ServiceBusExplorer/ServiceBusExplorer.csproj
+++ b/src/ServiceBusExplorer/ServiceBusExplorer.csproj
@@ -77,7 +77,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ServiceBus, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.ServiceBus.4.1.2\lib\net45\Microsoft.ServiceBus.dll</HintPath>
+      <HintPath>..\packages\WindowsAzure.ServiceBus.4.1.6\lib\net45\Microsoft.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
@@ -407,6 +407,7 @@
     <Compile Include="Helpers\IEventDataInspector.cs" />
     <Compile Include="Helpers\IBrokeredMessageInspector.cs" />
     <Compile Include="Helpers\LogBrokeredMessageInspector.cs" />
+    <Compile Include="Helpers\MessagingPurger.cs" />
     <Compile Include="Helpers\MessageSerializationHelper.cs" />
     <Compile Include="Helpers\NotificationHubAuthorizationRuleWrapper.cs" />
     <Compile Include="Helpers\OnOffDeviceBrokeredMessageGenerator.cs" />
@@ -645,7 +646,9 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/src/ServiceBusExplorer/packages.config
+++ b/src/ServiceBusExplorer/packages.config
@@ -5,5 +5,5 @@
   <package id="Microsoft.Azure.NotificationHubs" version="2.16.0.234" targetFramework="net461" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
-  <package id="WindowsAzure.ServiceBus" version="4.1.2" targetFramework="net461" />
+  <package id="WindowsAzure.ServiceBus" version="4.1.6" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Attempts to fix #60. There are many variations with partioned entities, session entities, message size, network latency and other factors so the code will probably have to be tuned.

I used VS automatic formatting and it did a lot of formatting on other places too. I thought I'd leave those changes since I think it looks better and will take a while to undo. 

I had some issues with entities with sessions so only one receiving task is used for them. I upgraded to the latest Service Bus client, but it didn't help. But that is how I have tested this so the code upgrades the Service Bus client to the latest version.

I moved code from the HandleQueueControl and the HandleSubscriptionControl classes to a new class called MessagingPurger where subscriptions and queues are handled in basically the same way.