### PR TITLE
Do not refresh list of queues/topics when closing dead-lettered message inspection window.

### DIFF
--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -3512,9 +3512,6 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                 {
                     Application.UseWaitCursor = false;
                 }
-
-                MainForm.SingletonMainForm.RefreshQueues();
-                MainForm.SingletonMainForm.RefreshTopics();
             }
         }
 


### PR DESCRIPTION
Fixes #297

Whenever a DLQ-ed message details form was closed, the main form was refreshed and retrieved all queues/topics/subscriptions. This is undesirable when just inspecting DLQ-ed messages.