### PR TITLE
Fixed minor issue with FastColoredTextBox controls

### DIFF
--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -3298,7 +3298,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
             deadletterMessage = bindingList[e.RowIndex];
             deadletterPropertyGrid.SelectedObject = deadletterMessage;
 
-            LanguageDetector.SetFormattedMessage(serviceBusHelper, deadletterMessage, txtMessageText);
+            LanguageDetector.SetFormattedMessage(serviceBusHelper, deadletterMessage, txtDeadletterText);
 
             var listViewItems = deadletterMessage.Properties.Select(p => new ListViewItem(new[] { p.Key, Convert.ToString(p.Value) })).ToArray();
             deadletterPropertyListView.Items.Clear();
@@ -3320,7 +3320,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
             transferDeadletterMessage = bindingList[e.RowIndex];
             transferDeadletterPropertyGrid.SelectedObject = transferDeadletterMessage;
 
-            LanguageDetector.SetFormattedMessage(serviceBusHelper, transferDeadletterMessage, txtMessageText);
+            LanguageDetector.SetFormattedMessage(serviceBusHelper, transferDeadletterMessage, txtTransferDeadletterText);
 
             var listViewItems = transferDeadletterMessage.Properties.Select(p => new ListViewItem(new[] { p.Key, Convert.ToString(p.Value) })).ToArray();
             transferDeadletterPropertyListView.Items.Clear();

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -2264,7 +2264,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                 deadletterMessage = bindingList[e.RowIndex];
                 deadletterPropertyGrid.SelectedObject = deadletterMessage;
 
-                LanguageDetector.SetFormattedMessage(serviceBusHelper, deadletterMessage, txtMessageText);
+                LanguageDetector.SetFormattedMessage(serviceBusHelper, deadletterMessage, txtDeadletterText);
 
                 var listViewItems = deadletterMessage.Properties.Select(p => new ListViewItem(new[] { p.Key, Convert.ToString(p.Value) })).ToArray();
                 deadletterPropertyListView.Items.Clear();


### PR DESCRIPTION
Fixed problem with new FastColoredTextBox: when selecting a deadletter message in the grid inside the queue or subscription, I was assigning the formatted text to the wrong textbox control.