### PR TITLE
Prevent using an entity-specific connection string

### DIFF
--- a/src/ServiceBusExplorer.Tests/Helpers/ConnectionStringHelperTests.cs
+++ b/src/ServiceBusExplorer.Tests/Helpers/ConnectionStringHelperTests.cs
@@ -1,0 +1,45 @@
+﻿#region Using Directives
+
+using Microsoft.Azure.ServiceBusExplorer.Helpers;
+using NUnit.Framework;
+
+#endregion
+
+namespace Microsoft.Azure.ServiceBusExplorer.Tests.Helpers
+{
+    [TestFixture]
+    public class ConnectionStringHelperTests
+    {
+        [Test]
+        public void IsEntitySpecific_NoEntityPath_ReturnsFalse()
+        {
+            string connectionString = "Endpoint=sb://some-namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=ejfklwejfwlkejfwfflwkejfklwef";
+
+            Assert.IsFalse(ConnectionStringHelper.IsEntitySpecific(connectionString));
+        }
+
+        [Test]
+        public void IsEntitySpecific_EntityPathInTheEnd_ReturnsTrue()
+        {
+            string connectionString = "Endpoint=sb://some-namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=ejfklwejfwlkejfwfflwkejfklwef;EntityPath=loremipsum";
+
+            Assert.IsTrue(ConnectionStringHelper.IsEntitySpecific(connectionString));
+        }
+
+        [Test]
+        public void IsEntitySpecific_EntityPathInTheMiddle_ReturnsFalse()
+        {
+            string connectionString = "Endpoint=sb://some-namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;EntityPath=loremipsum;SharedAccessKey=ejfklwejfwlkejfwfflwkejfklwef";
+
+            Assert.IsTrue(ConnectionStringHelper.IsEntitySpecific(connectionString));
+        }
+
+        [Test]
+        public void IsEntitySpecific_EntityPathInTheBeginning_ReturnsFalse()
+        {
+            string connectionString = "EntityPath=loremipsum;Endpoint=sb://some-namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=ejfklwejfwlkejfwfflwkejfklwef";
+
+            Assert.IsTrue(ConnectionStringHelper.IsEntitySpecific(connectionString));
+        }
+    }
+}

--- a/src/ServiceBusExplorer.Tests/ServiceBusExplorer.Tests.csproj
+++ b/src/ServiceBusExplorer.Tests/ServiceBusExplorer.Tests.csproj
@@ -38,6 +38,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Helpers\ConnectionStringHelperTests.cs" />
     <Compile Include="Helpers\TwoFilesConfigurationTests.cs" />
     <Compile Include="Helpers\ConversionHelperTests.cs" />
     <Compile Include="Helpers\JsonSerializerHelperTest.cs" />

--- a/src/ServiceBusExplorer/Forms/ConnectForm.cs
+++ b/src/ServiceBusExplorer/Forms/ConnectForm.cs
@@ -89,6 +89,11 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
         //***************************
         private const string ConnectionStringCannotBeNull = "The connection string cannot be null.";
 
+        private const string ConnectionStringCannotBeEntitySpecific = "The connection string cannot be entity specific.";
+
+        private const string ConnectionStringCannotBeEntitySpecificDetails = "Please make sure there is no \"EntityPath\" in the connection string. The connection string should be a namespace-level connection string and have the manage permission.";
+
+
         #endregion
 
         #region Private Instance Fields
@@ -239,6 +244,17 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                 if (string.IsNullOrWhiteSpace(ConnectionString))
                 {
                     MainForm.StaticWriteToLog(ConnectionStringCannotBeNull);
+                    return;
+                }
+                if (ConnectionStringHelper.IsEntitySpecific(txtUri.Text))
+                {
+                    MainForm.StaticWriteToLog(ConnectionStringCannotBeEntitySpecific);
+                    MessageBox.Show(
+                        this, 
+                        $"{ConnectionStringCannotBeEntitySpecific}\n\n{ConnectionStringCannotBeEntitySpecificDetails}", 
+                        this.Text,  // reuse title of this window
+                        MessageBoxButtons.OK, 
+                        MessageBoxIcon.Exclamation);
                     return;
                 }
             }
@@ -600,6 +616,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                     MainForm.StaticWriteToLog("The connection string of the Service Bus namespace cannot be null.");
                     return;
                 }
+
                 ServiceBusConnectionStringBuilder serviceBusConnectionStringBuilder;
                 try
                 {
@@ -615,6 +632,18 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                     serviceBusConnectionStringBuilder.Endpoints.Count == 0)
                 {
                     MainForm.StaticWriteToLog("The connection string does not contain any endpoint.");
+                    return;
+                }
+
+                if (serviceBusConnectionStringBuilder.EntityPath != null)
+                {
+                    MainForm.StaticWriteToLog(ConnectionStringCannotBeEntitySpecific);
+                    MessageBox.Show(
+                        this,
+                        $"{ConnectionStringCannotBeEntitySpecific}\n\n{ConnectionStringCannotBeEntitySpecificDetails}",
+                        "Save connection string",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Exclamation);
                     return;
                 }
 

--- a/src/ServiceBusExplorer/Helpers/ConnectionStringHelper.cs
+++ b/src/ServiceBusExplorer/Helpers/ConnectionStringHelper.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.ServiceBusExplorer.Helpers
+{
+    public static class ConnectionStringHelper
+    {
+        private readonly static Regex EntityPathRegex = new Regex(@"(?:^|[^\w])(EntityPath=[^;]+)");
+        
+        public static bool IsEntitySpecific(string connectionString)
+        {
+            return EntityPathRegex.IsMatch(connectionString);
+        }
+    }
+}

--- a/src/ServiceBusExplorer/Helpers/ConnectionStringHelper.cs
+++ b/src/ServiceBusExplorer/Helpers/ConnectionStringHelper.cs
@@ -1,16 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿#region Using Directives
+
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
+
+#endregion
 
 namespace Microsoft.Azure.ServiceBusExplorer.Helpers
 {
     public static class ConnectionStringHelper
     {
         private readonly static Regex EntityPathRegex = new Regex(@"(?:^|[^\w])(EntityPath=[^;]+)");
-        
+
         public static bool IsEntitySpecific(string connectionString)
         {
             return EntityPathRegex.IsMatch(connectionString);

--- a/src/ServiceBusExplorer/ServiceBusExplorer.csproj
+++ b/src/ServiceBusExplorer/ServiceBusExplorer.csproj
@@ -370,6 +370,7 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Helpers\AttributeList.cs" />
     <Compile Include="Helpers\ConfigurationHelper.cs" />
+    <Compile Include="Helpers\ConnectionStringHelper.cs" />
     <Compile Include="Helpers\GitHubReleaseProvider.cs" />
     <Compile Include="Helpers\MainSettings.cs" />
     <Compile Include="Helpers\TwoFilesConfiguration.cs" />


### PR DESCRIPTION
This PR aims to fix #376 

Having run into this issue myself a few times, I decided to fix it.

While in the Save case I opted to reuse the logic provided by the connection string builder there was no such logic in the Ok button handler - the connection string is processed outside the dialog. Because it made sense to show the warning before the dialog is closed and because I did not want to add the builder there, I decided to add a simple regex verification in this case. 