### PR TITLE
Lazy load subscription rules

### DIFF
--- a/src/ServiceBusExplorer/Forms/MainForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.Designer.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.Azure.ServiceBusExplorer.Controls;
-using Microsoft.Azure.ServiceBusExplorer.Helpers;
 using Microsoft.ServiceBus.Messaging;
-using System.Windows.Forms;
 
 namespace Microsoft.Azure.ServiceBusExplorer.Forms
 {
@@ -598,6 +596,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.serviceBusTreeView.TabIndex = 13;
             this.serviceBusTreeView.NodeMouseClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.serviceBusTreeView_NodeMouseClick);
             this.serviceBusTreeView.KeyUp += new System.Windows.Forms.KeyEventHandler(this.serviceBusTreeView_KeyUp);
+            this.serviceBusTreeView.BeforeExpand += new System.Windows.Forms.TreeViewCancelEventHandler(this.serviceBusTreeView_BeforeExpand);
             // 
             // panelMain
             // 
@@ -621,8 +620,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             // mainSplitContainer
             // 
-            this.mainSplitContainer.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            this.mainSplitContainer.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.mainSplitContainer.Location = new System.Drawing.Point(16, 40);
             this.mainSplitContainer.Name = "mainSplitContainer";
@@ -2816,7 +2815,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.PerformLayout();
 
         }
-        
+
         #endregion
 
         private System.Windows.Forms.ImageList imageList;

--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -4551,7 +4551,6 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             if (treeNodesToLazyLoad?.Remove(node) ?? false)
             {
                 LazyLoadNode(node);
-                treeNodesToLazyLoad.Remove(node);
             }
         }
 


### PR DESCRIPTION
Fixes #308 - Very slow loading times for topics with a high number of subscriptions.

Topic Subscription nodes will now load a blank "Rules" node, and the real Rules will only be read from the server when the Subscription is selected or expanded. This speeds up the loading of Topics with hundreds of Subscriptions by an order of magnitude.

This was achieved by extracting much of the GetEntities() method which builds the tree into a LazyLoadNode() method. This will still add the Subscription nodes, but then adds the Rules to a list of items still be read and processed only when a Subscription node is clicked or expanded.