### PR TITLE
Make reversion from User config file to Application config file stick

### DIFF
--- a/src/ServiceBusExplorer/Forms/OptionForm.cs
+++ b/src/ServiceBusExplorer/Forms/OptionForm.cs
@@ -432,7 +432,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                     return BothConfigFileIndex;
 
                 default:
-                    throw new InvalidDataException("Unexpexted value passed to " +
+                    throw new InvalidDataException("Unexpected value passed to " +
                                                    nameof(GetIndexForConfigFileUseUIString));
             }
         }

--- a/src/ServiceBusExplorer/Helpers/MainSettings.cs
+++ b/src/ServiceBusExplorer/Helpers/MainSettings.cs
@@ -241,7 +241,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                     return EncodingType;
             }
 
-            throw new InvalidOperationException("Unexpected value ");
+            throw new InvalidOperationException(String.Format("Unexpected value for setting: {0}", setting));
         }
 
         #endregion


### PR DESCRIPTION
Fixes #319.

When you have set the option to use the User config file or Both config file, and then switch back to Application config file and save your settings, that change will not stick through an application restart. This is because the settings, including which config file to use, get saved to the Application file and not the User config file. So the User config file still has the old "User" or "Both" setting in it, and that will get loaded again and take precedence at the next program restart.

This PR fixes it by adding special-case logic to write the ConfigFileUse setting to the User config file if we have switched from a User-using ConfigFileUse to Application ConfigFileUse during the use of the Options form.