### PR TITLE
Purging DLQs with a single message

### DIFF
--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -453,7 +453,6 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
 
         public async Task<long> PurgeDeadletterQueueMessagesAsync()
         {
-            var dlqPath = QueueClient.FormatDeadLetterPath(queueDescription.Path);
             using (var deleteForm = new DeleteForm($"Would you like to purge the deadletter queue of the {queueDescription.Path} queue?"))
             {
                 if (deleteForm.ShowDialog() != DialogResult.OK)

--- a/src/ServiceBusExplorer/Helpers/MessagingPurger.cs
+++ b/src/ServiceBusExplorer/Helpers/MessagingPurger.cs
@@ -325,16 +325,20 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
         private bool EntityIsPartioned()
         {
             if (queueDescription != null)
+            {
                 return queueDescription.EnablePartitioning;
-            else
-                return subscriptionWrapper.TopicDescription.EnablePartitioning;
+            }
+
+            return subscriptionWrapper.TopicDescription.EnablePartitioning;
         }
         private bool EntityRequiresSession()
         {
             if (queueDescription != null)
+            {
                 return queueDescription.RequiresSession;
-            else
-                return subscriptionWrapper.SubscriptionDescription.RequiresSession;
+            }
+
+            return subscriptionWrapper.SubscriptionDescription.RequiresSession;
         }
         #endregion
     }

--- a/src/ServiceBusExplorer/Helpers/MessagingPurger.cs
+++ b/src/ServiceBusExplorer/Helpers/MessagingPurger.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
         /// <summary>
         /// Purges the messages from a queue, subscription or a dead letter queue. Handles all kinds of queues.
         /// </summary>
-        /// <param name="purgeDeadLetterSubQueue">If false it will purge the queue, if true it will purge the 
+        /// <param name="purgeDeadLetterQueueInstead">If false it will purge the queue, if true it will purge the 
         /// dead letter queue instead.</param>
         /// <returns>The number of messages purged</returns>
         public async Task<long> Purge(bool purgeDeadLetterQueueInstead = false)
@@ -68,11 +68,11 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
 
             if (!purgeDeadLetterQueueInstead && EntityRequiresSession())
             {
-                totalMessagesPurged = await PurgeSessionEntity();
+                totalMessagesPurged = await PurgeSessionEntity().ConfigureAwait(false);
             }
             else
             {
-                totalMessagesPurged = await PurgeNonSessionEntity(purgeDeadLetterQueueInstead: purgeDeadLetterQueueInstead);
+                totalMessagesPurged = await PurgeNonSessionEntity(purgeDeadLetterQueueInstead: purgeDeadLetterQueueInstead).ConfigureAwait(false);
             }
 
             return totalMessagesPurged;
@@ -86,7 +86,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                 messageCount: out long messagesToPurgeCount,
                 entityPath: out _);
 
-            return await DoPurgeSessionEntity(messagesToPurgeCount);
+            return await DoPurgeSessionEntity(messagesToPurgeCount)
+                .ConfigureAwait(false);
         }
 
         private async Task<long> DoPurgeSessionEntity(long messagesToPurgeCount)
@@ -159,7 +160,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
             }
             finally
             {
-                await entityClient.CloseAsync().ConfigureAwait(false);
+                await entityClient.CloseAsync()
+                    .ConfigureAwait(false);
             }
 
             return totalMessagesPurged;
@@ -179,7 +181,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                 purgedMessagesCount += await DoPurgeNonSessionEntity(
                     queue: purgeDeadLetterQueueInstead ? true : queueDescription != null,
                     messagesToPurgeCount: messagesToPurgeCount,
-                    entityPath: entityPath);
+                    entityPath: entityPath)
+                    .ConfigureAwait(false);
 
                 GetEntityData(purgeDeadLetterQueueInstead, out messageCount, out _);
                 ++retries;
@@ -307,7 +310,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                 });  // End of lambda 
             }
 
-            await Task.WhenAll(tasks);
+            await Task.WhenAll(tasks).ConfigureAwait(false);
             return totalMessagesPurged;
         }
 

--- a/src/ServiceBusExplorer/Helpers/MessagingPurger.cs
+++ b/src/ServiceBusExplorer/Helpers/MessagingPurger.cs
@@ -298,17 +298,6 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
             return totalMessagesPurged;
         }
 
-        // TODO: this method was never used. Is it even needed?
-        bool EntityIsPartioned()
-        {
-            if (queueDescription != null)
-            {
-                return queueDescription.EnablePartitioning;
-            }
-
-            return subscriptionWrapper.TopicDescription.EnablePartitioning;
-        }
-
         bool EntityRequiresSession()
         {
             if (queueDescription != null)

--- a/src/ServiceBusExplorer/Helpers/MessagingPurger.cs
+++ b/src/ServiceBusExplorer/Helpers/MessagingPurger.cs
@@ -298,6 +298,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
             return totalMessagesPurged;
         }
 
+        // TODO: this method was never used. Is it even needed?
         bool EntityIsPartioned()
         {
             if (queueDescription != null)

--- a/src/ServiceBusExplorer/Helpers/MessagingPurger.cs
+++ b/src/ServiceBusExplorer/Helpers/MessagingPurger.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                     }
                     finally
                     {
-                        await CloseReceiver(receiver).ConfigureAwait(false);
+                        await receiver.CloseAsync().ConfigureAwait(false);
                         await messagingFactory.CloseAsync().ConfigureAwait(false);
                     }
 
@@ -309,17 +309,6 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
 
             await Task.WhenAll(tasks);
             return totalMessagesPurged;
-        }
-
-        private static async Task CloseReceiver(ClientEntity receiver)
-        {
-            // Currently there is no implementation of CloseAsync in the MessageReceiver nor in the
-            // SubscriptionClient class, only in their common base cless, but in case there appears 
-            // one we want to call it.
-            if (receiver is MessageReceiver)
-                await ((MessageReceiver)receiver).CloseAsync().ConfigureAwait(false);
-            else
-                await ((SubscriptionClient)receiver).CloseAsync().ConfigureAwait(false);
         }
 
         private bool EntityIsPartioned()

--- a/src/ServiceBusExplorer/Helpers/MessagingPurger.cs
+++ b/src/ServiceBusExplorer/Helpers/MessagingPurger.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
             var retries = 0;
 
             // Sometimes it does not start polling or quits polling while not done
-            while (purgedMessagesCount < messagesToPurgeCount && messageCount > 1 && retries < 3)
+            while (purgedMessagesCount < messagesToPurgeCount && messageCount >= 1 && retries < 3)
             {
                 purgedMessagesCount += await DoPurgeNonSessionEntity(
                     queue: purgeDeadLetterQueueInstead ? true : queueDescription != null,

--- a/src/ServiceBusExplorer/Helpers/MessagingPurger.cs
+++ b/src/ServiceBusExplorer/Helpers/MessagingPurger.cs
@@ -27,7 +27,6 @@ using System.Linq;
 using Microsoft.ServiceBus.Messaging;
 using System.Threading.Tasks;
 using System.Threading;
-using System.Diagnostics;
 
 #endregion
 
@@ -160,7 +159,6 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
             }
             finally
             {
-                await CloseClient(entityClient).ConfigureAwait(false);
                 await entityClient.CloseAsync().ConfigureAwait(false);
             }
 
@@ -322,17 +320,6 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                 await ((MessageReceiver)receiver).CloseAsync().ConfigureAwait(false);
             else
                 await ((SubscriptionClient)receiver).CloseAsync().ConfigureAwait(false);
-        }
-
-        private static async Task CloseClient(ClientEntity clientEntity)
-        {
-            // Currently there is no implementation of CloseAsync in the QueueClient nor in the
-            // SubscriptionClient class, only in their common base cless, but in case there appears 
-            // one we want to call it.
-            if (clientEntity is QueueClient)
-                await ((QueueClient)clientEntity).CloseAsync().ConfigureAwait(false);
-            else
-                await ((SubscriptionClient)clientEntity).CloseAsync().ConfigureAwait(false);
         }
 
         private bool EntityIsPartioned()


### PR DESCRIPTION
Fixes #183 

I took the liberty to clean up the class a little bit and remove some redandencies.
Couldn't figure out what to do about https://github.com/paolosalvatori/ServiceBusExplorer/commit/63e6c9d67f14e31b54d0e7ee12fbff4447a07d4e. @paolosalvatori should that method be entirely removed as it was (and is not) ever called?