### PR TITLE
Remove default max length of 32767 for most text boxes

### DIFF
--- a/src/ServiceBusExplorer/Controls/HandleConsumerGroupControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleConsumerGroupControl.Designer.cs
@@ -155,6 +155,7 @@
             this.txtUserMetadata.BackColor = System.Drawing.SystemColors.Window;
             this.txtUserMetadata.Location = new System.Drawing.Point(21, 59);
             this.txtUserMetadata.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtUserMetadata.MaxLength = 0;
             this.txtUserMetadata.Multiline = true;
             this.txtUserMetadata.Name = "txtUserMetadata";
             this.txtUserMetadata.Size = new System.Drawing.Size(767, 344);

--- a/src/ServiceBusExplorer/Controls/HandleEventHubControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleEventHubControl.Designer.cs
@@ -239,6 +239,7 @@
             this.txtUserMetadata.BackColor = System.Drawing.SystemColors.Window;
             this.txtUserMetadata.Location = new System.Drawing.Point(21, 59);
             this.txtUserMetadata.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtUserMetadata.MaxLength = 0;
             this.txtUserMetadata.Multiline = true;
             this.txtUserMetadata.Name = "txtUserMetadata";
             this.txtUserMetadata.Size = new System.Drawing.Size(767, 294);

--- a/src/ServiceBusExplorer/Controls/HandleNotificationHubControl.designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleNotificationHubControl.designer.cs
@@ -1655,6 +1655,7 @@
             this.txtTemplatePayload.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtTemplatePayload.Location = new System.Drawing.Point(21, 39);
             this.txtTemplatePayload.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtTemplatePayload.MaxLength = 0;
             this.txtTemplatePayload.Multiline = true;
             this.txtTemplatePayload.Name = "txtTemplatePayload";
             this.txtTemplatePayload.ReadOnly = true;
@@ -1726,6 +1727,7 @@
             this.txtTemplateTagExpression.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtTemplateTagExpression.Location = new System.Drawing.Point(21, 39);
             this.txtTemplateTagExpression.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtTemplateTagExpression.MaxLength = 0;
             this.txtTemplateTagExpression.Multiline = true;
             this.txtTemplateTagExpression.Name = "txtTemplateTagExpression";
             this.txtTemplateTagExpression.ScrollBars = System.Windows.Forms.ScrollBars.Both;
@@ -2023,6 +2025,7 @@
             this.txtMpnsPayload.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtMpnsPayload.Location = new System.Drawing.Point(21, 39);
             this.txtMpnsPayload.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtMpnsPayload.MaxLength = 0;
             this.txtMpnsPayload.Multiline = true;
             this.txtMpnsPayload.Name = "txtMpnsPayload";
             this.txtMpnsPayload.ReadOnly = true;
@@ -2095,6 +2098,7 @@
             this.txtMpnsTagExpression.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtMpnsTagExpression.Location = new System.Drawing.Point(21, 39);
             this.txtMpnsTagExpression.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtMpnsTagExpression.MaxLength = 0;
             this.txtMpnsTagExpression.Multiline = true;
             this.txtMpnsTagExpression.Name = "txtMpnsTagExpression";
             this.txtMpnsTagExpression.ScrollBars = System.Windows.Forms.ScrollBars.Both;
@@ -2399,6 +2403,7 @@
             this.txtWnsPayload.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtWnsPayload.Location = new System.Drawing.Point(21, 39);
             this.txtWnsPayload.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtWnsPayload.MaxLength = 0;
             this.txtWnsPayload.Multiline = true;
             this.txtWnsPayload.Name = "txtWnsPayload";
             this.txtWnsPayload.ReadOnly = true;
@@ -2471,6 +2476,7 @@
             this.txtWnsTagExpression.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtWnsTagExpression.Location = new System.Drawing.Point(21, 39);
             this.txtWnsTagExpression.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtWnsTagExpression.MaxLength = 0;
             this.txtWnsTagExpression.Multiline = true;
             this.txtWnsTagExpression.Name = "txtWnsTagExpression";
             this.txtWnsTagExpression.ScrollBars = System.Windows.Forms.ScrollBars.Both;
@@ -2758,6 +2764,7 @@
             this.txtApnsJsonPayload.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtApnsJsonPayload.Location = new System.Drawing.Point(21, 39);
             this.txtApnsJsonPayload.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtApnsJsonPayload.MaxLength = 0;
             this.txtApnsJsonPayload.Multiline = true;
             this.txtApnsJsonPayload.Name = "txtApnsJsonPayload";
             this.txtApnsJsonPayload.ScrollBars = System.Windows.Forms.ScrollBars.Both;
@@ -2848,6 +2855,7 @@
             this.txtAppleTagExpression.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtAppleTagExpression.Location = new System.Drawing.Point(21, 39);
             this.txtAppleTagExpression.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtAppleTagExpression.MaxLength = 0;
             this.txtAppleTagExpression.Multiline = true;
             this.txtAppleTagExpression.Name = "txtAppleTagExpression";
             this.txtAppleTagExpression.ScrollBars = System.Windows.Forms.ScrollBars.Both;
@@ -3254,6 +3262,7 @@
             this.txtGcmJsonPayload.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtGcmJsonPayload.Location = new System.Drawing.Point(21, 39);
             this.txtGcmJsonPayload.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtGcmJsonPayload.MaxLength = 0;
             this.txtGcmJsonPayload.Multiline = true;
             this.txtGcmJsonPayload.Name = "txtGcmJsonPayload";
             this.txtGcmJsonPayload.ScrollBars = System.Windows.Forms.ScrollBars.Both;
@@ -3344,6 +3353,7 @@
             this.txtGcmTagExpression.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtGcmTagExpression.Location = new System.Drawing.Point(21, 39);
             this.txtGcmTagExpression.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtGcmTagExpression.MaxLength = 0;
             this.txtGcmTagExpression.Multiline = true;
             this.txtGcmTagExpression.Name = "txtGcmTagExpression";
             this.txtGcmTagExpression.ScrollBars = System.Windows.Forms.ScrollBars.Both;

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.Designer.cs
@@ -1601,6 +1601,7 @@
             this.txtMessageText.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtMessageText.Location = new System.Drawing.Point(21, 39);
             this.txtMessageText.Margin = new System.Windows.Forms.Padding(4);
+            this.txtMessageText.MaxLength = 0;
             this.txtMessageText.Multiline = true;
             this.txtMessageText.Name = "txtMessageText";
             this.txtMessageText.ScrollBars = System.Windows.Forms.ScrollBars.Both;
@@ -1892,6 +1893,7 @@
             this.txtDeadletterText.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtDeadletterText.Location = new System.Drawing.Point(21, 39);
             this.txtDeadletterText.Margin = new System.Windows.Forms.Padding(4);
+            this.txtDeadletterText.MaxLength = 0;
             this.txtDeadletterText.Multiline = true;
             this.txtDeadletterText.Name = "txtDeadletterText";
             this.txtDeadletterText.ScrollBars = System.Windows.Forms.ScrollBars.Both;
@@ -2179,6 +2181,7 @@
             this.txtTransferDeadletterText.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtTransferDeadletterText.Location = new System.Drawing.Point(21, 39);
             this.txtTransferDeadletterText.Margin = new System.Windows.Forms.Padding(4);
+            this.txtTransferDeadletterText.MaxLength = 0;
             this.txtTransferDeadletterText.Multiline = true;
             this.txtTransferDeadletterText.Name = "txtTransferDeadletterText";
             this.txtTransferDeadletterText.ScrollBars = System.Windows.Forms.ScrollBars.Both;
@@ -2433,6 +2436,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtSessionState.Location = new System.Drawing.Point(21, 39);
             this.txtSessionState.Margin = new System.Windows.Forms.Padding(4);
+            this.txtSessionState.MaxLength = 0;
             this.txtSessionState.Multiline = true;
             this.txtSessionState.Name = "txtSessionState";
             this.txtSessionState.Size = new System.Drawing.Size(764, 202);

--- a/src/ServiceBusExplorer/Controls/HandleRelayControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleRelayControl.Designer.cs
@@ -236,6 +236,7 @@
             this.txtUserMetadata.BackColor = System.Drawing.SystemColors.Window;
             this.txtUserMetadata.Location = new System.Drawing.Point(21, 108);
             this.txtUserMetadata.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtUserMetadata.MaxLength = 0;
             this.txtUserMetadata.Multiline = true;
             this.txtUserMetadata.Name = "txtUserMetadata";
             this.txtUserMetadata.Size = new System.Drawing.Size(308, 294);

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.Designer.cs
@@ -1441,6 +1441,7 @@
             this.txtMessageText.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtMessageText.Location = new System.Drawing.Point(21, 39);
             this.txtMessageText.Margin = new System.Windows.Forms.Padding(4);
+            this.txtMessageText.MaxLength = 0;
             this.txtMessageText.Multiline = true;
             this.txtMessageText.Name = "txtMessageText";
             this.txtMessageText.ScrollBars = System.Windows.Forms.ScrollBars.Both;
@@ -1732,6 +1733,7 @@
             this.txtDeadletterText.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtDeadletterText.Location = new System.Drawing.Point(21, 39);
             this.txtDeadletterText.Margin = new System.Windows.Forms.Padding(4);
+            this.txtDeadletterText.MaxLength = 0;
             this.txtDeadletterText.Multiline = true;
             this.txtDeadletterText.Name = "txtDeadletterText";
             this.txtDeadletterText.ScrollBars = System.Windows.Forms.ScrollBars.Both;
@@ -1986,6 +1988,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtSessionState.Location = new System.Drawing.Point(21, 39);
             this.txtSessionState.Margin = new System.Windows.Forms.Padding(4);
+            this.txtSessionState.MaxLength = 0;
             this.txtSessionState.Multiline = true;
             this.txtSessionState.Name = "txtSessionState";
             this.txtSessionState.Size = new System.Drawing.Size(766, 198);

--- a/src/ServiceBusExplorer/Controls/HandleTopicControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleTopicControl.Designer.cs
@@ -711,6 +711,7 @@
             this.txtUserMetadata.BackColor = System.Drawing.SystemColors.Window;
             this.txtUserMetadata.Location = new System.Drawing.Point(21, 108);
             this.txtUserMetadata.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtUserMetadata.MaxLength = 0;
             this.txtUserMetadata.Multiline = true;
             this.txtUserMetadata.Name = "txtUserMetadata";
             this.txtUserMetadata.Size = new System.Drawing.Size(308, 186);

--- a/src/ServiceBusExplorer/Controls/ListenerControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/ListenerControl.Designer.cs
@@ -882,6 +882,7 @@
             this.txtMessageText.BackColor = System.Drawing.SystemColors.Window;
             this.txtMessageText.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtMessageText.Location = new System.Drawing.Point(16, 32);
+            this.txtMessageText.MaxLength = 0;
             this.txtMessageText.Multiline = true;
             this.txtMessageText.Name = "txtMessageText";
             this.txtMessageText.ScrollBars = System.Windows.Forms.ScrollBars.Both;

--- a/src/ServiceBusExplorer/Controls/PartitionListenerControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/PartitionListenerControl.Designer.cs
@@ -962,6 +962,7 @@
             this.txtMessageText.BackColor = System.Drawing.SystemColors.Window;
             this.txtMessageText.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtMessageText.Location = new System.Drawing.Point(16, 32);
+            this.txtMessageText.MaxLength = 0;
             this.txtMessageText.Multiline = true;
             this.txtMessageText.Name = "txtMessageText";
             this.txtMessageText.ScrollBars = System.Windows.Forms.ScrollBars.Both;

--- a/src/ServiceBusExplorer/Controls/TestEventHubControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/TestEventHubControl.Designer.cs
@@ -497,6 +497,7 @@
             this.txtMessageText.BackColor = System.Drawing.SystemColors.Window;
             this.txtMessageText.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtMessageText.Location = new System.Drawing.Point(16, 32);
+            this.txtMessageText.MaxLength = 0;
             this.txtMessageText.Multiline = true;
             this.txtMessageText.Name = "txtMessageText";
             this.txtMessageText.ScrollBars = System.Windows.Forms.ScrollBars.Both;

--- a/src/ServiceBusExplorer/Controls/TestQueueControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/TestQueueControl.Designer.cs
@@ -613,6 +613,7 @@
             this.txtMessageText.BackColor = System.Drawing.SystemColors.Window;
             this.txtMessageText.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtMessageText.Location = new System.Drawing.Point(16, 32);
+            this.txtMessageText.MaxLength = 0;
             this.txtMessageText.Multiline = true;
             this.txtMessageText.Name = "txtMessageText";
             this.txtMessageText.ScrollBars = System.Windows.Forms.ScrollBars.Both;

--- a/src/ServiceBusExplorer/Controls/TestRelayControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/TestRelayControl.Designer.cs
@@ -222,6 +222,7 @@
             this.txtMessageText.BackColor = System.Drawing.SystemColors.Window;
             this.txtMessageText.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtMessageText.Location = new System.Drawing.Point(16, 32);
+            this.txtMessageText.MaxLength = 0;
             this.txtMessageText.Multiline = true;
             this.txtMessageText.Name = "txtMessageText";
             this.txtMessageText.ScrollBars = System.Windows.Forms.ScrollBars.Both;

--- a/src/ServiceBusExplorer/Controls/TestTopicControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/TestTopicControl.Designer.cs
@@ -372,6 +372,7 @@
             this.txtMessageText.BackColor = System.Drawing.SystemColors.Window;
             this.txtMessageText.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtMessageText.Location = new System.Drawing.Point(16, 32);
+            this.txtMessageText.MaxLength = 0;
             this.txtMessageText.Multiline = true;
             this.txtMessageText.Name = "txtMessageText";
             this.txtMessageText.ScrollBars = System.Windows.Forms.ScrollBars.Both;

--- a/src/ServiceBusExplorer/Forms/EventDataForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/EventDataForm.Designer.cs
@@ -184,6 +184,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtMessageText.BackColor = System.Drawing.SystemColors.Window;
             this.txtMessageText.Location = new System.Drawing.Point(16, 32);
+            this.txtMessageText.MaxLength = 0;
             this.txtMessageText.Multiline = true;
             this.txtMessageText.Name = "txtMessageText";
             this.txtMessageText.ScrollBars = System.Windows.Forms.ScrollBars.Both;

--- a/src/ServiceBusExplorer/Forms/MessageForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/MessageForm.Designer.cs
@@ -292,6 +292,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.txtMessageText.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtMessageText.Location = new System.Drawing.Point(21, 39);
             this.txtMessageText.Margin = new System.Windows.Forms.Padding(4);
+            this.txtMessageText.MaxLength = 0;
             this.txtMessageText.Multiline = true;
             this.txtMessageText.Name = "txtMessageText";
             this.txtMessageText.ScrollBars = System.Windows.Forms.ScrollBars.Both;

--- a/src/ServiceBusExplorer/Forms/TextForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/TextForm.Designer.cs
@@ -133,6 +133,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtContent.Location = new System.Drawing.Point(16, 32);
+            this.txtContent.MaxLength = 0;
             this.txtContent.Multiline = true;
             this.txtContent.Name = "txtContent";
             this.txtContent.ScrollBars = System.Windows.Forms.ScrollBars.Both;


### PR DESCRIPTION
This is especially important for message text boxes where a message could exceed the 32 KB limit.