### PR TITLE
Fix the exception when there are no Notification hubs

### DIFF
--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -4662,6 +4662,11 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                                         HandleNodeMouseClick(notificationHubListNode);
                                     }
                                 }
+                                catch (ArgumentException)
+                                {
+                                    // This is where we end up if there are no Notification Hubs in the namespace
+                                    serviceBusTreeView.Nodes.Remove(notificationHubListNode);
+                                }
                                 catch (Exception ex) when (FilterOutException(ex))
                                 {
                                     WriteToLog($"Failed to retrieve Notification Hub entities. Exception: {ex}");


### PR DESCRIPTION
This should fix #213. I have tried it with namespaces only containing one of the following types:

- Event hubs
- Relay
- Basic ServiceBus namespace


and unlike Tom I had no issues. Perhaps different age/versions of the namespaces or SKUs. I was unable to connect to a Notification Hubs namespace before and after this change.
