### PR TITLE
Fix copying behavior of properties when resubmitting messages

### DIFF
--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Helpers\IBrokeredMessageGenerator.cs" />
     <Compile Include="Helpers\IBrokeredMessageInspector.cs" />
     <Compile Include="Helpers\IdAttribute.cs" />
+    <Compile Include="Helpers\IEnumerableExtensions.cs" />
     <Compile Include="Helpers\IEventDataGenerator.cs" />
     <Compile Include="Helpers\IEventDataInspector.cs" />
     <Compile Include="Helpers\IMessageDeferProvider.cs" />

--- a/src/Common/Helpers/BrokeredMessageExtensions.cs
+++ b/src/Common/Helpers/BrokeredMessageExtensions.cs
@@ -93,7 +93,9 @@ namespace ServiceBusExplorer.Helpers
             if (!omitAllProperties)
             {
                 // Copy all custom properties
-                var propertiesToCopy = originalMessage.Properties.Where(h => !Constants.AlwaysOmittedProperties.Contains(h.Key.ToLower()));
+                var propertiesToCopy = originalMessage.Properties.Where(prop => !Constants.AlwaysOmittedProperties.Exists(
+                    omitProp => prop.Key.Equals(omitProp, StringComparison.InvariantCultureIgnoreCase)));
+
                 propertiesToCopy.ForEach(h => message.Properties[h.Key] = h.Value);
             }
 

--- a/src/Common/Helpers/BrokeredMessageExtensions.cs
+++ b/src/Common/Helpers/BrokeredMessageExtensions.cs
@@ -21,12 +21,13 @@
 
 #region Using Directives
 
+using Microsoft.Azure.ServiceBusExplorer.Helpers;
+using Microsoft.ServiceBus.Messaging;
 using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using Microsoft.ServiceBus.Messaging;
 
 #endregion
 
@@ -50,7 +51,7 @@ namespace ServiceBusExplorer.Helpers
             }
         }
 
-        public static BrokeredMessage Clone(this BrokeredMessage message, Stream stream)
+        public static BrokeredMessage Clone(this BrokeredMessage message, Stream stream, bool omitAllProperties)
         {
             if (stream == null)
             {
@@ -61,34 +62,39 @@ namespace ServiceBusExplorer.Helpers
                 stream.Seek(0, SeekOrigin.Begin);
             }
             var clone = message.Clone();
+            if (omitAllProperties)
+            {
+                clone.Properties.Clear();
+            }
             BodyStreamPropertyInfo.SetValue(clone, stream);
             return clone;
         }
 
-        public static BrokeredMessage Clone(this BrokeredMessage message, string text)
+        public static BrokeredMessage Clone(this BrokeredMessage message, string text, bool omitAllProperties)
         {
             var stream = new MemoryStream();
             var writer = new StreamWriter(stream);
             writer.Write(text);
             writer.Flush();
             var clone = message.Clone();
+            if (omitAllProperties)
+            {
+                clone.Properties.Clear();
+            }
             BodyStreamPropertyInfo.SetValue(clone, stream);
             return clone;
         }
 
-        public static BrokeredMessage CloneWithByteArrayBodyType(this BrokeredMessage originalMessage, string text)
+        public static BrokeredMessage CloneWithByteArrayBodyType(this BrokeredMessage originalMessage, string text, bool omitAllProperties)
         {
             var bytes = Encoding.UTF8.GetBytes(text);
             var message = new BrokeredMessage(bytes);
 
-            // Copy all custom properties
-            foreach (var header in originalMessage.Properties)
+            if (!omitAllProperties)
             {
-                // Recovery header should not be included
-                if (header.Key != "NServiceBus.Transport.Recovery")
-                {
-                    message.Properties[header.Key] = header.Value;
-                }
+                // Copy all custom properties
+                var propertiesToCopy = originalMessage.Properties.Where(h => !Constants.AlwaysOmittedProperties.Contains(h.Key.ToLower()));
+                propertiesToCopy.ForEach(h => message.Properties[h.Key] = h.Value);
             }
 
             // Required standard properties

--- a/src/Common/Helpers/Constants.cs
+++ b/src/Common/Helpers/Constants.cs
@@ -87,5 +87,6 @@ namespace ServiceBusExplorer.Helpers
         public static readonly Type MessageType = typeof(BrokeredMessage);
         public static readonly Type GuidType = typeof(Guid);
         public static readonly Type ObjectType = typeof(object);
+        public static readonly List<string> AlwaysOmittedProperties = new List<string> {"deadletterreason", "deadlettererrordescription", "nservicebus.transport.recovery"};
     }
 }

--- a/src/Common/Helpers/Constants.cs
+++ b/src/Common/Helpers/Constants.cs
@@ -87,6 +87,6 @@ namespace ServiceBusExplorer.Helpers
         public static readonly Type MessageType = typeof(BrokeredMessage);
         public static readonly Type GuidType = typeof(Guid);
         public static readonly Type ObjectType = typeof(object);
-        public static readonly List<string> AlwaysOmittedProperties = new List<string> {"deadletterreason", "deadlettererrordescription", "nservicebus.transport.recovery"};
+        public static readonly List<string> AlwaysOmittedProperties = new List<string> {"DeadLetterReason", "DeadLetterErrorDescription", "NServiceBus.Transport.Recovery"};
     }
 }

--- a/src/Common/Helpers/IEnumerableExtensions.cs
+++ b/src/Common/Helpers/IEnumerableExtensions.cs
@@ -1,0 +1,41 @@
+﻿#region Copyright
+//=======================================================================================
+// Microsoft Azure Customer Advisory Team 
+//
+// This sample is supplemental to the technical guidance published on my personal
+// blog at http://blogs.msdn.com/b/paolos/. 
+// 
+// Author: Paolo Salvatori
+//=======================================================================================
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// 
+// LICENSED UNDER THE APACHE LICENSE, VERSION 2.0 (THE "LICENSE"); YOU MAY NOT USE THESE 
+// FILES EXCEPT IN COMPLIANCE WITH THE LICENSE. YOU MAY OBTAIN A COPY OF THE LICENSE AT 
+// http://www.apache.org/licenses/LICENSE-2.0
+// UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, SOFTWARE DISTRIBUTED UNDER THE 
+// LICENSE IS DISTRIBUTED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
+// KIND, EITHER EXPRESS OR IMPLIED. SEE THE LICENSE FOR THE SPECIFIC LANGUAGE GOVERNING 
+// PERMISSIONS AND LIMITATIONS UNDER THE LICENSE.
+//=======================================================================================
+#endregion
+
+#region Using Directives
+
+using System;
+using System.Collections.Generic;
+
+#endregion
+
+namespace Microsoft.Azure.ServiceBusExplorer.Helpers
+{
+    public static class IEnumerableExtensions
+    {
+        public static void ForEach<T>(this IEnumerable<T> collection, Action<T> action)
+        {
+            foreach (var item in collection)
+            {
+                action?.Invoke(item);
+            }
+        }
+    }
+}

--- a/src/ServiceBusExplorer/Forms/MessageForm.cs
+++ b/src/ServiceBusExplorer/Forms/MessageForm.cs
@@ -415,7 +415,8 @@ namespace ServiceBusExplorer.Forms
                             {
                                 try
                                 {
-                                    if (Constants.AlwaysOmittedProperties.Contains(messagePropertyInfo.Key.ToLower()))
+                                    if (Constants.AlwaysOmittedProperties.Exists(
+                                        omitProp => messagePropertyInfo.Key.Equals(omitProp, StringComparison.InvariantCultureIgnoreCase)))
                                     {
                                         continue;
                                     }

--- a/src/ServiceBusExplorer/Forms/MessageForm.cs
+++ b/src/ServiceBusExplorer/Forms/MessageForm.cs
@@ -215,7 +215,7 @@ namespace ServiceBusExplorer.Forms
             btnSave.Visible = false;
             btnSubmit.Location = btnSave.Location;
             cboSenderInspector.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
-            int moveRightInPixels = btnClose.Left - btnSubmit.Left;
+            var moveRightInPixels = btnClose.Left - btnSubmit.Left;
             Size = new Size(Size.Width - moveRightInPixels, 80);
             lblBody.Left += moveRightInPixels;
             cboBodyType.Left += moveRightInPixels;
@@ -372,7 +372,7 @@ namespace ServiceBusExplorer.Forms
                                                      Path = $"{serviceBusHelper.NamespaceUri.AbsolutePath}/{messageSender.Path}",
                                                      Scheme = "sb"
                                                  }.Uri;
-                                outboundMessage = serviceBusHelper.CreateMessageForWcfReceiver(message.Clone(txtMessageText.Text),
+                                outboundMessage = serviceBusHelper.CreateMessageForWcfReceiver(message.Clone(txtMessageText.Text, messagesSplitContainer.Visible),
                                                                                                0,
                                                                                                false,
                                                                                                false,
@@ -384,8 +384,8 @@ namespace ServiceBusExplorer.Forms
                                 {
                                     // For body type ByteArray cloning is not an option. When cloned, supplied body can be only of a string or stream types, but not byte array :(
                                     outboundMessage = bodyType == BodyType.ByteArray ?
-                                                      brokeredMessage.CloneWithByteArrayBodyType(txtMessageText.Text) :
-                                                      brokeredMessage.Clone(brokeredMessage.GetBody<Stream>());
+                                                      brokeredMessage.CloneWithByteArrayBodyType(txtMessageText.Text, messagesSplitContainer.Visible) :
+                                                      brokeredMessage.Clone(brokeredMessage.GetBody<Stream>(), messagesSplitContainer.Visible);
                                 }
                                 else
                                 {
@@ -394,8 +394,8 @@ namespace ServiceBusExplorer.Forms
 
                                     // For body type ByteArray cloning is not an option. When cloned, supplied body can be only of a string or stream types, but not byte array :(
                                     outboundMessage = bodyType == BodyType.ByteArray ?
-                                                      message.CloneWithByteArrayBodyType(messageText) :
-                                                      message.Clone(message.GetBody<Stream>());
+                                                      message.CloneWithByteArrayBodyType(messageText, messagesSplitContainer.Visible) :
+                                                      message.Clone(message.GetBody<Stream>(), messagesSplitContainer.Visible);
                                 }
 
                                 outboundMessage = serviceBusHelper.CreateMessageForApiReceiver(outboundMessage,
@@ -415,10 +415,7 @@ namespace ServiceBusExplorer.Forms
                             {
                                 try
                                 {
-                                    if (string.Compare(messagePropertyInfo.Key, "DeadLetterReason",
-                                        StringComparison.InvariantCultureIgnoreCase) == 0 ||
-                                        string.Compare(messagePropertyInfo.Key, "DeadLetterErrorDescription",
-                                        StringComparison.InvariantCultureIgnoreCase) == 0)
+                                    if (Constants.AlwaysOmittedProperties.Contains(messagePropertyInfo.Key.ToLower()))
                                     {
                                         continue;
                                     }


### PR DESCRIPTION
Fixes #344

When resubmitting several messages in batch mode, properties should be copied when cloning. But when resubmitting only one message, properties should not, because the user can choose what properties he wants to copy through Message Custom Properties GroupBox.

   ![image](https://user-images.githubusercontent.com/3408827/62499629-a7ab6e80-b7e3-11e9-8233-8fa27792750e.png)

So, clone depends on resubmitting one or more messages.
In any case, properties with name "DeadLetterReason", "DeadLetterErrorDescription" and "NServiceBus.Transport.Recovery", should never be copied.

Issue #344 should be solved with this PR.