### PR TITLE
Reduce excess precision in msg/sec rates in log messages

### DIFF
--- a/src/ServiceBusExplorer/Controls/TestRelayControl.cs
+++ b/src/ServiceBusExplorer/Controls/TestRelayControl.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
         private const string SendTaskCountMustBeANumber = "The Sender Task Count field must be an integer number greater than zero.";
         private const string MessageCannotBeNull = "The Message field cannot be null.";
         private const string SenderStatisticsHeader = "Sender[{0}]:";
-        private const string SenderStatisticsLine1 = " - Message Count=[{0}] Messages Sent/Sec=[{1}] Total Elapsed Time (ms)=[{2}]";
+        private const string SenderStatisticsLine1 = " - Message Count=[{0}] Messages Sent/Sec=[{1:F1}] Total Elapsed Time (ms)=[{2}]";
         private const string SenderStatisticsLine2 = " - Average Send Time (ms)=[{0}] Minimum Send Time (ms)=[{1}] Maximum Send Time (ms)=[{2}] ";
         private const string MessageSuccessfullySent = "Sender[{0}]: Request message sent. MessageNumber=[{1}]";
         private const string MessageSuccessfullyReceived = "Sender[{0}]: Response message received. MessageNumber=[{1}]";

--- a/src/ServiceBusExplorer/Controls/TestRelayControl.cs
+++ b/src/ServiceBusExplorer/Controls/TestRelayControl.cs
@@ -77,8 +77,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
         private const string SendTaskCountMustBeANumber = "The Sender Task Count field must be an integer number greater than zero.";
         private const string MessageCannotBeNull = "The Message field cannot be null.";
         private const string SenderStatisticsHeader = "Sender[{0}]:";
-        private const string SenderStatitiscsLine1 = " - Message Count=[{0}] Messages Sent/Sec=[{1}] Total Elapsed Time (ms)=[{2}]";
-        private const string SenderStatitiscsLine2 = " - Average Send Time (ms)=[{0}] Minimum Send Time (ms)=[{1}] Maximum Send Time (ms)=[{2}] ";
+        private const string SenderStatisticsLine1 = " - Message Count=[{0}] Messages Sent/Sec=[{1}] Total Elapsed Time (ms)=[{2}]";
+        private const string SenderStatisticsLine2 = " - Average Send Time (ms)=[{0}] Minimum Send Time (ms)=[{1}] Maximum Send Time (ms)=[{2}] ";
         private const string MessageSuccessfullySent = "Sender[{0}]: Request message sent. MessageNumber=[{1}]";
         private const string MessageSuccessfullyReceived = "Sender[{0}]: Response message received. MessageNumber=[{1}]";
         private const string PayloadHeader = "Payload:";
@@ -666,12 +666,12 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                                     builder.AppendLine(exceptionMessage);
                                 }
                                 builder.AppendLine(string.Format(CultureInfo.CurrentCulture,
-                                                                 SenderStatitiscsLine1,
+                                                                 SenderStatisticsLine1,
                                                                  messagesSent,
                                                                  messagesPerSecond,
                                                                  totalElapsedTime));
                                 builder.AppendLine(string.Format(CultureInfo.CurrentCulture,
-                                                                 SenderStatitiscsLine2,
+                                                                 SenderStatisticsLine2,
                                                                  averageSendTime,
                                                                  minimumSendTime == long.MaxValue ? 0 : minimumSendTime,
                                                                  maximumSendTime));

--- a/src/ServiceBusExplorer/Helpers/ServiceBusHelper.cs
+++ b/src/ServiceBusExplorer/Helpers/ServiceBusHelper.cs
@@ -147,11 +147,11 @@ namespace Microsoft.Azure.ServiceBusExplorer
         private const string MessageReadFromDeadLetterQueue = " - The message was read from the DeadLetter queue.";
         private const string NoMessageWasReceived = "Receiver[{0}]: no message was received.";
         private const string SenderStatisticsHeader = "Sender[{0}]:";
-        private const string SenderStatisticsLine1 = " - Message Count=[{0}] Messages Sent/Sec=[{1}] Total Elapsed Time (ms)=[{2}]";
+        private const string SenderStatisticsLine1 = " - Message Count=[{0}] Messages Sent/Sec=[{1:F1}] Total Elapsed Time (ms)=[{2}]";
         private const string SenderStatisticsLine2 = " - Average Send Time (ms)=[{0}] Minimum Send Time (ms)=[{1}] Maximum Send Time (ms)=[{2}] ";
         private const string ReceiverStatisticsHeader = "Receiver[{0}]:";
-        private const string ReceiverStatisticsLine1 = " - Message Count=[{0}] Messages Read/Sec=[{1}] Total Elapsed Time (ms)=[{2}]";
-        private const string ReceiverStatisticsWithCompleteLine1 = " - Message Count=[{0}] Messages Read/Sec=[{1}] Total Receive Elapsed Time (ms)=[{2}] Total Complete Elapsed Time (ms)=[{3}]";
+        private const string ReceiverStatisticsLine1 = " - Message Count=[{0}] Messages Read/Sec=[{1:F1}] Total Elapsed Time (ms)=[{2}]";
+        private const string ReceiverStatisticsWithCompleteLine1 = " - Message Count=[{0}] Messages Read/Sec=[{1:F1}] Total Receive Elapsed Time (ms)=[{2}] Total Complete Elapsed Time (ms)=[{3}]";
         private const string ReceiverStatisticsLine2 = " - Average Receive Time (ms)=[{0}] Minimum Receive Time (ms)=[{1}] Maximum Receive Time (ms)=[{2}] ";
         private const string ReceiverStatisticsLine3 = " - Average Complete Time (ms)=[{0}] Minimum Complete Time (ms)=[{1}] Maximum Complete Time (ms)=[{2}] ";
         private const string ExceptionOccurred = " - Exception occurred: {0}";

--- a/src/ServiceBusExplorer/Helpers/ServiceBusHelper.cs
+++ b/src/ServiceBusExplorer/Helpers/ServiceBusHelper.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.ServiceBusExplorer
         private const string MessagePeekedButNotConsumed = "Receiver[{0}]: Message peeked, but not consumed. MessageId=[{1}] SessionId=[{2}] Label=[{3}] Size=[{4}]";
         private const string MessageSuccessfullyReceivedNoTask = "Message {0}: MessageId=[{1}] SessionId=[{2}] Label=[{3}] Size=[{4}] DeliveryCount[{5}]";
         private const string EventDataSuccessfullySent = "Sender[{0}]: EventData sent. MessageNumber=[{1}] PartitionKey=[{2}]";
-        private const string ReceiverStatitiscsLineNoTask = "Messages {0}: Count=[{1}]";
+        private const string ReceiverStatisticsLineNoTask = "Messages {0}: Count=[{1}]";
         private const string SentMessagePropertiesHeader = "Properties:";
         private const string ReceivedMessagePropertiesHeader = "Properties:";
         private const string SentMessagePayloadHeader = "Payload:";
@@ -147,13 +147,13 @@ namespace Microsoft.Azure.ServiceBusExplorer
         private const string MessageReadFromDeadLetterQueue = " - The message was read from the DeadLetter queue.";
         private const string NoMessageWasReceived = "Receiver[{0}]: no message was received.";
         private const string SenderStatisticsHeader = "Sender[{0}]:";
-        private const string SenderStatitiscsLine1 = " - Message Count=[{0}] Messages Sent/Sec=[{1}] Total Elapsed Time (ms)=[{2}]";
-        private const string SenderStatitiscsLine2 = " - Average Send Time (ms)=[{0}] Minimum Send Time (ms)=[{1}] Maximum Send Time (ms)=[{2}] ";
+        private const string SenderStatisticsLine1 = " - Message Count=[{0}] Messages Sent/Sec=[{1}] Total Elapsed Time (ms)=[{2}]";
+        private const string SenderStatisticsLine2 = " - Average Send Time (ms)=[{0}] Minimum Send Time (ms)=[{1}] Maximum Send Time (ms)=[{2}] ";
         private const string ReceiverStatisticsHeader = "Receiver[{0}]:";
-        private const string ReceiverStatitiscsLine1 = " - Message Count=[{0}] Messages Read/Sec=[{1}] Total Elapsed Time (ms)=[{2}]";
-        private const string ReceiverStatitiscsWithCompleteLine1 = " - Message Count=[{0}] Messages Read/Sec=[{1}] Total Receive Elapsed Time (ms)=[{2}] Total Complete Elapsed Time (ms)=[{3}]";
-        private const string ReceiverStatitiscsLine2 = " - Average Receive Time (ms)=[{0}] Minimum Receive Time (ms)=[{1}] Maximum Receive Time (ms)=[{2}] ";
-        private const string ReceiverStatitiscsLine3 = " - Average Complete Time (ms)=[{0}] Minimum Complete Time (ms)=[{1}] Maximum Complete Time (ms)=[{2}] ";
+        private const string ReceiverStatisticsLine1 = " - Message Count=[{0}] Messages Read/Sec=[{1}] Total Elapsed Time (ms)=[{2}]";
+        private const string ReceiverStatisticsWithCompleteLine1 = " - Message Count=[{0}] Messages Read/Sec=[{1}] Total Receive Elapsed Time (ms)=[{2}] Total Complete Elapsed Time (ms)=[{3}]";
+        private const string ReceiverStatisticsLine2 = " - Average Receive Time (ms)=[{0}] Minimum Receive Time (ms)=[{1}] Maximum Receive Time (ms)=[{2}] ";
+        private const string ReceiverStatisticsLine3 = " - Average Complete Time (ms)=[{0}] Minimum Complete Time (ms)=[{1}] Maximum Complete Time (ms)=[{2}] ";
         private const string ExceptionOccurred = " - Exception occurred: {0}";
         private const string UnableToReadMessageBody = "Unable to read the message body.";
         private const string EventHubClientCannotBeNull = "The EventHubClient parameter cannot be null.";
@@ -3442,12 +3442,12 @@ namespace Microsoft.Azure.ServiceBusExplorer
                 throw new Exception(builder.ToString());
             }
             builder.AppendLine(string.Format(CultureInfo.CurrentCulture,
-                                             SenderStatitiscsLine1,
+                                             SenderStatisticsLine1,
                                              messagesSent,
                                              messagesPerSecond,
                                              totalElapsedTime));
             builder.AppendLine(string.Format(CultureInfo.CurrentCulture,
-                                             SenderStatitiscsLine2,
+                                             SenderStatisticsLine2,
                                              averageSendTime,
                                              minimumSendTime == long.MaxValue ? 0 : minimumSendTime,
                                              maximumSendTime));
@@ -4241,12 +4241,12 @@ namespace Microsoft.Azure.ServiceBusExplorer
                 builder.AppendLine(exceptionMessage);
             }
             builder.AppendLine(string.Format(CultureInfo.CurrentCulture,
-                                             SenderStatitiscsLine1,
+                                             SenderStatisticsLine1,
                                              messagesSent,
                                              messagesPerSecond,
                                              totalElapsedTime));
             builder.AppendLine(string.Format(CultureInfo.CurrentCulture,
-                                             SenderStatitiscsLine2,
+                                             SenderStatisticsLine2,
                                              averageSendTime,
                                              minimumSendTime == long.MaxValue ? 0 : minimumSendTime,
                                              maximumSendTime));
@@ -5000,7 +5000,7 @@ namespace Microsoft.Azure.ServiceBusExplorer
             if (messageReceiver.Mode == ReceiveMode.ReceiveAndDelete)
             {
                 builder.AppendLine(string.Format(CultureInfo.CurrentCulture,
-                                                 ReceiverStatitiscsLine1,
+                                                 ReceiverStatisticsLine1,
                                                  messagesReceived,
                                                  messagesPerSecond,
                                                  totalReceiveElapsedTime));
@@ -5008,21 +5008,21 @@ namespace Microsoft.Azure.ServiceBusExplorer
             else
             {
                 builder.AppendLine(string.Format(CultureInfo.CurrentCulture,
-                                                 ReceiverStatitiscsWithCompleteLine1,
+                                                 ReceiverStatisticsWithCompleteLine1,
                                                  messagesReceived,
                                                  messagesPerSecond,
                                                  totalReceiveElapsedTime,
                                                  totalCompleteElapsedTime));
             }
             builder.AppendLine(string.Format(CultureInfo.CurrentCulture,
-                                             ReceiverStatitiscsLine2,
+                                             ReceiverStatisticsLine2,
                                              averageReceiveTime,
                                              minimumReceiveTime == long.MaxValue ? 0 : minimumReceiveTime,
                                              maximumReceiveTime));
             if (messageReceiver.Mode == ReceiveMode.PeekLock)
             {
                 builder.AppendLine(string.Format(CultureInfo.CurrentCulture,
-                                             ReceiverStatitiscsLine3,
+                                             ReceiverStatisticsLine3,
                                              averageCompleteTime,
                                              minimumCompleteTime == long.MaxValue ? 0 : minimumCompleteTime,
                                              maximumCompleteTime));
@@ -5630,7 +5630,7 @@ namespace Microsoft.Azure.ServiceBusExplorer
                     brokeredMessageList = null;
                 }
                 var builder = new StringBuilder();
-                builder.AppendLine(string.Format(ReceiverStatitiscsLineNoTask,
+                builder.AppendLine(string.Format(ReceiverStatisticsLineNoTask,
                                                 complete ? Read : Peeked,
                                                 messageTotal));
                 var traceMessage = builder.ToString();


### PR DESCRIPTION
In the log messages for sending and receiving messages, SBE currently formats the “messages/second” rates using the full precision of a `double`, with about 14 digits past the decimal point.

```
     - Message Count=[1] Messages Sent/Sec=[4.20168067226891] Total Elapsed Time (ms)=[238]
```

That's a wackdoodle amount of precision for the data we're looking at here. Given the actual variance in message send/receive times, and the measurement error, I'd guess there's maybe two actual significant digits of data there.

This PR reduces the excess precision here by changing the formatting of the msgs/sec values to use just 1 decimal point. Because it'll always take at least 10-20 ms to send a message, that'll be sufficient precision, and we don't need to worry about scale-independent significant digits here.

This will reduce potential user impression of high precision in metrics data, and IMHO makes the log messages more readable.

This PR also throws in a typo fix that occurs in several “statistics”-related private variable names.

### UI change screenshots

Before:

![lokfojmekbbfaoba](https://user-images.githubusercontent.com/2618447/54401524-62549c00-469e-11e9-9598-35875cddc7a0.png)

After:

![gbjgpejffbhpndlj](https://user-images.githubusercontent.com/2618447/54401533-684a7d00-469e-11e9-88ca-a6c20d7c3a24.png)
