### PR TITLE
Do not alter dates when indenting JSON

### DIFF
--- a/src/ServiceBusExplorer.Tests/Helpers/JsonSerializerHelperTest.cs
+++ b/src/ServiceBusExplorer.Tests/Helpers/JsonSerializerHelperTest.cs
@@ -50,6 +50,19 @@ namespace Microsoft.Azure.ServiceBusExplorer.Tests.Helpers
 
             Assert.AreEqual(indented, expectedResult);
         }
+        
+        [Test]
+        public void IndentJson_ValueIsJson_DoesNotChangeDateFormat()
+        {
+            var json = @"{""dateIso"":""2018-05-14T00:00:00Z"",""dateMicrosoft"":""/Date(1526256000000)/""}";
+            var expectedResult = @"{
+  ""dateIso"": ""2018-05-14T00:00:00Z"",
+  ""dateMicrosoft"": ""/Date(1526256000000)/""
+}";
+            var indented = JsonSerializerHelper.Indent(json);
+
+            Assert.AreEqual(indented, expectedResult);
+        }
 
         [Test]
         public void IndentJson_ValueHasTypeHandling_ReturnsIndentedStringWithTypeHandling()

--- a/src/ServiceBusExplorer/Helpers/JsonSerializerHelper.cs
+++ b/src/ServiceBusExplorer/Helpers/JsonSerializerHelper.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
 {
     public static class JsonSerializerHelper
     {
+        static readonly JsonSerializerSettings serializerSettings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None };
+
         /// <summary>
         /// Indent the supplied json string
         /// </summary>
@@ -41,9 +43,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
         {
             try
             {
-                var settings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None };
                 return JsonConvert
-                    .SerializeObject(JsonConvert.DeserializeObject(json.Replace("$type", "%%$type%%"), settings), Formatting.Indented)
+                    .SerializeObject(JsonConvert.DeserializeObject(json.Replace("$type", "%%$type%%"), serializerSettings), Formatting.Indented)
                     .Replace("%%$type%%", "$type");
             }
             catch (Exception)

--- a/src/ServiceBusExplorer/Helpers/JsonSerializerHelper.cs
+++ b/src/ServiceBusExplorer/Helpers/JsonSerializerHelper.cs
@@ -41,8 +41,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
         {
             try
             {
+                var settings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None };
                 return JsonConvert
-                    .SerializeObject(JsonConvert.DeserializeObject(json.Replace("$type", "%%$type%%")), Formatting.Indented)
+                    .SerializeObject(JsonConvert.DeserializeObject(json.Replace("$type", "%%$type%%"), settings), Formatting.Indented)
                     .Replace("%%$type%%", "$type");
             }
             catch (Exception)


### PR DESCRIPTION
Json.NET interprets strings as date by default as discussed on https://github.com/JamesNK/Newtonsoft.Json/issues/862

So a deserialize/serialize roundtrip may actually modify the source JSON. Using `DateParseHandling = DateParseHandling.None` ensures that dates are not interpreted and thus the serialized JSON is identical to the source (except for indentation of course).