### PR TITLE
Enhance forwards UI experience

### DIFF
--- a/src/Common/Helpers/ServiceBusHelper.cs
+++ b/src/Common/Helpers/ServiceBusHelper.cs
@@ -2289,7 +2289,7 @@ namespace Microsoft.Azure.ServiceBusExplorer
         /// Gets the uri of the deadletter queue for a given queue.
         /// </summary>
         /// <param name="queuePath">The name of a queue.</param>
-        /// <returns>he absolute uri of the deadletter queue.</returns>
+        /// <returns>the absolute uri of the deadletter queue.</returns>
         public Uri GetQueueDeadLetterQueueUri(string queuePath)
         {
             if (IsCloudNamespace)

--- a/src/Common/Helpers/ServiceBusHelper.cs
+++ b/src/Common/Helpers/ServiceBusHelper.cs
@@ -5594,14 +5594,17 @@ namespace Microsoft.Azure.ServiceBusExplorer
             if (Uri.IsWellFormedUriString(address, UriKind.Absolute))
             {
                 var uri = new Uri(address, UriKind.Absolute);
-                var uriRelativeToNamespace = NamespaceUri.MakeRelativeUri(uri);
-                return uriRelativeToNamespace.ToString();
+                if (NamespaceUri.IsBaseOf(uri))
+                {
+                    var uriRelativeToNamespace = NamespaceUri.MakeRelativeUri(uri);
+                    return uriRelativeToNamespace.ToString();
+                }
             }
             int i;
             return !string.IsNullOrWhiteSpace(address) &&
-                   (i = address.IndexOf('/')) > 0 &&
+                   (i = address.LastIndexOf('/', Math.Max(0, address.Length - 2))) > 0 &&
                    i < address.Length - 1 ?
-                address.Substring(address.LastIndexOf('/') + 1) :
+                address.Substring(i + 1) :
                 address;
         }
 

--- a/src/Common/Helpers/ServiceBusHelper.cs
+++ b/src/Common/Helpers/ServiceBusHelper.cs
@@ -5589,6 +5589,22 @@ namespace Microsoft.Azure.ServiceBusExplorer
             return host.Substring(index);
         }
 
+        public string GetAddressRelativeToNamespace(string address)
+        {
+            if (Uri.IsWellFormedUriString(address, UriKind.Absolute))
+            {
+                var uri = new Uri(address, UriKind.Absolute);
+                var uriRelativeToNamespace = NamespaceUri.MakeRelativeUri(uri);
+                return uriRelativeToNamespace.ToString();
+            }
+            int i;
+            return !string.IsNullOrWhiteSpace(address) &&
+                   (i = address.IndexOf('/')) > 0 &&
+                   i < address.Length - 1 ?
+                address.Substring(address.LastIndexOf('/') + 1) :
+                address;
+        }
+
         public ServiceBusHelper2 GetServiceBusHelper2()
         {
             var serviceBusHelper2 = new ServiceBusHelper2();

--- a/src/ServiceBusExplorer.Tests/Helpers/ServiceBusHelperTest.cs
+++ b/src/ServiceBusExplorer.Tests/Helpers/ServiceBusHelperTest.cs
@@ -1,0 +1,113 @@
+﻿#region Using Directives
+
+using NUnit.Framework;
+
+#endregion
+
+namespace Microsoft.Azure.ServiceBusExplorer.Tests.Helpers
+{
+    using System;
+
+    [TestFixture]
+    public class ServiceBusHelperTest
+    {
+        [Test]
+        public void GetAddressRelativeToNamespace_AbsoluteUriUnderNamespace_ReturnsRelativePath()
+        {
+            var helper = new ServiceBusHelper((m, a) => { });
+            helper.NamespaceUri = new Uri("sb://aaa.test.com/");
+
+            Assert.That(helper.GetAddressRelativeToNamespace("sb://aaa.test.com/some/path/segments/name"), Is.EqualTo("some/path/segments/name"));
+        }
+
+        [Test]
+        public void GetAddressRelativeToNamespace_AbsoluteUriUnderNamespaceTrailingSlash_ReturnsRelativePathWithTrailingSlash()
+        {
+            var helper = new ServiceBusHelper((m, a) => { });
+            helper.NamespaceUri = new Uri("sb://aaa.test.com/");
+
+            Assert.That(helper.GetAddressRelativeToNamespace("sb://aaa.test.com/some/path/segments/name/"), Is.EqualTo("some/path/segments/name/"));
+        }
+
+        [Test]
+        public void GetAddressRelativeToNamespace_AbsoluteUriNotUnderNamespace_ReturnsLastSegment()
+        {
+            var helper = new ServiceBusHelper((m, a) => { });
+            helper.NamespaceUri = new Uri("sb://aaa.test.com/");
+
+            Assert.That(helper.GetAddressRelativeToNamespace("sb://bbb.test.com/some/path/segments/name"), Is.EqualTo("name"));
+        }
+
+        [Test]
+        public void GetAddressRelativeToNamespace_AbsoluteUriNotUnderNamespaceTrailingSlash_ReturnsLastSegmentWithTrailingSlash()
+        {
+            var helper = new ServiceBusHelper((m, a) => { });
+            helper.NamespaceUri = new Uri("sb://aaa.test.com/");
+
+            Assert.That(helper.GetAddressRelativeToNamespace("sb://bbb.test.com/some/path/segments/name/"), Is.EqualTo("name/"));
+        }
+
+        [Test]
+        public void GetAddressRelativeToNamespace_RelativeUriWithMultipleSegments_ReturnsLastSegment()
+        {
+            var helper = new ServiceBusHelper((m, a) => { });
+            helper.NamespaceUri = new Uri("sb://aaa.test.com/");
+
+            Assert.That(helper.GetAddressRelativeToNamespace("some/path/segments/name"), Is.EqualTo("name"));
+        }
+
+        [Test]
+        public void GetAddressRelativeToNamespace_RelativeUriWithMultipleSegmentsTrailingSlash_ReturnsLastSegmentWithTrailingSlash()
+        {
+            var helper = new ServiceBusHelper((m, a) => { });
+            helper.NamespaceUri = new Uri("sb://aaa.test.com/");
+
+            Assert.That(helper.GetAddressRelativeToNamespace("some/path/segments/name/"), Is.EqualTo("name/"));
+        }
+
+        [Test]
+        public void GetAddressRelativeToNamespace_RelativeUriWithSingleSegment_ReturnsSegment()
+        {
+            var helper = new ServiceBusHelper((m, a) => { });
+            helper.NamespaceUri = new Uri("sb://aaa.test.com/");
+
+            Assert.That(helper.GetAddressRelativeToNamespace("name"), Is.EqualTo("name"));
+        }
+
+        [Test]
+        public void GetAddressRelativeToNamespace_RelativeUriWithSingleSegmentAndTrailingSlash_ReturnsSegment()
+        {
+            var helper = new ServiceBusHelper((m, a) => { });
+            helper.NamespaceUri = new Uri("sb://aaa.test.com/");
+
+            Assert.That(helper.GetAddressRelativeToNamespace("name/"), Is.EqualTo("name/"));
+        }
+
+        [Test]
+        public void GetAddressRelativeToNamespace_Slash_ReturnsSlash()
+        {
+            var helper = new ServiceBusHelper((m, a) => { });
+            helper.NamespaceUri = new Uri("sb://aaa.test.com/");
+
+            Assert.That(helper.GetAddressRelativeToNamespace("/"), Is.EqualTo("/"));
+        }
+
+        [Test]
+        public void GetAddressRelativeToNamespace_Empty_ReturnsEmpty()
+        {
+            var helper = new ServiceBusHelper((m, a) => { });
+            helper.NamespaceUri = new Uri("sb://aaa.test.com/");
+
+            Assert.That(helper.GetAddressRelativeToNamespace(""), Is.EqualTo(""));
+        }
+
+        [Test]
+        public void GetAddressRelativeToNamespace_Whitespace_ReturnsWhitespace()
+        {
+            var helper = new ServiceBusHelper((m, a) => { });
+            helper.NamespaceUri = new Uri("sb://aaa.test.com/");
+
+            Assert.That(helper.GetAddressRelativeToNamespace("    "), Is.EqualTo("    "));
+        }
+    }
+}

--- a/src/ServiceBusExplorer.Tests/ServiceBusExplorer.Tests.csproj
+++ b/src/ServiceBusExplorer.Tests/ServiceBusExplorer.Tests.csproj
@@ -26,7 +26,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-   <PackageReference Include="WindowsAzure.ServiceBus" Version="6.0.0" />
+    <PackageReference Include="WindowsAzure.ServiceBus" Version="6.0.0" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -40,6 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Helpers\ConnectionStringHelperTests.cs" />
+    <Compile Include="Helpers\ServiceBusHelperTest.cs" />
     <Compile Include="Helpers\TwoFilesConfigurationTests.cs" />
     <Compile Include="Helpers\ConversionHelperTests.cs" />
     <Compile Include="Helpers\JsonSerializerHelperTest.cs" />

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -2865,9 +2865,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
 
         private void btnOpenForwardToForm_Click(object sender, EventArgs e)
         {
-            using (
-                var form = new SelectEntityForm(SelectEntityDialogTitle, SelectEntityGrouperTitle, SelectEntityLabelText)
-            )
+            using (var form = creteSelectEntityFormForPath(txtForwardTo.Text))
             {
                 if (form.ShowDialog() == DialogResult.OK)
                 {
@@ -2878,15 +2876,47 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
 
         private void btnOpenForwardDeadLetteredMessagesToForm_Click(object sender, EventArgs e)
         {
-            using (
-                var form = new SelectEntityForm(SelectEntityDialogTitle, SelectEntityGrouperTitle, SelectEntityLabelText)
-            )
+            using (var form = creteSelectEntityFormForPath(txtForwardDeadLetteredMessagesTo.Text))
             {
                 if (form.ShowDialog() == DialogResult.OK)
                 {
                     txtForwardDeadLetteredMessagesTo.Text = form.Path;
                 }
             }
+        }
+
+        private SelectEntityForm creteSelectEntityFormForPath(string path)
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                QueueDescription queueDescriptionSource = null;
+                try
+                {
+                    queueDescriptionSource = serviceBusHelper.GetQueue(path);
+                }
+                catch (Exception)
+                {
+                    // we might have found a topic, and the sdk will throw with an indistinguishable MessagingException error.
+                }
+                if (queueDescriptionSource != null)
+                {
+                    return new SelectEntityForm(SelectEntityDialogTitle, SelectEntityGrouperTitle, SelectEntityLabelText, queueDescriptionSource);
+                }
+                TopicDescription topicDescriptionSource = null;
+                try
+                {
+                    topicDescriptionSource = serviceBusHelper.GetTopic(path);
+                }
+                catch (Exception)
+                {
+                    // we might have found a queue, and the sdk will throw with an indistinguishable MessagingException error.
+                }
+                if (topicDescriptionSource != null)
+                {
+                    return new SelectEntityForm(SelectEntityDialogTitle, SelectEntityGrouperTitle, SelectEntityLabelText, topicDescriptionSource);
+                }
+            }
+            return new SelectEntityForm(SelectEntityDialogTitle, SelectEntityGrouperTitle, SelectEntityLabelText);
         }
 
         private void listView_DrawColumnHeader(object sender, DrawListViewColumnHeaderEventArgs e)

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -1226,27 +1226,13 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
             // ForwardTo
             if (!string.IsNullOrWhiteSpace(queueDescription.ForwardTo))
             {
-                int i;
-                txtForwardTo.Text = !string.IsNullOrWhiteSpace(queueDescription.ForwardTo) &&
-                                    (i = queueDescription.ForwardTo.IndexOf('/')) > 0 &&
-                                    i < queueDescription.ForwardTo.Length - 1
-                    ? queueDescription.ForwardTo.Substring(queueDescription.ForwardTo.LastIndexOf('/') + 1)
-                    : queueDescription.ForwardTo;
-
+                txtForwardTo.Text = serviceBusHelper.GetAddressRelativeToNamespace(queueDescription.ForwardTo);
             }
 
             // ForwardDeadLetteredMessagesTo
             if (!string.IsNullOrWhiteSpace(queueDescription.ForwardDeadLetteredMessagesTo))
             {
-                int i;
-                txtForwardDeadLetteredMessagesTo.Text =
-                    !string.IsNullOrWhiteSpace(queueDescription.ForwardDeadLetteredMessagesTo) &&
-                    (i = queueDescription.ForwardDeadLetteredMessagesTo.IndexOf('/')) > 0 &&
-                    i < queueDescription.ForwardDeadLetteredMessagesTo.Length - 1
-                        ? queueDescription.ForwardDeadLetteredMessagesTo.Substring(
-                            queueDescription.ForwardDeadLetteredMessagesTo.LastIndexOf('/') + 1)
-                        : queueDescription.ForwardDeadLetteredMessagesTo;
-
+                txtForwardDeadLetteredMessagesTo.Text = serviceBusHelper.GetAddressRelativeToNamespace(queueDescription.ForwardDeadLetteredMessagesTo);
             }
 
             // MaxQueueSizeInBytes

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -1921,7 +1921,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
 
         private void btnOpenForwardToForm_Click(object sender, EventArgs e)
         {
-            using (var form = new SelectEntityForm(SelectEntityDialogTitle, SelectEntityGrouperTitle, SelectEntityLabelText))
+            using (var form = creteSelectEntityFormForPath(txtForwardTo.Text))
             {
                 if (form.ShowDialog() == DialogResult.OK)
                 {
@@ -1932,13 +1932,47 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
 
         private void btnOpenForwardDeadLetteredMessagesToForm_Click(object sender, EventArgs e)
         {
-            using (var form = new SelectEntityForm(SelectEntityDialogTitle, SelectEntityGrouperTitle, SelectEntityLabelText))
+            using (var form = creteSelectEntityFormForPath(txtForwardDeadLetteredMessagesTo.Text))
             {
                 if (form.ShowDialog() == DialogResult.OK)
                 {
                     txtForwardDeadLetteredMessagesTo.Text = form.Path;
                 }
             }
+        }
+
+        private SelectEntityForm creteSelectEntityFormForPath(string path)
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                QueueDescription queueDescriptionSource = null;
+                try
+                {
+                    queueDescriptionSource = serviceBusHelper.GetQueue(path);
+                }
+                catch (Exception)
+                {
+                    // we might have found a topic, and the sdk will throw with an indistinguishable MessagingException error.
+                }
+                if (queueDescriptionSource != null)
+                {
+                    return new SelectEntityForm(SelectEntityDialogTitle, SelectEntityGrouperTitle, SelectEntityLabelText, queueDescriptionSource);
+                }
+                TopicDescription topicDescriptionSource = null;
+                try
+                {
+                    topicDescriptionSource = serviceBusHelper.GetTopic(path);
+                }
+                catch (Exception)
+                {
+                    // we might have found a queue, and the sdk will throw with an indistinguishable MessagingException error.
+                }
+                if (topicDescriptionSource != null)
+                {
+                    return new SelectEntityForm(SelectEntityDialogTitle, SelectEntityGrouperTitle, SelectEntityLabelText, topicDescriptionSource);
+                }
+            }
+            return new SelectEntityForm(SelectEntityDialogTitle, SelectEntityGrouperTitle, SelectEntityLabelText);
         }
 
         private void mainTabControl_DrawItem(object sender, DrawItemEventArgs e)

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -754,6 +754,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
         private void InitializeData()
         {
             // Initialize buttons
+            var forwardTo = subscriptionWrapper.SubscriptionDescription.ForwardTo;
+            var forwardDeadLetteredMessagesTo = subscriptionWrapper.SubscriptionDescription.ForwardDeadLetteredMessagesTo;
             btnCreateDelete.Text = DeleteText;
             btnCancelUpdate.Text = UpdateText;
             btnChangeStatus.Text = subscriptionWrapper.SubscriptionDescription.Status == EntityStatus.Active ? DisableText : EnableText;
@@ -761,8 +763,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
             btnChangeStatus.Visible = true;
             btnMessages.Visible = true;
             btnSessions.Visible = subscriptionWrapper.SubscriptionDescription.RequiresSession;
-            btnMessages.Visible = string.IsNullOrWhiteSpace(subscriptionWrapper.SubscriptionDescription.ForwardTo);
-            btnDeadletter.Visible = string.IsNullOrWhiteSpace(subscriptionWrapper.SubscriptionDescription.ForwardDeadLetteredMessagesTo);
+            btnMessages.Visible = string.IsNullOrWhiteSpace(forwardTo);
+            btnDeadletter.Visible = string.IsNullOrWhiteSpace(forwardDeadLetteredMessagesTo);
 
             if (btnMessages.Visible && !btnSessions.Visible && !buttonsMoved)
             {
@@ -809,25 +811,15 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
             }
 
             // ForwardTo
-            if (!string.IsNullOrWhiteSpace(subscriptionWrapper.SubscriptionDescription.ForwardTo))
+            if (!string.IsNullOrWhiteSpace(forwardTo))
             {
-                int i;
-                txtForwardTo.Text = !string.IsNullOrWhiteSpace(subscriptionWrapper.SubscriptionDescription.ForwardTo) &&
-                                    (i = subscriptionWrapper.SubscriptionDescription.ForwardTo.IndexOf('/')) > 0 &&
-                                    i < subscriptionWrapper.SubscriptionDescription.ForwardTo.Length - 1 ?
-                                    subscriptionWrapper.SubscriptionDescription.ForwardTo.Substring(subscriptionWrapper.SubscriptionDescription.ForwardTo.LastIndexOf('/') + 1) :
-                                    subscriptionWrapper.SubscriptionDescription.ForwardTo;
+                txtForwardTo.Text = serviceBusHelper.GetAddressRelativeToNamespace(forwardTo);
             }
 
             // ForwardDeadLetteredMessagesTo
-            if (!string.IsNullOrWhiteSpace(subscriptionWrapper.SubscriptionDescription.ForwardDeadLetteredMessagesTo))
+            if (!string.IsNullOrWhiteSpace(forwardDeadLetteredMessagesTo))
             {
-                int i;
-                txtForwardDeadLetteredMessagesTo.Text = !string.IsNullOrWhiteSpace(subscriptionWrapper.SubscriptionDescription.ForwardDeadLetteredMessagesTo) &&
-                                    (i = subscriptionWrapper.SubscriptionDescription.ForwardDeadLetteredMessagesTo.IndexOf('/')) > 0 &&
-                                    i < subscriptionWrapper.SubscriptionDescription.ForwardDeadLetteredMessagesTo.Length - 1 ?
-                                    subscriptionWrapper.SubscriptionDescription.ForwardDeadLetteredMessagesTo.Substring(subscriptionWrapper.SubscriptionDescription.ForwardDeadLetteredMessagesTo.LastIndexOf('/') + 1) :
-                                    subscriptionWrapper.SubscriptionDescription.ForwardDeadLetteredMessagesTo;
+                txtForwardDeadLetteredMessagesTo.Text = serviceBusHelper.GetAddressRelativeToNamespace(forwardDeadLetteredMessagesTo);
             }
 
             // MaxDeliveryCount

--- a/src/ServiceBusExplorer/Forms/MessageForm.cs
+++ b/src/ServiceBusExplorer/Forms/MessageForm.cs
@@ -567,7 +567,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             if (subscriptionWrapper != null)
             {
                 return new SelectEntityForm(SelectEntityDialogTitle, SelectEntityGrouperTitle,
-                   SelectEntityLabelText, subscriptionWrapper);
+                   SelectEntityLabelText, subscriptionWrapper.TopicDescription);
             }
 
             return new SelectEntityForm(SelectEntityDialogTitle, SelectEntityGrouperTitle,

--- a/src/ServiceBusExplorer/Forms/SelectEntityForm.cs
+++ b/src/ServiceBusExplorer/Forms/SelectEntityForm.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
         //***************************
         const string QueueEntities = "Queues";
         const string TopicEntities = "Topics";
+        const string FilteredQueueEntities = "Queues (Filtered)";
+        const string FilteredTopicEntities = "Topics (Filtered)";
         const string EventHubEntities = "Event Hubs";
         const string RelayEntities = "Relays";
         const string NotificationHubEntities = "Notification Hubs";
@@ -189,7 +191,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                 {
                     foreach (TreeNode level1Node in rootNode.Nodes)
                     {
-                        if (level1Node.Text == QueueEntities)
+                        if (level1Node.Text == QueueEntities || level1Node.Text == FilteredQueueEntities)
                         {
                             if (FocusNodeIfMatching<QueueDescription>(level1Node, qd => qd.Path, queueDescriptionSource.Path))
                             {
@@ -205,7 +207,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                 {
                     foreach (TreeNode level1Node in rootNode.Nodes)
                     {
-                        if (level1Node.Text == TopicEntities)
+                        if (level1Node.Text == TopicEntities || level1Node.Text == FilteredTopicEntities)
                         {
                             if (FocusNodeIfMatching<TopicDescription>(level1Node, qd => qd.Path, topicDescriptionSource.Path))
                             {

--- a/src/ServiceBusExplorer/Forms/SelectEntityForm.cs
+++ b/src/ServiceBusExplorer/Forms/SelectEntityForm.cs
@@ -157,6 +157,31 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
         #region Event Handlers
         private void SelectEntityForm_Load(object sender, EventArgs e)
         {
+            bool FocusNodeIfMatching<T>(TreeNode treeNode, Func<T, string> getPath, string searchedPath) where T : class
+            {
+                if (treeNode.Tag is T tag)
+                {
+                    if (string.Compare(getPath(tag), searchedPath,
+                            StringComparison.InvariantCultureIgnoreCase) == 0)
+                    {
+                        serviceBusTreeView.HideSelection = false;
+                        serviceBusTreeView.Focus(); // Otherwise the node will be light gray
+                        serviceBusTreeView.SelectedNode = treeNode;
+                        SetTextAndType(treeNode);
+                        return true;
+                    }
+                }
+
+                foreach (TreeNode childNode in treeNode.Nodes)
+                {
+                    if (FocusNodeIfMatching<T>(childNode, getPath, searchedPath))
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
             // Select the queue where it is coming from since that is likely where it will go
             if (queueDescriptionSource != null)
             {
@@ -166,21 +191,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                     {
                         if (level1Node.Text == QueueEntities)
                         {
-                            foreach (TreeNode level2Node in level1Node.Nodes)
+                            if (FocusNodeIfMatching<QueueDescription>(level1Node, qd => qd.Path, queueDescriptionSource.Path))
                             {
-                                var queueTag = level2Node.Tag as QueueDescription;
-                                if (queueTag != null)
-                                {
-                                    if (string.Compare(queueTag.Path, queueDescriptionSource.Path,
-                                        StringComparison.InvariantCultureIgnoreCase) == 0)
-                                    {
-                                        serviceBusTreeView.HideSelection = false;
-                                        serviceBusTreeView.Focus();  // Otherwise the node will be light gray
-                                        serviceBusTreeView.SelectedNode = level2Node;
-                                        SetTextAndType(level2Node);
-                                        return;
-                                    }
-                                }
+                                return;
                             }
                         }
                     }
@@ -194,20 +207,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                     {
                         if (level1Node.Text == TopicEntities)
                         {
-                            foreach (TreeNode level2Node in level1Node.Nodes)
+                            if (FocusNodeIfMatching<TopicDescription>(level1Node, qd => qd.Path, topicDescriptionSource.Path))
                             {
-                                var topicTag = level2Node.Tag as TopicDescription;
-                                if (topicTag != null)
-                                {
-                                    if (topicTag.Path == topicDescriptionSource.Path)
-                                    {
-                                        serviceBusTreeView.HideSelection = false;
-                                        serviceBusTreeView.Focus();  // Otherwise the node will be light gray
-                                        serviceBusTreeView.SelectedNode = level2Node;
-                                        SetTextAndType(level2Node);
-                                        return;
-                                    }
-                                }
+                                return;
                             }
                         }
                     }

--- a/src/ServiceBusExplorer/Forms/SelectEntityForm.cs
+++ b/src/ServiceBusExplorer/Forms/SelectEntityForm.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
         readonly bool includeNotificationHubs;
         readonly bool includeRelays;
         readonly QueueDescription queueDescriptionSource;  // Might be null
-        readonly SubscriptionWrapper subscriptionWrapperSource;  // Might be null
+        readonly TopicDescription topicDescriptionSource;  // Might be null
         #endregion
 
         #region Public Constructor
@@ -138,7 +138,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
         public SelectEntityForm(string dialogTitle,
                        string groupTitle,
                        string labelText,
-                       SubscriptionWrapper subscriptionWrapperSource,
+                       TopicDescription topicDescriptionSource,
                        bool subscriptions = false,
                        bool eventHubs = false,
                        bool notificationHubs = false,
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                            notificationHubs,
                            relays)
         {
-            this.subscriptionWrapperSource = subscriptionWrapperSource;
+            this.topicDescriptionSource = topicDescriptionSource;
         }
         #endregion
 
@@ -186,7 +186,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                     }
                 }
             }
-            else if (subscriptionWrapperSource != null)
+            else if (topicDescriptionSource != null)
             {
                 foreach (TreeNode rootNode in serviceBusTreeView.Nodes)
                 {
@@ -199,7 +199,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                                 var topicTag = level2Node.Tag as TopicDescription;
                                 if (topicTag != null)
                                 {
-                                    if (topicTag.Path == subscriptionWrapperSource.TopicDescription.Path)
+                                    if (topicTag.Path == topicDescriptionSource.Path)
                                     {
                                         serviceBusTreeView.HideSelection = false;
                                         serviceBusTreeView.Focus();  // Otherwise the node will be light gray


### PR DESCRIPTION
Hello,

This PR is a proposal to better handle structured hierarchies of queues and topics when dealing with forwards.
* it exposes the **Path** relative to the namespace for **ForwardTo** and **ForwardDeadLetteredMessagesTo**
* it also ensures that when opening the queue/topic selection box for these auto-forward configuration, if an existing queue or topic is already configured, it will be focused.

I had to fix a bug in the auto focus code of the selection form to allow searching below the second level, which might contain only the part before the last slash in the queue/topic path.

Also note that this last feature will require network access to get the queue or topic from the configured Path. However, as this access will be done only on the opening of the form, I consider this is acceptable compared to the enhanced experience.

# Screenshots
UI showing that ForwardTo displays the whole Path instead of just the name:
![image](https://user-images.githubusercontent.com/8553578/71583121-6e1a2d80-2b0d-11ea-9fc2-83792433539d.png)

Selection UI just after clicking on the ... button. Currently configured queue is displayed:
![image](https://user-images.githubusercontent.com/8553578/71583089-42974300-2b0d-11ea-9e18-e2314cf98c3d.png)
