### PR TITLE
Fixed missing event hub name

### DIFF
--- a/src/ServiceBusExplorer/Forms/ContainerForm.cs
+++ b/src/ServiceBusExplorer/Forms/ContainerForm.cs
@@ -461,7 +461,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                 else
                 {
                     Text = string.Format(ConsumerGroupListenerFormat, consumerGroup);
-                    panelMain.HeaderText = string.Format(HeaderTextConsumerGroupListenerFormat, consumerGroup);
+                    panelMain.HeaderText = string.Format(HeaderTextConsumerGroupListenerFormat, hubName, consumerGroup);
                 }
                 partitionListenerControl.Focus();
                 panelMain.Controls.Add(partitionListenerControl);


### PR DESCRIPTION
When creating an event hub listener an exception occurred as HeaderTextConsumerGroupListenerFormat expects two strings (interpolation) - hub name and consumer group but only consumer group was passed