### PR TITLE
Checking if field is already a timespan

### DIFF
--- a/src/ServiceBusExplorer.Tests/Helpers/ConversionHelperTests.cs
+++ b/src/ServiceBusExplorer.Tests/Helpers/ConversionHelperTests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Tests.Helpers
         }
 
         [Theory]
+        [TestCase("00:00:00")]
         [TestCase("3:44:55")]
         [TestCase("03:44:55")]
         [TestCase("1:00:00:00.0000000")] // one day
@@ -35,6 +36,13 @@ namespace Microsoft.Azure.ServiceBusExplorer.Tests.Helpers
         {
             var convertedTimespan = ConversionHelper.MapStringTypeToCLRType("TimeSpan", timespanStr);
             Assert.AreEqual(convertedTimespan, TimeSpan.Parse(timespanStr));
+        }
+
+        [Test]
+        public void MapStringTypeToCLRType_ValueIsTimeSpan_ReturnsEqualTimespanObject()
+        {
+            var convertedTimespan = ConversionHelper.MapStringTypeToCLRType("TimeSpan", TimeSpan.Zero);
+            Assert.AreEqual(convertedTimespan, TimeSpan.Zero);
         }
     }
 }

--- a/src/ServiceBusExplorer/Helpers/ConversionHelper.cs
+++ b/src/ServiceBusExplorer/Helpers/ConversionHelper.cs
@@ -130,6 +130,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                 case "DateTime":
                     return Convert.ChangeType(value, typeof(DateTime));
                 case "TimeSpan":
+                    if (value is TimeSpan t) return t;
+                    if (value is string st) return TimeSpan.Parse(st);
                     return TimeSpan.Parse((string)value);
                 case "Guid":
                     return new Guid(value.ToString());


### PR DESCRIPTION
Resending msg fails when I want to resend msg with default, unchanged timespan value. 
It works correctly when I edit value manually, because field becomes a string property.
![image](https://user-images.githubusercontent.com/5083018/54683029-e2e92180-4b10-11e9-8194-03338fc60730.png)



I have added a unit test and a fix for such issue. It avoids timespan parsing when argument is already a timespan.
