### PR TITLE
Streamline Chocolatey install discoverability

### DIFF
--- a/src/ServiceBusExplorer/ServiceBusExplorer.nuspec
+++ b/src/ServiceBusExplorer/ServiceBusExplorer.nuspec
@@ -1,7 +1,7 @@
 <package>
   <metadata>
     <id>servicebusexplorer</id>
-    <title>ServiceBusExplorer</title>
+    <title>Service Bus Explorer</title>
     <version>$version$</version>
     <authors>Paolo Salvatori</authors>
     <owners>Paolo Salvatori</owners>


### PR DESCRIPTION
Rename Service Bus Explorer title to streamline Chocolatey installs.

As of today, you have to search on `ServiceBusExplorer` rather than `Service Bus Explorer`:
![image](https://user-images.githubusercontent.com/4345663/58795016-e5c8be00-85f9-11e9-8cc0-e14717555097.png)


This is inconvenient and you have to know that you have to look it up like that as well.

This rename is also more inline with the [Chocolatey guidelines](https://github.com/chocolatey/choco/wiki/CreatePackages#naming-your-package)