### PR TITLE
Fix long delay when creating invalid entity

### DIFF
--- a/src/ServiceBusExplorer/Helpers/RetryHelper.cs
+++ b/src/ServiceBusExplorer/Helpers/RetryHelper.cs
@@ -238,6 +238,19 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                                                  retryCount));
                     Thread.Sleep(retryTimeout);
                 }
+                catch (MessagingException ex)
+                {
+                    if (numRetries == 0 || (!ex.IsTransient))
+                    {
+                        throw;
+                    }
+                    writeToLog(string.Format(RetryingMethod,
+                                                 ex.Message,
+                                                 func.Method.Name,
+                                                 retryCount - numRetries + 1,
+                                                 retryCount));
+                    Thread.Sleep(retryTimeout);
+                }
                 catch (TimeoutException ex)
                 {
                     if (numRetries == 0)
@@ -307,6 +320,19 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                 catch (MessagingCommunicationException ex)
                 {
                     if (numRetries == 0)
+                    {
+                        throw;
+                    }
+                    writeToLog(string.Format(RetryingMethod,
+                                                 ex.Message,
+                                                 func.Method.Name,
+                                                 retryCount - numRetries + 1,
+                                                 retryCount));
+                    Thread.Sleep(retryTimeout);
+                }
+                catch (MessagingException ex)
+                {
+                    if (numRetries == 0 || (!ex.IsTransient))
                     {
                         throw;
                     }

--- a/src/ServiceBusExplorer/Helpers/RetryHelper.cs
+++ b/src/ServiceBusExplorer/Helpers/RetryHelper.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
         private const string ActionCannotBeNull = "Action argument cannot be null.";
         private const string FuncCannotBeNull = "Func argument cannot be null.";
         private const string RetryingMethod = "Exception: {0}. Method {1}: retry {2} of {3}.";
+        private const string CaughtGenericException = "Exception type was: {0}.";
         private const int DefaultRetryCount = 10;
         private const int DefaultRetryTimeout = 100;
         #endregion
@@ -114,6 +115,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                                                  action.Method.Name,
                                                  retryCount - numRetries + 1,
                                                  retryCount));
+                    writeToLog(string.Format(CaughtGenericException, ex.GetType()));
                     Thread.Sleep(retryTimeout);
                 }
             } while (numRetries-- > 0);
@@ -179,6 +181,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                                                  action.Method.Name,
                                                  retryCount - numRetries + 1,
                                                  retryCount));
+                    writeToLog(string.Format(CaughtGenericException, ex.GetType()));
                     Thread.Sleep(retryTimeout);
                 }
             } while (numRetries-- > 0);
@@ -259,6 +262,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                                                  func.Method.Name,
                                                  retryCount - numRetries + 1,
                                                  retryCount));
+                    writeToLog(string.Format(CaughtGenericException, ex.GetType()));
                     Thread.Sleep(retryTimeout);
                 }
             } while (numRetries-- > 0);
@@ -337,6 +341,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                                                  func.Method.Name,
                                                  retryCount - numRetries + 1,
                                                  retryCount));
+                    writeToLog(string.Format(CaughtGenericException, ex.GetType()));
                     Thread.Sleep(retryTimeout);
                 }
             } while (numRetries-- > 0);


### PR DESCRIPTION
Partially addresses #327.

Currently, when you attempt to create an Event Hub in a Namespace that is for Queues/Topics, or vice versa, the UI will freeze for about 30 seconds, before spewing some errors to the log. This is because the creation attempt is retried 10 times, even though this isn't a transient error.

This PR improves UI responsiveness by changing `RetryHelper` to consider `QuotaExceededException` (which is what happens in this case) to be non-transient, and not retry it.

Does not fix the UI freeze when creating Relays in a non-Relay namespace, because that throws a different `AggregateException`, which I'm not comfortable special-casing to be non-transient in this PR, unless y'all give that an explicit thumbs-up.

You could go even further along this route: `RetryHelper` considers the generic `Exception` to be transient and retries it. I think maybe it should be the other way around: consider generic `Exception` to be non-transient, and only retry on special-cased exceptions that are known to be probably transient.