### PR TITLE
Changes to Event Hub and Consumer Group controls

### DIFF
--- a/src/ServiceBusExplorer/Controls/HandleConsumerGroupControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleConsumerGroupControl.Designer.cs
@@ -56,10 +56,9 @@
             this.tabPageDescription.Controls.Add(this.grouperConsumerGroupProperties);
             this.tabPageDescription.Controls.Add(this.grouperConsumerGroupInformation);
             this.tabPageDescription.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.tabPageDescription.Location = new System.Drawing.Point(4, 27);
-            this.tabPageDescription.Margin = new System.Windows.Forms.Padding(4);
+            this.tabPageDescription.Location = new System.Drawing.Point(4, 24);
             this.tabPageDescription.Name = "tabPageDescription";
-            this.tabPageDescription.Size = new System.Drawing.Size(1293, 560);
+            this.tabPageDescription.Size = new System.Drawing.Size(968, 452);
             this.tabPageDescription.TabIndex = 2;
             this.tabPageDescription.Text = "Description";
             // 
@@ -77,26 +76,24 @@
             this.grouperName.ForeColor = System.Drawing.Color.White;
             this.grouperName.GroupImage = null;
             this.grouperName.GroupTitle = "Name";
-            this.grouperName.Location = new System.Drawing.Point(21, 10);
-            this.grouperName.Margin = new System.Windows.Forms.Padding(4);
+            this.grouperName.Location = new System.Drawing.Point(16, 8);
             this.grouperName.Name = "grouperName";
-            this.grouperName.Padding = new System.Windows.Forms.Padding(27, 25, 27, 25);
+            this.grouperName.Padding = new System.Windows.Forms.Padding(20, 20, 20, 20);
             this.grouperName.PaintGroupBox = true;
             this.grouperName.RoundCorners = 4;
             this.grouperName.ShadowColor = System.Drawing.Color.DarkGray;
             this.grouperName.ShadowControl = false;
             this.grouperName.ShadowThickness = 1;
-            this.grouperName.Size = new System.Drawing.Size(811, 98);
+            this.grouperName.Size = new System.Drawing.Size(608, 80);
             this.grouperName.TabIndex = 0;
             // 
             // lblRelativeURI
             // 
             this.lblRelativeURI.AutoSize = true;
             this.lblRelativeURI.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblRelativeURI.Location = new System.Drawing.Point(21, 34);
-            this.lblRelativeURI.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblRelativeURI.Location = new System.Drawing.Point(16, 28);
             this.lblRelativeURI.Name = "lblRelativeURI";
-            this.lblRelativeURI.Size = new System.Drawing.Size(161, 17);
+            this.lblRelativeURI.Size = new System.Drawing.Size(120, 13);
             this.lblRelativeURI.TabIndex = 22;
             this.lblRelativeURI.Text = "Consumer Group Name:";
             // 
@@ -106,11 +103,11 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtName.BackColor = System.Drawing.SystemColors.Window;
             this.txtName.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
-            this.txtName.Location = new System.Drawing.Point(21, 54);
-            this.txtName.Margin = new System.Windows.Forms.Padding(4);
+            this.txtName.Location = new System.Drawing.Point(16, 44);
             this.txtName.Name = "txtName";
-            this.txtName.Size = new System.Drawing.Size(767, 23);
+            this.txtName.Size = new System.Drawing.Size(576, 20);
             this.txtName.TabIndex = 0;
+            this.txtName.TextChanged += new System.EventHandler(this.txtName_TextChanged);
             // 
             // grouperConsumerGroupProperties
             // 
@@ -128,16 +125,15 @@
             this.grouperConsumerGroupProperties.ForeColor = System.Drawing.Color.White;
             this.grouperConsumerGroupProperties.GroupImage = null;
             this.grouperConsumerGroupProperties.GroupTitle = "Consumer Group Properties";
-            this.grouperConsumerGroupProperties.Location = new System.Drawing.Point(21, 118);
-            this.grouperConsumerGroupProperties.Margin = new System.Windows.Forms.Padding(4);
+            this.grouperConsumerGroupProperties.Location = new System.Drawing.Point(16, 96);
             this.grouperConsumerGroupProperties.Name = "grouperConsumerGroupProperties";
-            this.grouperConsumerGroupProperties.Padding = new System.Windows.Forms.Padding(27, 25, 27, 25);
+            this.grouperConsumerGroupProperties.Padding = new System.Windows.Forms.Padding(20, 20, 20, 20);
             this.grouperConsumerGroupProperties.PaintGroupBox = true;
             this.grouperConsumerGroupProperties.RoundCorners = 4;
             this.grouperConsumerGroupProperties.ShadowColor = System.Drawing.Color.DarkGray;
             this.grouperConsumerGroupProperties.ShadowControl = false;
             this.grouperConsumerGroupProperties.ShadowThickness = 1;
-            this.grouperConsumerGroupProperties.Size = new System.Drawing.Size(811, 423);
+            this.grouperConsumerGroupProperties.Size = new System.Drawing.Size(608, 344);
             this.grouperConsumerGroupProperties.TabIndex = 3;
             // 
             // txtUserMetadata
@@ -146,22 +142,20 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtUserMetadata.BackColor = System.Drawing.SystemColors.Window;
-            this.txtUserMetadata.Location = new System.Drawing.Point(21, 59);
-            this.txtUserMetadata.Margin = new System.Windows.Forms.Padding(4);
+            this.txtUserMetadata.Location = new System.Drawing.Point(16, 48);
             this.txtUserMetadata.MaxLength = 0;
             this.txtUserMetadata.Multiline = true;
             this.txtUserMetadata.Name = "txtUserMetadata";
-            this.txtUserMetadata.Size = new System.Drawing.Size(767, 344);
+            this.txtUserMetadata.Size = new System.Drawing.Size(576, 280);
             this.txtUserMetadata.TabIndex = 2;
             // 
             // lblUserMetadata
             // 
             this.lblUserMetadata.AutoSize = true;
             this.lblUserMetadata.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblUserMetadata.Location = new System.Drawing.Point(21, 34);
-            this.lblUserMetadata.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblUserMetadata.Location = new System.Drawing.Point(16, 28);
             this.lblUserMetadata.Name = "lblUserMetadata";
-            this.lblUserMetadata.Size = new System.Drawing.Size(117, 17);
+            this.lblUserMetadata.Size = new System.Drawing.Size(88, 13);
             this.lblUserMetadata.TabIndex = 27;
             this.lblUserMetadata.Text = "User Description:";
             // 
@@ -181,16 +175,15 @@
             this.grouperConsumerGroupInformation.ForeColor = System.Drawing.Color.White;
             this.grouperConsumerGroupInformation.GroupImage = null;
             this.grouperConsumerGroupInformation.GroupTitle = "Consumer Group Information";
-            this.grouperConsumerGroupInformation.Location = new System.Drawing.Point(853, 10);
-            this.grouperConsumerGroupInformation.Margin = new System.Windows.Forms.Padding(4);
+            this.grouperConsumerGroupInformation.Location = new System.Drawing.Point(640, 8);
             this.grouperConsumerGroupInformation.Name = "grouperConsumerGroupInformation";
-            this.grouperConsumerGroupInformation.Padding = new System.Windows.Forms.Padding(27, 25, 27, 25);
+            this.grouperConsumerGroupInformation.Padding = new System.Windows.Forms.Padding(20, 20, 20, 20);
             this.grouperConsumerGroupInformation.PaintGroupBox = true;
             this.grouperConsumerGroupInformation.RoundCorners = 4;
             this.grouperConsumerGroupInformation.ShadowColor = System.Drawing.Color.DarkGray;
             this.grouperConsumerGroupInformation.ShadowControl = false;
             this.grouperConsumerGroupInformation.ShadowThickness = 1;
-            this.grouperConsumerGroupInformation.Size = new System.Drawing.Size(416, 532);
+            this.grouperConsumerGroupInformation.Size = new System.Drawing.Size(312, 432);
             this.grouperConsumerGroupInformation.TabIndex = 6;
             // 
             // propertyListView
@@ -201,11 +194,10 @@
             this.propertyListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.nameColumnHeader,
             this.valueColumnHeader});
-            this.propertyListView.Location = new System.Drawing.Point(21, 39);
-            this.propertyListView.Margin = new System.Windows.Forms.Padding(4);
+            this.propertyListView.Location = new System.Drawing.Point(16, 32);
             this.propertyListView.Name = "propertyListView";
             this.propertyListView.OwnerDraw = true;
-            this.propertyListView.Size = new System.Drawing.Size(371, 472);
+            this.propertyListView.Size = new System.Drawing.Size(279, 384);
             this.propertyListView.TabIndex = 0;
             this.propertyListView.UseCompatibleStateImageBehavior = false;
             this.propertyListView.View = System.Windows.Forms.View.Details;
@@ -233,11 +225,10 @@
             this.mainTabControl.Controls.Add(this.tabPagePartitions);
             this.mainTabControl.DrawMode = System.Windows.Forms.TabDrawMode.OwnerDrawFixed;
             this.mainTabControl.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.mainTabControl.Location = new System.Drawing.Point(21, 20);
-            this.mainTabControl.Margin = new System.Windows.Forms.Padding(4);
+            this.mainTabControl.Location = new System.Drawing.Point(16, 16);
             this.mainTabControl.Name = "mainTabControl";
             this.mainTabControl.SelectedIndex = 0;
-            this.mainTabControl.Size = new System.Drawing.Size(1301, 591);
+            this.mainTabControl.Size = new System.Drawing.Size(976, 480);
             this.mainTabControl.TabIndex = 19;
             this.mainTabControl.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.mainTabControl_DrawItem);
             // 
@@ -246,11 +237,10 @@
             this.tabPagePartitions.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
             this.tabPagePartitions.Controls.Add(this.grouperPartitionsList);
             this.tabPagePartitions.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.tabPagePartitions.Location = new System.Drawing.Point(4, 27);
-            this.tabPagePartitions.Margin = new System.Windows.Forms.Padding(4);
+            this.tabPagePartitions.Location = new System.Drawing.Point(4, 24);
             this.tabPagePartitions.Name = "tabPagePartitions";
-            this.tabPagePartitions.Padding = new System.Windows.Forms.Padding(4);
-            this.tabPagePartitions.Size = new System.Drawing.Size(1293, 560);
+            this.tabPagePartitions.Padding = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.tabPagePartitions.Size = new System.Drawing.Size(968, 452);
             this.tabPagePartitions.TabIndex = 4;
             this.tabPagePartitions.Text = "Partitions";
             // 
@@ -270,16 +260,15 @@
             this.grouperPartitionsList.ForeColor = System.Drawing.Color.White;
             this.grouperPartitionsList.GroupImage = null;
             this.grouperPartitionsList.GroupTitle = "Partitions";
-            this.grouperPartitionsList.Location = new System.Drawing.Point(21, 10);
-            this.grouperPartitionsList.Margin = new System.Windows.Forms.Padding(4);
+            this.grouperPartitionsList.Location = new System.Drawing.Point(16, 8);
             this.grouperPartitionsList.Name = "grouperPartitionsList";
-            this.grouperPartitionsList.Padding = new System.Windows.Forms.Padding(27, 25, 27, 25);
+            this.grouperPartitionsList.Padding = new System.Windows.Forms.Padding(20, 20, 20, 20);
             this.grouperPartitionsList.PaintGroupBox = true;
             this.grouperPartitionsList.RoundCorners = 4;
             this.grouperPartitionsList.ShadowColor = System.Drawing.Color.DarkGray;
             this.grouperPartitionsList.ShadowControl = false;
             this.grouperPartitionsList.ShadowThickness = 1;
-            this.grouperPartitionsList.Size = new System.Drawing.Size(1248, 532);
+            this.grouperPartitionsList.Size = new System.Drawing.Size(936, 432);
             this.grouperPartitionsList.TabIndex = 18;
             this.grouperPartitionsList.CustomPaint += new System.Action<System.Windows.Forms.PaintEventArgs>(this.grouperPartitionsList_CustomPaint);
             // 
@@ -295,15 +284,14 @@
             this.partitionsDataGridView.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.partitionsDataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.partitionsDataGridView.GridColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.partitionsDataGridView.Location = new System.Drawing.Point(23, 41);
-            this.partitionsDataGridView.Margin = new System.Windows.Forms.Padding(4);
+            this.partitionsDataGridView.Location = new System.Drawing.Point(17, 33);
             this.partitionsDataGridView.Name = "partitionsDataGridView";
             this.partitionsDataGridView.ReadOnly = true;
             this.partitionsDataGridView.RowHeadersWidth = 24;
             this.partitionsDataGridView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
             this.partitionsDataGridView.ShowCellErrors = false;
             this.partitionsDataGridView.ShowRowErrors = false;
-            this.partitionsDataGridView.Size = new System.Drawing.Size(1201, 470);
+            this.partitionsDataGridView.Size = new System.Drawing.Size(901, 382);
             this.partitionsDataGridView.TabIndex = 0;
             this.partitionsDataGridView.DataError += new System.Windows.Forms.DataGridViewDataErrorEventHandler(this.partitionsDataGridView_DataError);
             this.partitionsDataGridView.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.partitionsDataGridView_RowsAdded);
@@ -319,10 +307,9 @@
             this.btnRefresh.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnRefresh.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnRefresh.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnRefresh.Location = new System.Drawing.Point(1013, 620);
-            this.btnRefresh.Margin = new System.Windows.Forms.Padding(4);
+            this.btnRefresh.Location = new System.Drawing.Point(760, 504);
             this.btnRefresh.Name = "btnRefresh";
-            this.btnRefresh.Size = new System.Drawing.Size(96, 30);
+            this.btnRefresh.Size = new System.Drawing.Size(72, 24);
             this.btnRefresh.TabIndex = 3;
             this.btnRefresh.Text = "Refresh";
             this.btnRefresh.UseVisualStyleBackColor = false;
@@ -339,10 +326,9 @@
             this.btnCancelUpdate.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCancelUpdate.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnCancelUpdate.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnCancelUpdate.Location = new System.Drawing.Point(1227, 620);
-            this.btnCancelUpdate.Margin = new System.Windows.Forms.Padding(4);
+            this.btnCancelUpdate.Location = new System.Drawing.Point(920, 504);
             this.btnCancelUpdate.Name = "btnCancelUpdate";
-            this.btnCancelUpdate.Size = new System.Drawing.Size(96, 30);
+            this.btnCancelUpdate.Size = new System.Drawing.Size(72, 24);
             this.btnCancelUpdate.TabIndex = 5;
             this.btnCancelUpdate.Text = "Update";
             this.btnCancelUpdate.UseVisualStyleBackColor = false;
@@ -359,10 +345,9 @@
             this.btnCreateDelete.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCreateDelete.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnCreateDelete.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnCreateDelete.Location = new System.Drawing.Point(1120, 620);
-            this.btnCreateDelete.Margin = new System.Windows.Forms.Padding(4);
+            this.btnCreateDelete.Location = new System.Drawing.Point(840, 504);
             this.btnCreateDelete.Name = "btnCreateDelete";
-            this.btnCreateDelete.Size = new System.Drawing.Size(96, 30);
+            this.btnCreateDelete.Size = new System.Drawing.Size(72, 24);
             this.btnCreateDelete.TabIndex = 4;
             this.btnCreateDelete.Text = "Create";
             this.btnCreateDelete.UseVisualStyleBackColor = false;
@@ -376,12 +361,12 @@
             this.entityInformationContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.copyPartitionInformationToClipboardMenuItem});
             this.entityInformationContextMenuStrip.Name = "registrationContextMenuStrip";
-            this.entityInformationContextMenuStrip.Size = new System.Drawing.Size(401, 28);
+            this.entityInformationContextMenuStrip.Size = new System.Drawing.Size(335, 26);
             // 
             // copyPartitionInformationToClipboardMenuItem
             // 
             this.copyPartitionInformationToClipboardMenuItem.Name = "copyPartitionInformationToClipboardMenuItem";
-            this.copyPartitionInformationToClipboardMenuItem.Size = new System.Drawing.Size(400, 24);
+            this.copyPartitionInformationToClipboardMenuItem.Size = new System.Drawing.Size(334, 22);
             this.copyPartitionInformationToClipboardMenuItem.Text = "Copy Consumer Group Information to Clipboard.";
             this.copyPartitionInformationToClipboardMenuItem.ToolTipText = "Copy consumer group information to clipboard.";
             this.copyPartitionInformationToClipboardMenuItem.Click += new System.EventHandler(this.copyPartitionInformationToClipboardMenuItem_Click);
@@ -395,10 +380,9 @@
             this.btnGetPartitions.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnGetPartitions.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnGetPartitions.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnGetPartitions.Location = new System.Drawing.Point(907, 620);
-            this.btnGetPartitions.Margin = new System.Windows.Forms.Padding(4);
+            this.btnGetPartitions.Location = new System.Drawing.Point(680, 504);
             this.btnGetPartitions.Name = "btnGetPartitions";
-            this.btnGetPartitions.Size = new System.Drawing.Size(96, 30);
+            this.btnGetPartitions.Size = new System.Drawing.Size(72, 24);
             this.btnGetPartitions.TabIndex = 2;
             this.btnGetPartitions.Text = "Partitions";
             this.btnGetPartitions.UseVisualStyleBackColor = false;
@@ -406,7 +390,7 @@
             // 
             // HandleConsumerGroupControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
             this.Controls.Add(this.btnGetPartitions);
@@ -414,9 +398,8 @@
             this.Controls.Add(this.btnRefresh);
             this.Controls.Add(this.btnCancelUpdate);
             this.Controls.Add(this.btnCreateDelete);
-            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "HandleConsumerGroupControl";
-            this.Size = new System.Drawing.Size(1344, 670);
+            this.Size = new System.Drawing.Size(1008, 544);
             this.tabPageDescription.ResumeLayout(false);
             this.grouperName.ResumeLayout(false);
             this.grouperName.PerformLayout();

--- a/src/ServiceBusExplorer/Controls/HandleConsumerGroupControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleConsumerGroupControl.cs
@@ -789,6 +789,12 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
         {
             GetPartitions();
         }
+
+        private void txtName_TextChanged(object sender, EventArgs e)
+        {
+            txtName.Text = txtName.Text.ToLower();
+            txtName.SelectionStart = txtName.Text.Length;
+        }
         #endregion
     }
 }

--- a/src/ServiceBusExplorer/Controls/HandleEventHubControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleEventHubControl.Designer.cs
@@ -16,19 +16,18 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
             this.tabPageDescription = new System.Windows.Forms.TabPage();
             this.grouperPath = new Microsoft.Azure.ServiceBusExplorer.Controls.Grouper();
             this.lblRelativeURI = new System.Windows.Forms.Label();
             this.txtPath = new System.Windows.Forms.TextBox();
             this.grouperEventHubProperties = new Microsoft.Azure.ServiceBusExplorer.Controls.Grouper();
+            this.lblMessageRetentionInDaysValue = new System.Windows.Forms.Label();
+            this.lblMessageRetentionInDays = new System.Windows.Forms.Label();
+            this.trackBarMessageRetentionInDays = new Microsoft.Azure.ServiceBusExplorer.Controls.CustomTrackBar();
             this.lblPartitionCount = new System.Windows.Forms.Label();
             this.trackBarPartitionCount = new Microsoft.Azure.ServiceBusExplorer.Controls.CustomTrackBar();
             this.lblPartitionCountValue = new System.Windows.Forms.Label();
-            this.txtMessageRetentionInDays = new Microsoft.Azure.ServiceBusExplorer.Controls.NumericTextBox();
-            this.lblMessageRetentionInDays = new System.Windows.Forms.Label();
             this.txtUserMetadata = new System.Windows.Forms.TextBox();
             this.lblUserMetadata = new System.Windows.Forms.Label();
             this.grouperEventHubInformation = new Microsoft.Azure.ServiceBusExplorer.Controls.Grouper();
@@ -67,10 +66,9 @@
             this.tabPageDescription.Controls.Add(this.grouperEventHubProperties);
             this.tabPageDescription.Controls.Add(this.grouperEventHubInformation);
             this.tabPageDescription.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.tabPageDescription.Location = new System.Drawing.Point(4, 27);
-            this.tabPageDescription.Margin = new System.Windows.Forms.Padding(4);
+            this.tabPageDescription.Location = new System.Drawing.Point(4, 24);
             this.tabPageDescription.Name = "tabPageDescription";
-            this.tabPageDescription.Size = new System.Drawing.Size(1293, 560);
+            this.tabPageDescription.Size = new System.Drawing.Size(968, 452);
             this.tabPageDescription.TabIndex = 2;
             this.tabPageDescription.Text = "Description";
             // 
@@ -88,26 +86,24 @@
             this.grouperPath.ForeColor = System.Drawing.Color.White;
             this.grouperPath.GroupImage = null;
             this.grouperPath.GroupTitle = "Path";
-            this.grouperPath.Location = new System.Drawing.Point(21, 10);
-            this.grouperPath.Margin = new System.Windows.Forms.Padding(4);
+            this.grouperPath.Location = new System.Drawing.Point(16, 8);
             this.grouperPath.Name = "grouperPath";
-            this.grouperPath.Padding = new System.Windows.Forms.Padding(27, 25, 27, 25);
+            this.grouperPath.Padding = new System.Windows.Forms.Padding(20);
             this.grouperPath.PaintGroupBox = true;
             this.grouperPath.RoundCorners = 4;
             this.grouperPath.ShadowColor = System.Drawing.Color.DarkGray;
             this.grouperPath.ShadowControl = false;
             this.grouperPath.ShadowThickness = 1;
-            this.grouperPath.Size = new System.Drawing.Size(811, 98);
+            this.grouperPath.Size = new System.Drawing.Size(608, 80);
             this.grouperPath.TabIndex = 0;
             // 
             // lblRelativeURI
             // 
             this.lblRelativeURI.AutoSize = true;
             this.lblRelativeURI.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblRelativeURI.Location = new System.Drawing.Point(21, 34);
-            this.lblRelativeURI.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblRelativeURI.Location = new System.Drawing.Point(16, 28);
             this.lblRelativeURI.Name = "lblRelativeURI";
-            this.lblRelativeURI.Size = new System.Drawing.Size(90, 17);
+            this.lblRelativeURI.Size = new System.Drawing.Size(71, 13);
             this.lblRelativeURI.TabIndex = 22;
             this.lblRelativeURI.Text = "Relative URI:";
             // 
@@ -117,11 +113,11 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtPath.BackColor = System.Drawing.SystemColors.Window;
             this.txtPath.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
-            this.txtPath.Location = new System.Drawing.Point(21, 54);
-            this.txtPath.Margin = new System.Windows.Forms.Padding(4);
+            this.txtPath.Location = new System.Drawing.Point(16, 44);
             this.txtPath.Name = "txtPath";
-            this.txtPath.Size = new System.Drawing.Size(767, 23);
+            this.txtPath.Size = new System.Drawing.Size(576, 20);
             this.txtPath.TabIndex = 0;
+            this.txtPath.TextChanged += new System.EventHandler(this.txtPath_TextChanged);
             // 
             // grouperEventHubProperties
             // 
@@ -132,11 +128,12 @@
             this.grouperEventHubProperties.BackgroundGradientMode = Microsoft.Azure.ServiceBusExplorer.Controls.Grouper.GroupBoxGradientMode.None;
             this.grouperEventHubProperties.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.grouperEventHubProperties.BorderThickness = 1F;
+            this.grouperEventHubProperties.Controls.Add(this.lblMessageRetentionInDaysValue);
+            this.grouperEventHubProperties.Controls.Add(this.lblMessageRetentionInDays);
+            this.grouperEventHubProperties.Controls.Add(this.trackBarMessageRetentionInDays);
             this.grouperEventHubProperties.Controls.Add(this.lblPartitionCount);
             this.grouperEventHubProperties.Controls.Add(this.trackBarPartitionCount);
             this.grouperEventHubProperties.Controls.Add(this.lblPartitionCountValue);
-            this.grouperEventHubProperties.Controls.Add(this.txtMessageRetentionInDays);
-            this.grouperEventHubProperties.Controls.Add(this.lblMessageRetentionInDays);
             this.grouperEventHubProperties.Controls.Add(this.txtUserMetadata);
             this.grouperEventHubProperties.Controls.Add(this.lblUserMetadata);
             this.grouperEventHubProperties.CustomGroupBoxColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
@@ -144,27 +141,72 @@
             this.grouperEventHubProperties.ForeColor = System.Drawing.Color.White;
             this.grouperEventHubProperties.GroupImage = null;
             this.grouperEventHubProperties.GroupTitle = "Event Hub Properties";
-            this.grouperEventHubProperties.Location = new System.Drawing.Point(21, 118);
-            this.grouperEventHubProperties.Margin = new System.Windows.Forms.Padding(4);
+            this.grouperEventHubProperties.Location = new System.Drawing.Point(16, 96);
             this.grouperEventHubProperties.Name = "grouperEventHubProperties";
-            this.grouperEventHubProperties.Padding = new System.Windows.Forms.Padding(27, 25, 27, 25);
+            this.grouperEventHubProperties.Padding = new System.Windows.Forms.Padding(20);
             this.grouperEventHubProperties.PaintGroupBox = true;
             this.grouperEventHubProperties.RoundCorners = 4;
             this.grouperEventHubProperties.ShadowColor = System.Drawing.Color.DarkGray;
             this.grouperEventHubProperties.ShadowControl = false;
             this.grouperEventHubProperties.ShadowThickness = 1;
-            this.grouperEventHubProperties.Size = new System.Drawing.Size(811, 423);
+            this.grouperEventHubProperties.Size = new System.Drawing.Size(608, 344);
             this.grouperEventHubProperties.TabIndex = 3;
+            // 
+            // lblMessageRetentionInDaysValue
+            // 
+            this.lblMessageRetentionInDaysValue.AutoSize = true;
+            this.lblMessageRetentionInDaysValue.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.lblMessageRetentionInDaysValue.Location = new System.Drawing.Point(272, 316);
+            this.lblMessageRetentionInDaysValue.Name = "lblMessageRetentionInDaysValue";
+            this.lblMessageRetentionInDaysValue.Size = new System.Drawing.Size(19, 13);
+            this.lblMessageRetentionInDaysValue.TabIndex = 38;
+            this.lblMessageRetentionInDaysValue.Text = "16";
+            // 
+            // lblMessageRetentionInDays
+            // 
+            this.lblMessageRetentionInDays.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.lblMessageRetentionInDays.AutoSize = true;
+            this.lblMessageRetentionInDays.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.lblMessageRetentionInDays.Location = new System.Drawing.Point(16, 296);
+            this.lblMessageRetentionInDays.Name = "lblMessageRetentionInDays";
+            this.lblMessageRetentionInDays.Size = new System.Drawing.Size(141, 13);
+            this.lblMessageRetentionInDays.TabIndex = 28;
+            this.lblMessageRetentionInDays.Text = "Message Retention In Days:";
+            // 
+            // trackBarMessageRetentionInDays
+            // 
+            this.trackBarMessageRetentionInDays.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.trackBarMessageRetentionInDays.BackColor = System.Drawing.Color.Transparent;
+            this.trackBarMessageRetentionInDays.BorderColor = System.Drawing.Color.Black;
+            this.trackBarMessageRetentionInDays.Font = new System.Drawing.Font("Verdana", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.trackBarMessageRetentionInDays.ForeColor = System.Drawing.Color.Black;
+            this.trackBarMessageRetentionInDays.IndentHeight = 6;
+            this.trackBarMessageRetentionInDays.LargeChange = 1;
+            this.trackBarMessageRetentionInDays.Location = new System.Drawing.Point(16, 308);
+            this.trackBarMessageRetentionInDays.Maximum = 7;
+            this.trackBarMessageRetentionInDays.Minimum = 1;
+            this.trackBarMessageRetentionInDays.Name = "trackBarMessageRetentionInDays";
+            this.trackBarMessageRetentionInDays.Size = new System.Drawing.Size(256, 29);
+            this.trackBarMessageRetentionInDays.TabIndex = 37;
+            this.trackBarMessageRetentionInDays.TextTickStyle = System.Windows.Forms.TickStyle.None;
+            this.trackBarMessageRetentionInDays.TickColor = System.Drawing.Color.Black;
+            this.trackBarMessageRetentionInDays.TickHeight = 4;
+            this.trackBarMessageRetentionInDays.TrackerColor = System.Drawing.Color.FromArgb(((int)(((byte)(92)))), ((int)(((byte)(125)))), ((int)(((byte)(150)))));
+            this.trackBarMessageRetentionInDays.TrackerSize = new System.Drawing.Size(12, 12);
+            this.trackBarMessageRetentionInDays.TrackLineBrushStyle = Microsoft.Azure.ServiceBusExplorer.Controls.BrushStyle.Solid;
+            this.trackBarMessageRetentionInDays.TrackLineColor = System.Drawing.Color.FromArgb(((int)(((byte)(92)))), ((int)(((byte)(125)))), ((int)(((byte)(150)))));
+            this.trackBarMessageRetentionInDays.TrackLineHeight = 1;
+            this.trackBarMessageRetentionInDays.Value = 1;
+            this.trackBarMessageRetentionInDays.ValueChanged += new Microsoft.Azure.ServiceBusExplorer.Controls.ValueChangedHandler(this.trackBarMessageRetentionInDays_ValueChanged);
             // 
             // lblPartitionCount
             // 
             this.lblPartitionCount.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.lblPartitionCount.AutoSize = true;
             this.lblPartitionCount.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblPartitionCount.Location = new System.Drawing.Point(416, 364);
-            this.lblPartitionCount.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblPartitionCount.Location = new System.Drawing.Point(312, 296);
             this.lblPartitionCount.Name = "lblPartitionCount";
-            this.lblPartitionCount.Size = new System.Drawing.Size(105, 17);
+            this.lblPartitionCount.Size = new System.Drawing.Size(79, 13);
             this.lblPartitionCount.TabIndex = 30;
             this.lblPartitionCount.Text = "Partition Count:";
             // 
@@ -177,56 +219,33 @@
             this.trackBarPartitionCount.ForeColor = System.Drawing.Color.Black;
             this.trackBarPartitionCount.IndentHeight = 6;
             this.trackBarPartitionCount.LargeChange = 1;
-            this.trackBarPartitionCount.Location = new System.Drawing.Point(416, 379);
-            this.trackBarPartitionCount.Margin = new System.Windows.Forms.Padding(4);
+            this.trackBarPartitionCount.Location = new System.Drawing.Point(312, 308);
             this.trackBarPartitionCount.Maximum = 32;
-            this.trackBarPartitionCount.Minimum = 8;
+            this.trackBarPartitionCount.Minimum = 2;
             this.trackBarPartitionCount.Name = "trackBarPartitionCount";
-            this.trackBarPartitionCount.Size = new System.Drawing.Size(341, 29);
+            this.trackBarPartitionCount.Size = new System.Drawing.Size(256, 29);
             this.trackBarPartitionCount.TabIndex = 36;
             this.trackBarPartitionCount.TextTickStyle = System.Windows.Forms.TickStyle.None;
             this.trackBarPartitionCount.TickColor = System.Drawing.Color.Black;
+            this.trackBarPartitionCount.TickFrequency = 5;
             this.trackBarPartitionCount.TickHeight = 4;
             this.trackBarPartitionCount.TrackerColor = System.Drawing.Color.FromArgb(((int)(((byte)(92)))), ((int)(((byte)(125)))), ((int)(((byte)(150)))));
             this.trackBarPartitionCount.TrackerSize = new System.Drawing.Size(12, 12);
             this.trackBarPartitionCount.TrackLineBrushStyle = Microsoft.Azure.ServiceBusExplorer.Controls.BrushStyle.Solid;
             this.trackBarPartitionCount.TrackLineColor = System.Drawing.Color.FromArgb(((int)(((byte)(92)))), ((int)(((byte)(125)))), ((int)(((byte)(150)))));
             this.trackBarPartitionCount.TrackLineHeight = 1;
-            this.trackBarPartitionCount.Value = 16;
+            this.trackBarPartitionCount.Value = 2;
             this.trackBarPartitionCount.ValueChanged += new Microsoft.Azure.ServiceBusExplorer.Controls.ValueChangedHandler(this.trackBarPartitionCount_ValueChanged);
             // 
             // lblPartitionCountValue
             // 
             this.lblPartitionCountValue.AutoSize = true;
             this.lblPartitionCountValue.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblPartitionCountValue.Location = new System.Drawing.Point(757, 389);
-            this.lblPartitionCountValue.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblPartitionCountValue.Location = new System.Drawing.Point(568, 316);
             this.lblPartitionCountValue.Name = "lblPartitionCountValue";
-            this.lblPartitionCountValue.Size = new System.Drawing.Size(24, 17);
+            this.lblPartitionCountValue.Size = new System.Drawing.Size(19, 13);
             this.lblPartitionCountValue.TabIndex = 35;
             this.lblPartitionCountValue.Text = "16";
-            // 
-            // txtMessageRetentionInDays
-            // 
-            this.txtMessageRetentionInDays.AllowSpace = false;
-            this.txtMessageRetentionInDays.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.txtMessageRetentionInDays.Location = new System.Drawing.Point(21, 384);
-            this.txtMessageRetentionInDays.Margin = new System.Windows.Forms.Padding(4);
-            this.txtMessageRetentionInDays.Name = "txtMessageRetentionInDays";
-            this.txtMessageRetentionInDays.Size = new System.Drawing.Size(372, 23);
-            this.txtMessageRetentionInDays.TabIndex = 29;
-            // 
-            // lblMessageRetentionInDays
-            // 
-            this.lblMessageRetentionInDays.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.lblMessageRetentionInDays.AutoSize = true;
-            this.lblMessageRetentionInDays.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblMessageRetentionInDays.Location = new System.Drawing.Point(21, 364);
-            this.lblMessageRetentionInDays.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.lblMessageRetentionInDays.Name = "lblMessageRetentionInDays";
-            this.lblMessageRetentionInDays.Size = new System.Drawing.Size(185, 17);
-            this.lblMessageRetentionInDays.TabIndex = 28;
-            this.lblMessageRetentionInDays.Text = "Message Retention In Days:";
             // 
             // txtUserMetadata
             // 
@@ -234,22 +253,20 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtUserMetadata.BackColor = System.Drawing.SystemColors.Window;
-            this.txtUserMetadata.Location = new System.Drawing.Point(21, 59);
-            this.txtUserMetadata.Margin = new System.Windows.Forms.Padding(4);
+            this.txtUserMetadata.Location = new System.Drawing.Point(16, 48);
             this.txtUserMetadata.MaxLength = 0;
             this.txtUserMetadata.Multiline = true;
             this.txtUserMetadata.Name = "txtUserMetadata";
-            this.txtUserMetadata.Size = new System.Drawing.Size(767, 294);
+            this.txtUserMetadata.Size = new System.Drawing.Size(576, 240);
             this.txtUserMetadata.TabIndex = 2;
             // 
             // lblUserMetadata
             // 
             this.lblUserMetadata.AutoSize = true;
             this.lblUserMetadata.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblUserMetadata.Location = new System.Drawing.Point(21, 34);
-            this.lblUserMetadata.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblUserMetadata.Location = new System.Drawing.Point(16, 28);
             this.lblUserMetadata.Name = "lblUserMetadata";
-            this.lblUserMetadata.Size = new System.Drawing.Size(117, 17);
+            this.lblUserMetadata.Size = new System.Drawing.Size(88, 13);
             this.lblUserMetadata.TabIndex = 27;
             this.lblUserMetadata.Text = "User Description:";
             // 
@@ -269,16 +286,15 @@
             this.grouperEventHubInformation.ForeColor = System.Drawing.Color.White;
             this.grouperEventHubInformation.GroupImage = null;
             this.grouperEventHubInformation.GroupTitle = "Event Hub Information";
-            this.grouperEventHubInformation.Location = new System.Drawing.Point(853, 10);
-            this.grouperEventHubInformation.Margin = new System.Windows.Forms.Padding(4);
+            this.grouperEventHubInformation.Location = new System.Drawing.Point(640, 8);
             this.grouperEventHubInformation.Name = "grouperEventHubInformation";
-            this.grouperEventHubInformation.Padding = new System.Windows.Forms.Padding(27, 25, 27, 25);
+            this.grouperEventHubInformation.Padding = new System.Windows.Forms.Padding(20);
             this.grouperEventHubInformation.PaintGroupBox = true;
             this.grouperEventHubInformation.RoundCorners = 4;
             this.grouperEventHubInformation.ShadowColor = System.Drawing.Color.DarkGray;
             this.grouperEventHubInformation.ShadowControl = false;
             this.grouperEventHubInformation.ShadowThickness = 1;
-            this.grouperEventHubInformation.Size = new System.Drawing.Size(416, 532);
+            this.grouperEventHubInformation.Size = new System.Drawing.Size(312, 432);
             this.grouperEventHubInformation.TabIndex = 6;
             // 
             // propertyListView
@@ -289,11 +305,10 @@
             this.propertyListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.nameColumnHeader,
             this.valueColumnHeader});
-            this.propertyListView.Location = new System.Drawing.Point(21, 39);
-            this.propertyListView.Margin = new System.Windows.Forms.Padding(4);
+            this.propertyListView.Location = new System.Drawing.Point(16, 32);
             this.propertyListView.Name = "propertyListView";
             this.propertyListView.OwnerDraw = true;
-            this.propertyListView.Size = new System.Drawing.Size(371, 472);
+            this.propertyListView.Size = new System.Drawing.Size(279, 384);
             this.propertyListView.TabIndex = 0;
             this.propertyListView.UseCompatibleStateImageBehavior = false;
             this.propertyListView.View = System.Windows.Forms.View.Details;
@@ -321,24 +336,21 @@
             this.mainTabControl.Controls.Add(this.tabPageAuthorization);
             this.mainTabControl.DrawMode = System.Windows.Forms.TabDrawMode.OwnerDrawFixed;
             this.mainTabControl.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.mainTabControl.Location = new System.Drawing.Point(21, 20);
-            this.mainTabControl.Margin = new System.Windows.Forms.Padding(4);
+            this.mainTabControl.Location = new System.Drawing.Point(16, 16);
             this.mainTabControl.Name = "mainTabControl";
             this.mainTabControl.SelectedIndex = 0;
-            this.mainTabControl.Size = new System.Drawing.Size(1301, 591);
+            this.mainTabControl.Size = new System.Drawing.Size(976, 480);
             this.mainTabControl.TabIndex = 19;
             this.mainTabControl.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.mainTabControl_DrawItem);
-            
             // 
             // tabPageAuthorization
             // 
             this.tabPageAuthorization.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
             this.tabPageAuthorization.Controls.Add(this.grouperAuthorizationRuleList);
             this.tabPageAuthorization.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.tabPageAuthorization.Location = new System.Drawing.Point(4, 27);
-            this.tabPageAuthorization.Margin = new System.Windows.Forms.Padding(4);
+            this.tabPageAuthorization.Location = new System.Drawing.Point(4, 24);
             this.tabPageAuthorization.Name = "tabPageAuthorization";
-            this.tabPageAuthorization.Size = new System.Drawing.Size(1293, 560);
+            this.tabPageAuthorization.Size = new System.Drawing.Size(968, 452);
             this.tabPageAuthorization.TabIndex = 3;
             this.tabPageAuthorization.Text = "Authorization Rules";
             // 
@@ -358,16 +370,15 @@
             this.grouperAuthorizationRuleList.ForeColor = System.Drawing.Color.White;
             this.grouperAuthorizationRuleList.GroupImage = null;
             this.grouperAuthorizationRuleList.GroupTitle = "Authorization Rule List";
-            this.grouperAuthorizationRuleList.Location = new System.Drawing.Point(21, 10);
-            this.grouperAuthorizationRuleList.Margin = new System.Windows.Forms.Padding(4);
+            this.grouperAuthorizationRuleList.Location = new System.Drawing.Point(16, 8);
             this.grouperAuthorizationRuleList.Name = "grouperAuthorizationRuleList";
-            this.grouperAuthorizationRuleList.Padding = new System.Windows.Forms.Padding(27, 25, 27, 25);
+            this.grouperAuthorizationRuleList.Padding = new System.Windows.Forms.Padding(20);
             this.grouperAuthorizationRuleList.PaintGroupBox = true;
             this.grouperAuthorizationRuleList.RoundCorners = 4;
             this.grouperAuthorizationRuleList.ShadowColor = System.Drawing.Color.DarkGray;
             this.grouperAuthorizationRuleList.ShadowControl = false;
             this.grouperAuthorizationRuleList.ShadowThickness = 1;
-            this.grouperAuthorizationRuleList.Size = new System.Drawing.Size(1248, 532);
+            this.grouperAuthorizationRuleList.Size = new System.Drawing.Size(936, 432);
             this.grouperAuthorizationRuleList.TabIndex = 21;
             this.grouperAuthorizationRuleList.CustomPaint += new System.Action<System.Windows.Forms.PaintEventArgs>(this.grouperAuthorizationRuleList_CustomPaint);
             // 
@@ -382,15 +393,14 @@
             this.authorizationRulesDataGridView.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.authorizationRulesDataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.authorizationRulesDataGridView.GridColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.authorizationRulesDataGridView.Location = new System.Drawing.Point(21, 39);
-            this.authorizationRulesDataGridView.Margin = new System.Windows.Forms.Padding(4);
+            this.authorizationRulesDataGridView.Location = new System.Drawing.Point(16, 32);
             this.authorizationRulesDataGridView.MultiSelect = false;
             this.authorizationRulesDataGridView.Name = "authorizationRulesDataGridView";
             this.authorizationRulesDataGridView.RowHeadersWidth = 24;
             this.authorizationRulesDataGridView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
             this.authorizationRulesDataGridView.ShowCellErrors = false;
             this.authorizationRulesDataGridView.ShowRowErrors = false;
-            this.authorizationRulesDataGridView.Size = new System.Drawing.Size(1205, 474);
+            this.authorizationRulesDataGridView.Size = new System.Drawing.Size(904, 385);
             this.authorizationRulesDataGridView.TabIndex = 0;
             this.authorizationRulesDataGridView.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.authorizationRulesDataGridView_CellContentClick);
             this.authorizationRulesDataGridView.DataError += new System.Windows.Forms.DataGridViewDataErrorEventHandler(this.authorizationRulesDataGridView_DataError);
@@ -409,10 +419,9 @@
             this.btnRefresh.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnRefresh.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnRefresh.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnRefresh.Location = new System.Drawing.Point(907, 620);
-            this.btnRefresh.Margin = new System.Windows.Forms.Padding(4);
+            this.btnRefresh.Location = new System.Drawing.Point(680, 504);
             this.btnRefresh.Name = "btnRefresh";
-            this.btnRefresh.Size = new System.Drawing.Size(96, 30);
+            this.btnRefresh.Size = new System.Drawing.Size(72, 24);
             this.btnRefresh.TabIndex = 2;
             this.btnRefresh.Text = "Refresh";
             this.btnRefresh.UseVisualStyleBackColor = false;
@@ -429,10 +438,9 @@
             this.btnChangeStatus.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnChangeStatus.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnChangeStatus.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnChangeStatus.Location = new System.Drawing.Point(1013, 620);
-            this.btnChangeStatus.Margin = new System.Windows.Forms.Padding(4);
+            this.btnChangeStatus.Location = new System.Drawing.Point(760, 504);
             this.btnChangeStatus.Name = "btnChangeStatus";
-            this.btnChangeStatus.Size = new System.Drawing.Size(96, 30);
+            this.btnChangeStatus.Size = new System.Drawing.Size(72, 24);
             this.btnChangeStatus.TabIndex = 3;
             this.btnChangeStatus.Text = "Disable";
             this.btnChangeStatus.UseVisualStyleBackColor = false;
@@ -449,10 +457,9 @@
             this.btnCancelUpdate.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCancelUpdate.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnCancelUpdate.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnCancelUpdate.Location = new System.Drawing.Point(1227, 620);
-            this.btnCancelUpdate.Margin = new System.Windows.Forms.Padding(4);
+            this.btnCancelUpdate.Location = new System.Drawing.Point(920, 504);
             this.btnCancelUpdate.Name = "btnCancelUpdate";
-            this.btnCancelUpdate.Size = new System.Drawing.Size(96, 30);
+            this.btnCancelUpdate.Size = new System.Drawing.Size(72, 24);
             this.btnCancelUpdate.TabIndex = 5;
             this.btnCancelUpdate.Text = "Update";
             this.btnCancelUpdate.UseVisualStyleBackColor = false;
@@ -469,10 +476,9 @@
             this.btnCreateDelete.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCreateDelete.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnCreateDelete.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnCreateDelete.Location = new System.Drawing.Point(1120, 620);
-            this.btnCreateDelete.Margin = new System.Windows.Forms.Padding(4);
+            this.btnCreateDelete.Location = new System.Drawing.Point(840, 504);
             this.btnCreateDelete.Name = "btnCreateDelete";
-            this.btnCreateDelete.Size = new System.Drawing.Size(96, 30);
+            this.btnCreateDelete.Size = new System.Drawing.Size(72, 24);
             this.btnCreateDelete.TabIndex = 4;
             this.btnCreateDelete.Text = "Create";
             this.btnCreateDelete.UseVisualStyleBackColor = false;
@@ -486,19 +492,26 @@
             this.entityInformationContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.copyPartitionInformationToClipboardMenuItem});
             this.entityInformationContextMenuStrip.Name = "registrationContextMenuStrip";
-            this.entityInformationContextMenuStrip.Size = new System.Drawing.Size(358, 28);
+            this.entityInformationContextMenuStrip.Size = new System.Drawing.Size(299, 26);
             // 
             // copyPartitionInformationToClipboardMenuItem
             // 
             this.copyPartitionInformationToClipboardMenuItem.Name = "copyPartitionInformationToClipboardMenuItem";
-            this.copyPartitionInformationToClipboardMenuItem.Size = new System.Drawing.Size(357, 24);
+            this.copyPartitionInformationToClipboardMenuItem.Size = new System.Drawing.Size(298, 22);
             this.copyPartitionInformationToClipboardMenuItem.Text = "Copy Event Hub Information to Clipboard.";
             this.copyPartitionInformationToClipboardMenuItem.ToolTipText = "Copy event hub information to clipboard.";
             this.copyPartitionInformationToClipboardMenuItem.Click += new System.EventHandler(this.copyPartitionInformationToClipboardMenuItem_Click);
             // 
+            // dataPointDataGridView
+            // 
+            this.dataPointDataGridView.Location = new System.Drawing.Point(0, 0);
+            this.dataPointDataGridView.Name = "dataPointDataGridView";
+            this.dataPointDataGridView.Size = new System.Drawing.Size(240, 150);
+            this.dataPointDataGridView.TabIndex = 0;
+            // 
             // HandleEventHubControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
             this.Controls.Add(this.mainTabControl);
@@ -506,9 +519,8 @@
             this.Controls.Add(this.btnChangeStatus);
             this.Controls.Add(this.btnCancelUpdate);
             this.Controls.Add(this.btnCreateDelete);
-            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "HandleEventHubControl";
-            this.Size = new System.Drawing.Size(1344, 670);
+            this.Size = new System.Drawing.Size(1008, 544);
             this.tabPageDescription.ResumeLayout(false);
             this.grouperPath.ResumeLayout(false);
             this.grouperPath.PerformLayout();
@@ -549,7 +561,6 @@
         private Grouper grouperAuthorizationRuleList;
         private System.Windows.Forms.DataGridView authorizationRulesDataGridView;
         private System.Windows.Forms.Label lblPartitionCount;
-        private NumericTextBox txtMessageRetentionInDays;
         private System.Windows.Forms.Label lblMessageRetentionInDays;
         private CustomTrackBar trackBarPartitionCount;
         private System.Windows.Forms.Label lblPartitionCountValue;
@@ -557,5 +568,7 @@
         private System.Windows.Forms.ContextMenuStrip entityInformationContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem copyPartitionInformationToClipboardMenuItem;
         private System.Windows.Forms.DataGridView dataPointDataGridView;
+        private CustomTrackBar trackBarMessageRetentionInDays;
+        private System.Windows.Forms.Label lblMessageRetentionInDaysValue;
     }
 }

--- a/src/ServiceBusExplorer/Controls/HandleEventHubControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleEventHubControl.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
 
                 toolTip.SetToolTip(txtPath, PathTooltip);
                 toolTip.SetToolTip(txtUserMetadata, UserMetadataTooltip);
-                toolTip.SetToolTip(txtMessageRetentionInDays, MessageRetentionInDaysTooltip);
+                toolTip.SetToolTip(trackBarMessageRetentionInDays, MessageRetentionInDaysTooltip);
                 toolTip.SetToolTip(trackBarPartitionCount, PartitionCountTooltip);
 
                 propertyListView.ContextMenuStrip = entityInformationContextMenuStrip;
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
             {
                 // Set Defaults
                 var eventHub = new EventHubDescription("DUMMY");
-                txtMessageRetentionInDays.Text = eventHub.MessageRetentionInDays.ToString(CultureInfo.InvariantCulture);
+                trackBarMessageRetentionInDays.Value = (int)eventHub.MessageRetentionInDays;
                 trackBarPartitionCount.Value = eventHub.PartitionCount;
 
                 // Initialize buttons
@@ -319,7 +319,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
             }
 
             // MessageRetentionInDays
-            txtMessageRetentionInDays.Text = eventHubDescription.MessageRetentionInDays.ToString(CultureInfo.InvariantCulture);
+            trackBarMessageRetentionInDays.Value = (int)eventHubDescription.MessageRetentionInDays;
 
             // PartitionCount
             trackBarPartitionCount.Value = eventHubDescription.PartitionCount;
@@ -355,10 +355,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                             UserMetadata = txtUserMetadata.Text
                         };
 
-                    if (!string.IsNullOrEmpty(txtMessageRetentionInDays.Text))
-                    {
-                        description.MessageRetentionInDays = txtMessageRetentionInDays.IntegerValue;
-                    }
+                    description.MessageRetentionInDays = trackBarMessageRetentionInDays.Value;
 
                     description.PartitionCount = trackBarPartitionCount.Value;
 
@@ -479,10 +476,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                 {
                     eventHubDescription.UserMetadata = txtUserMetadata.Text;
 
-                    if (!string.IsNullOrEmpty(txtMessageRetentionInDays.Text))
-                    {
-                        eventHubDescription.MessageRetentionInDays = txtMessageRetentionInDays.IntegerValue;
-                    }
+                    eventHubDescription.MessageRetentionInDays = trackBarMessageRetentionInDays.Value;
 
                     var bindingList = authorizationRulesBindingSource.DataSource as BindingList<AuthorizationRuleWrapper>;
                     if (bindingList != null)
@@ -978,6 +972,17 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
             {
                 HandleException(ex);
             }
+        }
+
+        private void trackBarMessageRetentionInDays_ValueChanged(object sender, decimal value)
+        {
+            lblMessageRetentionInDaysValue.Text = trackBarMessageRetentionInDays.Value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        private void txtPath_TextChanged(object sender, EventArgs e)
+        {
+            txtPath.Text = txtPath.Text.ToLower();
+            txtPath.SelectionStart = txtPath.Text.Length;
         }
 
         #endregion

--- a/src/ServiceBusExplorer/Forms/ContainerForm.cs
+++ b/src/ServiceBusExplorer/Forms/ContainerForm.cs
@@ -71,12 +71,12 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
         private const string SubscriptionListenerFormat = "Listener for subscription {0}";
         private const string HeaderTextQueueListenerFormat = "Queue Listener: {0}";
         private const string HeaderTextSubscriptionListenerFormat = "Subscription Listener: {0}";
-        private const string ConsumerGroupListenerFormat = "Listener for Consumer Group {0}";
-        private const string PartitionListenerFormat = "Listener for Partition {0} of Consumer Group {1}";
+        private const string ConsumerGroupListenerFormat = "Listener for {0}.{1} Consumer Group";
+        private const string PartitionListenerFormat = "Listener for Partition {0} of {1}.{2} Consumer Group";
         private const string IoTHubListenerFormat = "Listener for Consumer Group {0} of IoT HUb {1}";
-        private const string HeaderTextConsumerGroupListenerFormat = "Consumer Group Listener: {0}";
-        private const string HeaderTextPartitionListenerFormat = "Partition Listener: {0}";
-        private const string HeaderTextIoTHubListenerFormat = "IoT Hub Listener: {0}";
+        private const string HeaderTextConsumerGroupListenerFormat = "Consumer Group Listener: {0}.{1}";
+        private const string HeaderTextPartitionListenerFormat = "Partition Listener: {0}.{1}[{2}]";
+        private const string HeaderTextIoTHubListenerFormat = "IoT Hub Listener: {0}.{1}";
 
         //***************************
         // Constants
@@ -402,13 +402,13 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
 
                 if (descriptions.Count == 1)
                 {
-                    Text = string.Format(PartitionListenerFormat, descriptions[0].PartitionId, consumerGroupDescription.Name);
-                    panelMain.HeaderText = string.Format(HeaderTextPartitionListenerFormat, descriptions[0].PartitionId);
+                    Text = string.Format(PartitionListenerFormat, descriptions[0].PartitionId, consumerGroupDescription.EventHubPath, consumerGroupDescription.Name);
+                    panelMain.HeaderText = string.Format(HeaderTextPartitionListenerFormat, consumerGroupDescription.EventHubPath, consumerGroupDescription.Name, descriptions[0].PartitionId);
                 }
                 else
                 {
-                    Text = string.Format(ConsumerGroupListenerFormat, consumerGroupDescription.Name);
-                    panelMain.HeaderText = string.Format(HeaderTextConsumerGroupListenerFormat, consumerGroupDescription.Name);
+                    Text = string.Format(ConsumerGroupListenerFormat, consumerGroupDescription.EventHubPath, consumerGroupDescription.Name);
+                    panelMain.HeaderText = string.Format(HeaderTextConsumerGroupListenerFormat, consumerGroupDescription.EventHubPath, consumerGroupDescription.Name);
                 }                
                 partitionListenerControl.Focus();
                 panelMain.Controls.Add(partitionListenerControl);
@@ -456,7 +456,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                     var match = Regex.Match(connectionString, "HostName=([A-Za-z0-9_-]+)", RegexOptions.IgnoreCase);
                     var ioTHubName = match.Success ? match.Groups[1].Value : string.Empty;
                     Text = string.Format(IoTHubListenerFormat, consumerGroup, ioTHubName);
-                    panelMain.HeaderText = string.Format(HeaderTextIoTHubListenerFormat, ioTHubName);
+                    panelMain.HeaderText = string.Format(HeaderTextIoTHubListenerFormat, ioTHubName, consumerGroup);
                 }
                 else
                 {


### PR DESCRIPTION
HandleEventHubControl:
- Replaced control for Message Retention in Days from TextBox to TrackBar
 - Added code to TextChanged event for the Relative URI TextBox to lowercase the text as a user enters the name of a new Event Hub
 - Changed the minimum number of partitions for an Event Hub from 8 to 2

HandleConsumerGroupControl:
 - Added code to TextChanged event for the Consumer Group Name TextBox to lowercase the text as a user enters the name of a new Consumer Group

ContainerForm:
 - Changed the code of the ContainerForm to explicitly add the Event Hub and Consumer Group name to the title bar when opening the form for an Event Hub Listener