### PR TITLE
Reformat multi-line tooltip source code for readability

### DIFF
--- a/src/ServiceBusExplorer/Forms/ConnectForm.cs
+++ b/src/ServiceBusExplorer/Forms/ConnectForm.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
         private const string ConnectionStringTooltip =
             "Microsoft Azure Service Bus\r\n"
             + "-----------------------------\r\n"
-            + "Endpoint=sb://<servicebusnamespace>.servicebus.windows.net/;SharedAccessKeyName=<SAS policy name>;SharedAccessKey=<SAS policy key> \r\n"
+            + "Endpoint=sb://<servicebusnamespace>.servicebus.windows.net/;SharedAccessKeyName=<SAS policy name>;SharedAccessKey=<SAS policy key>\r\n"
             + "\r\n"
             + "Service Bus for Windows Server\r\n"
             + "---------------------------------\r\n"

--- a/src/ServiceBusExplorer/Forms/ConnectForm.cs
+++ b/src/ServiceBusExplorer/Forms/ConnectForm.cs
@@ -73,7 +73,14 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
         // Tooltips
         //***************************
         private const string ConnectionStringTooltip =
-            "Microsoft Azure Service Bus\r\n-----------------------------\r\nEndpoint=sb://<servicebusnamespace>.servicebus.windows.net/;SharedSecretIssuer=<issuer>;SharedSecretValue=<secret>\r\n\r\nService Bus for Windows Server\r\n---------------------------------\r\nEndpoint=sb://<machinename>/<servicebusnamespace>;StsEndpoint=https://<machinename>:9355/<servicebusnamespace>;\r\nRuntimePort=9354;ManagementPort=9355;WindowsUsername=<username>;WindowsDomain=<domain/machinename>;WindowsPassword=<password>";
+            "Microsoft Azure Service Bus\r\n"
+            + "-----------------------------\r\n"
+            + "Endpoint=sb://<servicebusnamespace>.servicebus.windows.net/;SharedSecretIssuer=<issuer>;SharedSecretValue=<secret>\r\n"
+            + "\r\n"
+            + "Service Bus for Windows Server\r\n"
+            + "---------------------------------\r\n"
+            + "Endpoint=sb://<machinename>/<servicebusnamespace>;StsEndpoint=https://<machinename>:9355/<servicebusnamespace>;\r\n"
+            + "RuntimePort=9354;ManagementPort=9355;WindowsUsername=<username>;WindowsDomain=<domain/machinename>;WindowsPassword=<password>";
 
         private const string UriTooltip = "Gets or sets the Uri of the service bus namespace endpoint.";
 

--- a/src/ServiceBusExplorer/Forms/ConnectForm.cs
+++ b/src/ServiceBusExplorer/Forms/ConnectForm.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
         private const string ConnectionStringTooltip =
             "Microsoft Azure Service Bus\r\n"
             + "-----------------------------\r\n"
-            + "Endpoint=sb://<servicebusnamespace>.servicebus.windows.net/;SharedSecretIssuer=<issuer>;SharedSecretValue=<secret>\r\n"
+            + "Endpoint=sb://<servicebusnamespace>.servicebus.windows.net/;SharedAccessKeyName=<SAS policy name>;SharedAccessKey=<SAS policy key> \r\n"
             + "\r\n"
             + "Service Bus for Windows Server\r\n"
             + "---------------------------------\r\n"


### PR DESCRIPTION
The Connection String tooltip source code is hard to read, and the long line causes a "wide" horizontal scroll bar in the editor. Would you consider reformatting it over multiple lines for readability?