### PR TITLE
Update WindowsAzure.ServiceBus from 4.1.6 to 4.1.8

### DIFF
--- a/src/ServiceBusExplorer/ServiceBusExplorer.csproj
+++ b/src/ServiceBusExplorer/ServiceBusExplorer.csproj
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ServiceBus, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.ServiceBus.4.1.6\lib\net45\Microsoft.ServiceBus.dll</HintPath>
+      <HintPath>..\packages\WindowsAzure.ServiceBus.4.1.8\lib\net45\Microsoft.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>

--- a/src/ServiceBusExplorer/packages.config
+++ b/src/ServiceBusExplorer/packages.config
@@ -5,5 +5,5 @@
   <package id="Microsoft.Azure.NotificationHubs" version="2.16.0.234" targetFramework="net461" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
-  <package id="WindowsAzure.ServiceBus" version="4.1.6" targetFramework="net461" />
+  <package id="WindowsAzure.ServiceBus" version="4.1.8" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
The version 4.1.6 causes for some users, whose firewall doesn't permit native AMQP communication (and thus falls back on HTTPS/Web Sockets), an application freeze during message retrieval from queues and subscriptions. This bug was fixed in 4.1.8 (see Release Notes section on https://www.nuget.org/packages/WindowsAzure.ServiceBus/4.1.8)