### PR TITLE
TimeSpan support for the Custom Properties

### DIFF
--- a/src/ServiceBusExplorer.Tests/Helpers/ConversionHelperTests.cs
+++ b/src/ServiceBusExplorer.Tests/Helpers/ConversionHelperTests.cs
@@ -26,5 +26,15 @@ namespace Microsoft.Azure.ServiceBusExplorer.Tests.Helpers
             var convertedGuid = ConversionHelper.MapStringTypeToCLRType("Guid", guidStr);
             Assert.AreEqual(guidStr.ToLower(), convertedGuid.ToString());
         }
+
+        [Theory]
+        [TestCase("3:44:55")]
+        [TestCase("03:44:55")]
+        [TestCase("1:00:00:00.0000000")] // one day
+        public void MapStringTypeToCLRType_ValueIsTimeSpanString_ReturnsEqualTimespanObject(string timespanStr)
+        {
+            var convertedTimespan = ConversionHelper.MapStringTypeToCLRType("TimeSpan", timespanStr);
+            Assert.AreEqual(convertedTimespan, TimeSpan.Parse(timespanStr));
+        }
     }
 }

--- a/src/ServiceBusExplorer/Forms/MessageForm.cs
+++ b/src/ServiceBusExplorer/Forms/MessageForm.cs
@@ -1,20 +1,20 @@
 ﻿#region Copyright
 //=======================================================================================
-// Microsoft Azure Customer Advisory Team 
+// Microsoft Azure Customer Advisory Team
 //
 // This sample is supplemental to the technical guidance published on my personal
-// blog at http://blogs.msdn.com/b/paolos/. 
-// 
+// blog at http://blogs.msdn.com/b/paolos/.
+//
 // Author: Paolo Salvatori
 //=======================================================================================
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// 
-// LICENSED UNDER THE APACHE LICENSE, VERSION 2.0 (THE "LICENSE"); YOU MAY NOT USE THESE 
-// FILES EXCEPT IN COMPLIANCE WITH THE LICENSE. YOU MAY OBTAIN A COPY OF THE LICENSE AT 
+//
+// LICENSED UNDER THE APACHE LICENSE, VERSION 2.0 (THE "LICENSE"); YOU MAY NOT USE THESE
+// FILES EXCEPT IN COMPLIANCE WITH THE LICENSE. YOU MAY OBTAIN A COPY OF THE LICENSE AT
 // http://www.apache.org/licenses/LICENSE-2.0
-// UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, SOFTWARE DISTRIBUTED UNDER THE 
-// LICENSE IS DISTRIBUTED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
-// KIND, EITHER EXPRESS OR IMPLIED. SEE THE LICENSE FOR THE SPECIFIC LANGUAGE GOVERNING 
+// UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, SOFTWARE DISTRIBUTED UNDER THE
+// LICENSE IS DISTRIBUTED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED. SEE THE LICENSE FOR THE SPECIFIC LANGUAGE GOVERNING
 // PERMISSIONS AND LIMITATIONS UNDER THE LICENSE.
 //=======================================================================================
 #endregion
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
         #endregion
 
         #region Private Static Fields
-        static readonly List<string> Types = new List<string> { "Boolean", "Byte", "Int16", "Int32", "Int64", "Single", "Double", "Decimal", "Guid", "DateTime", "String" };
+        static readonly List<string> Types = new List<string> { "Boolean", "Byte", "Int16", "Int32", "Int64", "Single", "Double", "Decimal", "Guid", "DateTime", "TimeSpan", "String" };
         #endregion
 
         #region Public Properties
@@ -175,12 +175,12 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             propertiesDataGridView.DefaultCellStyle.SelectionBackColor = Color.FromArgb(92, 125, 150);
             propertiesDataGridView.DefaultCellStyle.SelectionForeColor = SystemColors.Window;
 
-            // Set RowHeadersDefaultCellStyle.SelectionBackColor so that its default 
+            // Set RowHeadersDefaultCellStyle.SelectionBackColor so that its default
             // value won't override DataGridView.DefaultCellStyle.SelectionBackColor.
             propertiesDataGridView.RowHeadersDefaultCellStyle.SelectionBackColor = Color.FromArgb(153, 180, 209);
 
-            // Set the background color for all rows and for alternating rows.  
-            // The value for alternating rows overrides the value for all rows. 
+            // Set the background color for all rows and for alternating rows.
+            // The value for alternating rows overrides the value for all rows.
             propertiesDataGridView.RowsDefaultCellStyle.BackColor = SystemColors.Window;
             propertiesDataGridView.RowsDefaultCellStyle.ForeColor = SystemColors.ControlText;
 

--- a/src/ServiceBusExplorer/Helpers/ConversionHelper.cs
+++ b/src/ServiceBusExplorer/Helpers/ConversionHelper.cs
@@ -130,11 +130,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                 case "DateTime":
                     return Convert.ChangeType(value, typeof(DateTime));
                 case "TimeSpan":
-                    if (value is string valueString)
-                    {
-                        return TimeSpan.Parse(valueString);
-                    }
-                    break;
+                    return TimeSpan.Parse((string)value);
                 case "Guid":
                     return new Guid(value.ToString());
             }

--- a/src/ServiceBusExplorer/Helpers/ConversionHelper.cs
+++ b/src/ServiceBusExplorer/Helpers/ConversionHelper.cs
@@ -1,20 +1,20 @@
 ﻿#region Copyright
 //=======================================================================================
-// Microsoft Azure Customer Advisory Team 
+// Microsoft Azure Customer Advisory Team
 //
 // This sample is supplemental to the technical guidance published on my personal
-// blog at http://blogs.msdn.com/b/paolos/. 
-// 
+// blog at http://blogs.msdn.com/b/paolos/.
+//
 // Author: Paolo Salvatori
 //=======================================================================================
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// 
-// LICENSED UNDER THE APACHE LICENSE, VERSION 2.0 (THE "LICENSE"); YOU MAY NOT USE THESE 
-// FILES EXCEPT IN COMPLIANCE WITH THE LICENSE. YOU MAY OBTAIN A COPY OF THE LICENSE AT 
+//
+// LICENSED UNDER THE APACHE LICENSE, VERSION 2.0 (THE "LICENSE"); YOU MAY NOT USE THESE
+// FILES EXCEPT IN COMPLIANCE WITH THE LICENSE. YOU MAY OBTAIN A COPY OF THE LICENSE AT
 // http://www.apache.org/licenses/LICENSE-2.0
-// UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, SOFTWARE DISTRIBUTED UNDER THE 
-// LICENSE IS DISTRIBUTED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
-// KIND, EITHER EXPRESS OR IMPLIED. SEE THE LICENSE FOR THE SPECIFIC LANGUAGE GOVERNING 
+// UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, SOFTWARE DISTRIBUTED UNDER THE
+// LICENSE IS DISTRIBUTED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED. SEE THE LICENSE FOR THE SPECIFIC LANGUAGE GOVERNING
 // PERMISSIONS AND LIMITATIONS UNDER THE LICENSE.
 //=======================================================================================
 #endregion
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
         #endregion
 
         #region Static Constructor
-		static ConversionHelper()
+        static ConversionHelper()
         {
             clrToEDMMappingDictionary.Add(typeof(byte), "Edm.Byte");
             clrToEDMMappingDictionary.Add(typeof(short), "Edm.Int16");
@@ -54,8 +54,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
             clrToEDMMappingDictionary.Add(typeof(Guid), "Edm.Guid");
             clrToEDMMappingDictionary.Add(typeof(DateTime), "Edm.DateTime");
             clrToEDMMappingDictionary.Add(typeof(bool), "Edm.Boolean");
-        } 
-	    #endregion
+        }
+        #endregion
 
         #region Public Static Methods
         public static object MapEDMTypeToCLRType(string type, string value, bool isNull)
@@ -129,6 +129,12 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                     return Convert.ChangeType(value, typeof(decimal));
                 case "DateTime":
                     return Convert.ChangeType(value, typeof(DateTime));
+                case "TimeSpan":
+                    if (value is string valueString)
+                    {
+                        return TimeSpan.Parse(valueString);
+                    }
+                    break;
                 case "Guid":
                     return new Guid(value.ToString());
             }
@@ -143,7 +149,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                 return clrToEDMMappingDictionary[type];
             }
             return null;
-        } 
+        }
         #endregion
     }
 }


### PR DESCRIPTION
PR adds a support for TimeSpan property type to the MessageForm.
![image](https://user-images.githubusercontent.com/5083018/52871271-f9830e00-3149-11e9-9ca1-3dabf8c5326f.png)

It also logs info when timespan is not valid.
```
<17:31:44> The following validations failed:
 - RetryInterval property conversion error: String was not recognized as a valid Boolean.
```

Question: I just noticed that my IDE removed redundant white characters. Should I bring them back?

Fixes #304 