### PR TITLE
fixed cloning by utilizing Service Bus .Clone(stream) instead of .Clone(string)

### DIFF
--- a/src/ServiceBusExplorer/Forms/MessageForm.cs
+++ b/src/ServiceBusExplorer/Forms/MessageForm.cs
@@ -394,7 +394,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                                     // For body type ByteArray cloning is not an option. When cloned, supplied body can be only of a string or stream types, but not byte array :(
                                     outboundMessage = bodyType == BodyType.ByteArray ?
                                                       brokeredMessage.CloneWithByteArrayBodyType(txtMessageText.Text) :
-                                                      brokeredMessage.Clone();
+                                                      brokeredMessage.Clone(brokeredMessage.GetBody<Stream>());
                                 }
                                 else
                                 {
@@ -500,7 +500,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                             var messageIndex = 0;
                             try
                             {
-                                while(messageIndex < outboundMessages.Count)
+                                while (messageIndex < outboundMessages.Count)
                                 {
                                     await messageSender.SendAsync(outboundMessages[messageIndex++]);
                                 }

--- a/src/ServiceBusExplorer/Forms/MessageForm.cs
+++ b/src/ServiceBusExplorer/Forms/MessageForm.cs
@@ -403,7 +403,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                                     // For body type ByteArray cloning is not an option. When cloned, supplied body can be only of a string or stream types, but not byte array :(
                                     outboundMessage = bodyType == BodyType.ByteArray ?
                                                       message.CloneWithByteArrayBodyType(messageText) :
-                                                      message.Clone(messageText);
+                                                      message.Clone(message.GetBody<Stream>());
                                 }
 
                                 outboundMessage = serviceBusHelper.CreateMessageForApiReceiver(outboundMessage,

--- a/src/ServiceBusExplorer/Forms/MessageForm.cs
+++ b/src/ServiceBusExplorer/Forms/MessageForm.cs
@@ -394,7 +394,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                                     // For body type ByteArray cloning is not an option. When cloned, supplied body can be only of a string or stream types, but not byte array :(
                                     outboundMessage = bodyType == BodyType.ByteArray ?
                                                       brokeredMessage.CloneWithByteArrayBodyType(txtMessageText.Text) :
-                                                      brokeredMessage.Clone(txtMessageText.Text);
+                                                      brokeredMessage.Clone();
                                 }
                                 else
                                 {

--- a/src/ServiceBusExplorer/Forms/MessageForm.cs
+++ b/src/ServiceBusExplorer/Forms/MessageForm.cs
@@ -500,7 +500,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                             var messageIndex = 0;
                             try
                             {
-                                while (messageIndex < outboundMessages.Count)
+                                while(messageIndex < outboundMessages.Count)
                                 {
                                     await messageSender.SendAsync(outboundMessages[messageIndex++]);
                                 }


### PR DESCRIPTION
…one() for Streams


Regarding:
https://github.com/paolosalvatori/ServiceBusExplorer/issues/245

This appears to be everything necessary in order to resolve the issue I was having.

I am uncertain of all functionality of ServiceBusExplorer to QA this change, but this is basically what I found will meet the needs of properly cloning a stream.