### PR TITLE
Persist Message Content Type in the settings

### DIFF
--- a/src/Common/Helpers/ConfigurationHelper.cs
+++ b/src/Common/Helpers/ConfigurationHelper.cs
@@ -183,6 +183,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
                 out string messageText, out string messageFile);
             resultProperties.MessageText = messageText;
             resultProperties.MessageFile = messageFile;
+            
+            resultProperties.MessageContentType = configuration.GetStringValue(ConfigurationParameters.MessageContentTypeParameter,
+                string.Empty);
 
             resultProperties.SelectedEntities = ConfigurationHelper.GetSelectedEntities(configuration);
 

--- a/src/Common/Helpers/ConfigurationParameters.cs
+++ b/src/Common/Helpers/ConfigurationParameters.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
         public const string SaveCheckpointsToFileParameter = "saveCheckpointsToFile";
         public const string SchemeParameter = "scheme";
         public const string MessageParameter = "message";
+        public const string MessageContentTypeParameter = "contentType";
         public const string FileParameter = "file";
         public const string LabelParameter = "label";
         public const string RetryCountParameter = "retryCount";

--- a/src/Common/Helpers/MainSettings.cs
+++ b/src/Common/Helpers/MainSettings.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
         public string Label { get; set; }
         public string MessageFile { get; set; }
         public string MessageText { get; set; }
+        public string MessageContentType { get; set; }
 
         public List<string> SelectedEntities { get; set; }
 
@@ -107,6 +108,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
             Label = DefaultLabel;
             MessageFile = string.Empty;
             MessageText = string.Empty;
+            MessageContentType = string.Empty;
             SelectedEntities = ConfigurationHelper.Entities;
 
             MessageBodyType = BodyType.Stream.ToString();
@@ -141,6 +143,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
             if (Label != otherProperties.Label) return false;
             if (MessageFile != otherProperties.MessageFile) return false;
             if (MessageText != otherProperties.MessageText) return false;
+            if (MessageContentType != otherProperties.MessageContentType) return false;
 
             if (!SelectedEntities.SequenceEqual(SelectedEntities)) return false;
 
@@ -227,6 +230,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Helpers
 
                 case ConfigurationParameters.MessageParameter:
                     return MessageText;
+
+                case ConfigurationParameters.MessageContentTypeParameter:
+                    return MessageContentType;
 
                 case ConfigurationParameters.SelectedEntitiesParameter:
                     return SelectedEntities;

--- a/src/ServiceBusExplorer/Controls/TestQueueControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/TestQueueControl.Designer.cs
@@ -431,6 +431,7 @@
             this.txtMessageText.CharWidth = 8;
             this.txtMessageText.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.txtMessageText.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
+            this.txtMessageText.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.txtMessageText.ForeColor = System.Drawing.SystemColors.ControlText;
             this.txtMessageText.IsReplaceMode = false;
             this.txtMessageText.Location = new System.Drawing.Point(16, 32);
@@ -507,9 +508,9 @@
             this.radioButtonXmlTemplate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.radioButtonXmlTemplate.AutoSize = true;
             this.radioButtonXmlTemplate.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.radioButtonXmlTemplate.Location = new System.Drawing.Point(310, 286);
+            this.radioButtonXmlTemplate.Location = new System.Drawing.Point(305, 286);
             this.radioButtonXmlTemplate.Name = "radioButtonXmlTemplate";
-            this.radioButtonXmlTemplate.Size = new System.Drawing.Size(89, 17);
+            this.radioButtonXmlTemplate.Size = new System.Drawing.Size(94, 17);
             this.radioButtonXmlTemplate.TabIndex = 12;
             this.radioButtonXmlTemplate.TabStop = true;
             this.radioButtonXmlTemplate.Text = "XML Template";
@@ -522,7 +523,7 @@
             this.radioButtonJsonTemplate.ForeColor = System.Drawing.SystemColors.ControlText;
             this.radioButtonJsonTemplate.Location = new System.Drawing.Point(192, 286);
             this.radioButtonJsonTemplate.Name = "radioButtonJsonTemplate";
-            this.radioButtonJsonTemplate.Size = new System.Drawing.Size(94, 17);
+            this.radioButtonJsonTemplate.Size = new System.Drawing.Size(100, 17);
             this.radioButtonJsonTemplate.TabIndex = 11;
             this.radioButtonJsonTemplate.TabStop = true;
             this.radioButtonJsonTemplate.Text = "JSON Template";
@@ -564,6 +565,7 @@
             this.nameColumnHeader,
             this.sizeColumnHeader});
             this.messageFileListView.FullRowSelect = true;
+            this.messageFileListView.HideSelection = false;
             this.messageFileListView.Location = new System.Drawing.Point(16, 32);
             this.messageFileListView.Name = "messageFileListView";
             this.messageFileListView.OwnerDraw = true;
@@ -1150,6 +1152,7 @@
             this.txtContentType.Name = "txtContentType";
             this.txtContentType.Size = new System.Drawing.Size(176, 20);
             this.txtContentType.TabIndex = 5;
+            this.txtContentType.TextChanged += new System.EventHandler(this.txtContentType_TextChanged);
             // 
             // txtScheduledEnqueueTimeUtc
             // 

--- a/src/ServiceBusExplorer/Controls/TestQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/TestQueueControl.cs
@@ -2147,18 +2147,12 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
 
         private void txtMessageText_TextChanged(object sender, FastColoredTextBoxNS.TextChangedEventArgs e)
         {
-            if (!string.IsNullOrWhiteSpace(txtMessageText.Text))
-            {
-                mainForm.MessageText = txtMessageText.Text;
-            }
+            mainForm.MessageText = txtMessageText.Text;
         }
 
         private void txtContentType_TextChanged(object sender, EventArgs e)
         {
-            if (!string.IsNullOrWhiteSpace(txtContentType.Text))
-            {
-                mainForm.MessageContentType = txtContentType.Text;
-            }
+            mainForm.MessageContentType = txtContentType.Text;
         }
 
         private void grouperMessageFormat_CustomPaint(PaintEventArgs e)

--- a/src/ServiceBusExplorer/Controls/TestQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/TestQueueControl.cs
@@ -377,6 +377,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                 txtReceiveBatchSize.Text = DefaulReceiveBatchSize;
                 txtSendTaskCount.Text = DefaultSenderTaskCount;
                 txtReceiveTaskCount.Text = DefaultReceiverTaskCount;
+                txtContentType.Text = mainForm.MessageContentType;
                 txtReceiveTimeout.Text = mainForm?.ReceiveTimeout.ToString(CultureInfo.InvariantCulture);
                 txtSessionTimeout.Text = mainForm?.ServerTimeout.ToString(CultureInfo.InvariantCulture);
                 txtPrefetchCount.Text = mainForm?.PrefetchCount.ToString(CultureInfo.InvariantCulture);
@@ -2149,6 +2150,14 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
             if (!string.IsNullOrWhiteSpace(txtMessageText.Text))
             {
                 mainForm.MessageText = txtMessageText.Text;
+            }
+        }
+
+        private void txtContentType_TextChanged(object sender, EventArgs e)
+        {
+            if (!string.IsNullOrWhiteSpace(txtContentType.Text))
+            {
+                mainForm.MessageContentType = txtContentType.Text;
             }
         }
 

--- a/src/ServiceBusExplorer/Controls/TestTopicControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/TestTopicControl.Designer.cs
@@ -1152,6 +1152,7 @@
             this.txtContentType.Name = "txtContentType";
             this.txtContentType.Size = new System.Drawing.Size(176, 20);
             this.txtContentType.TabIndex = 5;
+            this.txtContentType.TextChanged += new System.EventHandler(this.txtContentType_TextChanged);
             // 
             // txtScheduledEnqueueTimeUtc
             // 

--- a/src/ServiceBusExplorer/Controls/TestTopicControl.cs
+++ b/src/ServiceBusExplorer/Controls/TestTopicControl.cs
@@ -2152,18 +2152,12 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
 
         private void txtMessageText_TextChanged(object sender, TextChangedEventArgs e)
         {
-            if (!string.IsNullOrWhiteSpace(txtMessageText.Text))
-            {
-                mainForm.MessageText = txtMessageText.Text;
-            }
+            mainForm.MessageText = txtMessageText.Text;
         }
 
         private void txtContentType_TextChanged(object sender, EventArgs e)
         {
-            if (!string.IsNullOrWhiteSpace(txtContentType.Text))
-            {
-                mainForm.MessageContentType = txtContentType.Text;
-            }
+            mainForm.MessageContentType = txtContentType.Text;
         }
 
         private void grouperMessageFormat_CustomPaint(PaintEventArgs e)

--- a/src/ServiceBusExplorer/Controls/TestTopicControl.cs
+++ b/src/ServiceBusExplorer/Controls/TestTopicControl.cs
@@ -369,6 +369,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
                 txtReceiveBatchSize.Text = DefaulReceiveBatchSize;
                 txtSendTaskCount.Text = DefaultSenderTaskCount;
                 txtReceiveTaskCount.Text = DefaultReceiverTaskCount;
+                txtContentType.Text = mainForm.MessageContentType;
                 txtReceiveTimeout.Text = mainForm?.ReceiveTimeout.ToString(CultureInfo.InvariantCulture);
                 txtServerTimeout.Text = mainForm?.ServerTimeout.ToString(CultureInfo.InvariantCulture);
                 txtPrefetchCount.Text = mainForm?.PrefetchCount.ToString(CultureInfo.InvariantCulture);
@@ -2154,6 +2155,14 @@ namespace Microsoft.Azure.ServiceBusExplorer.Controls
             if (!string.IsNullOrWhiteSpace(txtMessageText.Text))
             {
                 mainForm.MessageText = txtMessageText.Text;
+            }
+        }
+
+        private void txtContentType_TextChanged(object sender, EventArgs e)
+        {
+            if (!string.IsNullOrWhiteSpace(txtContentType.Text))
+            {
+                mainForm.MessageContentType = txtContentType.Text;
             }
         }
 

--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -208,6 +208,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
         private readonly FieldInfo eventClickFieldInfo;
         private readonly PropertyInfo eventsPropertyInfo;
         private string messageText;
+        private string messageContentType;
         private string relayMessageText;
         private string messageFile;
         private string label;
@@ -394,6 +395,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                 Label = label,
                 MessageFile = messageFile,
                 MessageText = messageText,
+                MessageContentType = messageContentType,
 
                 SelectedEntities = selectedEntites,
                 MessageBodyType = messageBodyType,
@@ -449,6 +451,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                 label = optionForm.MainSettings.Label;
                 messageFile = optionForm.MainSettings.MessageFile;
                 messageText = optionForm.MainSettings.MessageText;
+                messageContentType = optionForm.MainSettings.MessageContentType;
 
                 selectedEntites = optionForm.MainSettings.SelectedEntities;
                 messageBodyType = optionForm.MainSettings.MessageBodyType;
@@ -3723,6 +3726,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                 Label = label,
                 MessageFile = messageFile,
                 MessageText = messageText,
+                MessageContentType = messageContentType,
                 SelectedEntities = selectedEntites,
                 MessageBodyType = messageBodyType,
                 ConnectivityMode = ServiceBusHelper.ConnectivityMode
@@ -3798,6 +3802,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             label = readSettings.Label;
 
             messageText = readSettings.MessageText;
+            messageContentType = readSettings.MessageContentType;
             messageFile = readSettings.MessageFile;
 
             selectedEntites = readSettings.SelectedEntities;
@@ -3905,6 +3910,18 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             set
             {
                 messageText = value;
+            }
+        }
+
+        public string MessageContentType
+        {
+            get
+            {
+                return messageContentType;
+            }
+            set
+            {
+                messageContentType = value;
             }
         }
 

--- a/src/ServiceBusExplorer/Forms/OptionForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/OptionForm.Designer.cs
@@ -108,6 +108,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.cboConfigFile = new System.Windows.Forms.ComboBox();
             this.label1 = new System.Windows.Forms.Label();
             this.grouperSettings = new Microsoft.Azure.ServiceBusExplorer.Controls.Grouper();
+            this.lblMessageContentType = new System.Windows.Forms.Label();
+            this.txtMessageContentType = new System.Windows.Forms.TextBox();
             this.cboDefaultMessageBodyType = new System.Windows.Forms.ComboBox();
             this.LabelDefaultMessageBodyType = new System.Windows.Forms.Label();
             this.cboSelectedEntities = new Microsoft.Azure.ServiceBusExplorer.Controls.CheckBoxComboBox();
@@ -141,10 +143,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.btnOk.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnOk.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnOk.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnOk.Location = new System.Drawing.Point(576, 633);
-            this.btnOk.Margin = new System.Windows.Forms.Padding(4);
+            this.btnOk.Location = new System.Drawing.Point(432, 544);
             this.btnOk.Name = "btnOk";
-            this.btnOk.Size = new System.Drawing.Size(96, 30);
+            this.btnOk.Size = new System.Drawing.Size(72, 24);
             this.btnOk.TabIndex = 4;
             this.btnOk.Text = "&OK";
             this.btnOk.UseVisualStyleBackColor = false;
@@ -161,10 +162,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.btnCancel.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCancel.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnCancel.Location = new System.Drawing.Point(681, 633);
-            this.btnCancel.Margin = new System.Windows.Forms.Padding(4);
+            this.btnCancel.Location = new System.Drawing.Point(511, 544);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(96, 30);
+            this.btnCancel.Size = new System.Drawing.Size(72, 24);
             this.btnCancel.TabIndex = 0;
             this.btnCancel.Text = "&Cancel";
             this.btnCancel.UseVisualStyleBackColor = false;
@@ -180,10 +180,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.btnDefault.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnDefault.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnDefault.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnDefault.Location = new System.Drawing.Point(471, 633);
-            this.btnDefault.Margin = new System.Windows.Forms.Padding(4);
+            this.btnDefault.Location = new System.Drawing.Point(353, 544);
             this.btnDefault.Name = "btnDefault";
-            this.btnDefault.Size = new System.Drawing.Size(96, 30);
+            this.btnDefault.Size = new System.Drawing.Size(72, 24);
             this.btnDefault.TabIndex = 3;
             this.btnDefault.Text = "&Default";
             this.btnDefault.UseVisualStyleBackColor = false;
@@ -199,10 +198,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.btnSave.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnSave.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnSave.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnSave.Location = new System.Drawing.Point(366, 633);
-            this.btnSave.Margin = new System.Windows.Forms.Padding(4);
+            this.btnSave.Location = new System.Drawing.Point(274, 544);
             this.btnSave.Name = "btnSave";
-            this.btnSave.Size = new System.Drawing.Size(96, 30);
+            this.btnSave.Size = new System.Drawing.Size(72, 24);
             this.btnSave.TabIndex = 2;
             this.btnSave.Text = "&Save";
             this.btnSave.UseVisualStyleBackColor = false;
@@ -212,10 +210,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblLogFontSize.AutoSize = true;
             this.lblLogFontSize.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblLogFontSize.Location = new System.Drawing.Point(17, 30);
-            this.lblLogFontSize.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblLogFontSize.Location = new System.Drawing.Point(13, 24);
             this.lblLogFontSize.Name = "lblLogFontSize";
-            this.lblLogFontSize.Size = new System.Drawing.Size(99, 17);
+            this.lblLogFontSize.Size = new System.Drawing.Size(75, 13);
             this.lblLogFontSize.TabIndex = 3;
             this.lblLogFontSize.Text = "Log Font Size:";
             // 
@@ -227,10 +224,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             0,
             0,
             131072});
-            this.logNumericUpDown.Location = new System.Drawing.Point(251, 25);
-            this.logNumericUpDown.Margin = new System.Windows.Forms.Padding(4);
+            this.logNumericUpDown.Location = new System.Drawing.Point(188, 20);
             this.logNumericUpDown.Name = "logNumericUpDown";
-            this.logNumericUpDown.Size = new System.Drawing.Size(107, 23);
+            this.logNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.logNumericUpDown.TabIndex = 4;
             this.logNumericUpDown.ValueChanged += new System.EventHandler(this.logNumericUpDown_ValueChanged);
             // 
@@ -238,10 +234,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblTreeViewFontSize.AutoSize = true;
             this.lblTreeViewFontSize.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblTreeViewFontSize.Location = new System.Drawing.Point(17, 69);
-            this.lblTreeViewFontSize.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblTreeViewFontSize.Location = new System.Drawing.Point(13, 56);
             this.lblTreeViewFontSize.Name = "lblTreeViewFontSize";
-            this.lblTreeViewFontSize.Size = new System.Drawing.Size(138, 17);
+            this.lblTreeViewFontSize.Size = new System.Drawing.Size(105, 13);
             this.lblTreeViewFontSize.TabIndex = 7;
             this.lblTreeViewFontSize.Text = "Tree View Font Size:";
             // 
@@ -253,10 +248,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             0,
             0,
             131072});
-            this.treeViewNumericUpDown.Location = new System.Drawing.Point(251, 64);
-            this.treeViewNumericUpDown.Margin = new System.Windows.Forms.Padding(4);
+            this.treeViewNumericUpDown.Location = new System.Drawing.Point(188, 52);
             this.treeViewNumericUpDown.Name = "treeViewNumericUpDown";
-            this.treeViewNumericUpDown.Size = new System.Drawing.Size(107, 23);
+            this.treeViewNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.treeViewNumericUpDown.TabIndex = 8;
             this.treeViewNumericUpDown.ValueChanged += new System.EventHandler(this.treeViewNumericUpDown_ValueChanged);
             // 
@@ -264,24 +258,22 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblRetryCount.AutoSize = true;
             this.lblRetryCount.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblRetryCount.Location = new System.Drawing.Point(17, 109);
-            this.lblRetryCount.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblRetryCount.Location = new System.Drawing.Point(13, 89);
             this.lblRetryCount.Name = "lblRetryCount";
-            this.lblRetryCount.Size = new System.Drawing.Size(87, 17);
+            this.lblRetryCount.Size = new System.Drawing.Size(66, 13);
             this.lblRetryCount.TabIndex = 11;
             this.lblRetryCount.Text = "Retry Count:";
             // 
             // retryCountNumericUpDown
             // 
-            this.retryCountNumericUpDown.Location = new System.Drawing.Point(251, 104);
-            this.retryCountNumericUpDown.Margin = new System.Windows.Forms.Padding(4);
+            this.retryCountNumericUpDown.Location = new System.Drawing.Point(188, 84);
             this.retryCountNumericUpDown.Maximum = new decimal(new int[] {
             1000,
             0,
             0,
             0});
             this.retryCountNumericUpDown.Name = "retryCountNumericUpDown";
-            this.retryCountNumericUpDown.Size = new System.Drawing.Size(107, 23);
+            this.retryCountNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.retryCountNumericUpDown.TabIndex = 12;
             this.retryCountNumericUpDown.ValueChanged += new System.EventHandler(this.retryCountNumericUpDown_ValueChanged);
             // 
@@ -289,10 +281,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblRetryTimeout.AutoSize = true;
             this.lblRetryTimeout.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblRetryTimeout.Location = new System.Drawing.Point(17, 148);
-            this.lblRetryTimeout.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblRetryTimeout.Location = new System.Drawing.Point(13, 120);
             this.lblRetryTimeout.Name = "lblRetryTimeout";
-            this.lblRetryTimeout.Size = new System.Drawing.Size(191, 17);
+            this.lblRetryTimeout.Size = new System.Drawing.Size(141, 13);
             this.lblRetryTimeout.TabIndex = 15;
             this.lblRetryTimeout.Text = "Retry Timeout (milliseconds):";
             // 
@@ -303,15 +294,14 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             0,
             0,
             0});
-            this.retryTimeoutNumericUpDown.Location = new System.Drawing.Point(251, 143);
-            this.retryTimeoutNumericUpDown.Margin = new System.Windows.Forms.Padding(4);
+            this.retryTimeoutNumericUpDown.Location = new System.Drawing.Point(188, 116);
             this.retryTimeoutNumericUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
             0,
             0});
             this.retryTimeoutNumericUpDown.Name = "retryTimeoutNumericUpDown";
-            this.retryTimeoutNumericUpDown.Size = new System.Drawing.Size(107, 23);
+            this.retryTimeoutNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.retryTimeoutNumericUpDown.TabIndex = 16;
             this.retryTimeoutNumericUpDown.ValueChanged += new System.EventHandler(this.retryTimeoutNumericUpDown_ValueChanged);
             // 
@@ -319,10 +309,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblTop.AutoSize = true;
             this.lblTop.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblTop.Location = new System.Drawing.Point(379, 148);
-            this.lblTop.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblTop.Location = new System.Drawing.Point(284, 120);
             this.lblTop.Name = "lblTop";
-            this.lblTop.Size = new System.Drawing.Size(78, 17);
+            this.lblTop.Size = new System.Drawing.Size(60, 13);
             this.lblTop.TabIndex = 17;
             this.lblTop.Text = "Top Count:";
             // 
@@ -333,15 +322,14 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             0,
             0,
             0});
-            this.topNumericUpDown.Location = new System.Drawing.Point(625, 143);
-            this.topNumericUpDown.Margin = new System.Windows.Forms.Padding(4);
+            this.topNumericUpDown.Location = new System.Drawing.Point(469, 116);
             this.topNumericUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
             0,
             0});
             this.topNumericUpDown.Name = "topNumericUpDown";
-            this.topNumericUpDown.Size = new System.Drawing.Size(107, 23);
+            this.topNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.topNumericUpDown.TabIndex = 18;
             this.topNumericUpDown.Value = new decimal(new int[] {
             10,
@@ -354,24 +342,22 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblReceiveTimeout.AutoSize = true;
             this.lblReceiveTimeout.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblReceiveTimeout.Location = new System.Drawing.Point(379, 30);
-            this.lblReceiveTimeout.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblReceiveTimeout.Location = new System.Drawing.Point(284, 24);
             this.lblReceiveTimeout.Name = "lblReceiveTimeout";
-            this.lblReceiveTimeout.Size = new System.Drawing.Size(185, 17);
+            this.lblReceiveTimeout.Size = new System.Drawing.Size(140, 13);
             this.lblReceiveTimeout.TabIndex = 5;
             this.lblReceiveTimeout.Text = "Receive Timeout (seconds):";
             // 
             // receiveTimeoutNumericUpDown
             // 
-            this.receiveTimeoutNumericUpDown.Location = new System.Drawing.Point(625, 25);
-            this.receiveTimeoutNumericUpDown.Margin = new System.Windows.Forms.Padding(4);
+            this.receiveTimeoutNumericUpDown.Location = new System.Drawing.Point(469, 20);
             this.receiveTimeoutNumericUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
             0,
             0});
             this.receiveTimeoutNumericUpDown.Name = "receiveTimeoutNumericUpDown";
-            this.receiveTimeoutNumericUpDown.Size = new System.Drawing.Size(107, 23);
+            this.receiveTimeoutNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.receiveTimeoutNumericUpDown.TabIndex = 6;
             this.receiveTimeoutNumericUpDown.Value = new decimal(new int[] {
             1,
@@ -384,24 +370,22 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblServerTimeout.AutoSize = true;
             this.lblServerTimeout.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblServerTimeout.Location = new System.Drawing.Point(379, 69);
-            this.lblServerTimeout.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblServerTimeout.Location = new System.Drawing.Point(284, 56);
             this.lblServerTimeout.Name = "lblServerTimeout";
-            this.lblServerTimeout.Size = new System.Drawing.Size(176, 17);
+            this.lblServerTimeout.Size = new System.Drawing.Size(131, 13);
             this.lblServerTimeout.TabIndex = 9;
             this.lblServerTimeout.Text = "Server Timeout (seconds):";
             // 
             // serverTimeoutNumericUpDown
             // 
-            this.serverTimeoutNumericUpDown.Location = new System.Drawing.Point(625, 64);
-            this.serverTimeoutNumericUpDown.Margin = new System.Windows.Forms.Padding(4);
+            this.serverTimeoutNumericUpDown.Location = new System.Drawing.Point(469, 52);
             this.serverTimeoutNumericUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
             0,
             0});
             this.serverTimeoutNumericUpDown.Name = "serverTimeoutNumericUpDown";
-            this.serverTimeoutNumericUpDown.Size = new System.Drawing.Size(107, 23);
+            this.serverTimeoutNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.serverTimeoutNumericUpDown.TabIndex = 10;
             this.serverTimeoutNumericUpDown.Value = new decimal(new int[] {
             5,
@@ -414,10 +398,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblPrefetchCount.AutoSize = true;
             this.lblPrefetchCount.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblPrefetchCount.Location = new System.Drawing.Point(379, 109);
-            this.lblPrefetchCount.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblPrefetchCount.Location = new System.Drawing.Point(284, 89);
             this.lblPrefetchCount.Name = "lblPrefetchCount";
-            this.lblPrefetchCount.Size = new System.Drawing.Size(106, 17);
+            this.lblPrefetchCount.Size = new System.Drawing.Size(81, 13);
             this.lblPrefetchCount.TabIndex = 13;
             this.lblPrefetchCount.Text = "Prefetch Count:";
             // 
@@ -427,10 +410,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.saveMessageToFileCheckBox.Checked = true;
             this.saveMessageToFileCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.saveMessageToFileCheckBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.saveMessageToFileCheckBox.Location = new System.Drawing.Point(251, 345);
-            this.saveMessageToFileCheckBox.Margin = new System.Windows.Forms.Padding(4);
+            this.saveMessageToFileCheckBox.Location = new System.Drawing.Point(188, 280);
             this.saveMessageToFileCheckBox.Name = "saveMessageToFileCheckBox";
-            this.saveMessageToFileCheckBox.Size = new System.Drawing.Size(18, 17);
+            this.saveMessageToFileCheckBox.Size = new System.Drawing.Size(15, 14);
             this.saveMessageToFileCheckBox.TabIndex = 35;
             this.saveMessageToFileCheckBox.UseVisualStyleBackColor = true;
             this.saveMessageToFileCheckBox.CheckedChanged += new System.EventHandler(this.saveMessageToFileCheckBox_CheckedChanged);
@@ -442,15 +424,14 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             0,
             0,
             0});
-            this.prefetchCountNumericUpDown.Location = new System.Drawing.Point(625, 104);
-            this.prefetchCountNumericUpDown.Margin = new System.Windows.Forms.Padding(4);
+            this.prefetchCountNumericUpDown.Location = new System.Drawing.Point(469, 84);
             this.prefetchCountNumericUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
             0,
             0});
             this.prefetchCountNumericUpDown.Name = "prefetchCountNumericUpDown";
-            this.prefetchCountNumericUpDown.Size = new System.Drawing.Size(107, 23);
+            this.prefetchCountNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.prefetchCountNumericUpDown.TabIndex = 14;
             this.prefetchCountNumericUpDown.Value = new decimal(new int[] {
             10,
@@ -465,10 +446,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.savePropertiesToFileCheckBox.Checked = true;
             this.savePropertiesToFileCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.savePropertiesToFileCheckBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.savePropertiesToFileCheckBox.Location = new System.Drawing.Point(710, 345);
-            this.savePropertiesToFileCheckBox.Margin = new System.Windows.Forms.Padding(4);
+            this.savePropertiesToFileCheckBox.Location = new System.Drawing.Point(532, 280);
             this.savePropertiesToFileCheckBox.Name = "savePropertiesToFileCheckBox";
-            this.savePropertiesToFileCheckBox.Size = new System.Drawing.Size(18, 17);
+            this.savePropertiesToFileCheckBox.Size = new System.Drawing.Size(15, 14);
             this.savePropertiesToFileCheckBox.TabIndex = 37;
             this.savePropertiesToFileCheckBox.UseVisualStyleBackColor = true;
             this.savePropertiesToFileCheckBox.CheckedChanged += new System.EventHandler(this.savePropertiesToFileCheckBox_CheckedChanged);
@@ -477,10 +457,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblSaveMessageOnExit.AutoSize = true;
             this.lblSaveMessageOnExit.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblSaveMessageOnExit.Location = new System.Drawing.Point(17, 345);
-            this.lblSaveMessageOnExit.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblSaveMessageOnExit.Location = new System.Drawing.Point(13, 280);
             this.lblSaveMessageOnExit.Name = "lblSaveMessageOnExit";
-            this.lblSaveMessageOnExit.Size = new System.Drawing.Size(229, 17);
+            this.lblSaveMessageOnExit.Size = new System.Drawing.Size(174, 13);
             this.lblSaveMessageOnExit.TabIndex = 34;
             this.lblSaveMessageOnExit.Text = "Save Message Body to File on Exit:";
             // 
@@ -488,10 +467,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblSavePropertiesOnExit.AutoSize = true;
             this.lblSavePropertiesOnExit.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblSavePropertiesOnExit.Location = new System.Drawing.Point(379, 345);
-            this.lblSavePropertiesOnExit.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblSavePropertiesOnExit.Location = new System.Drawing.Point(284, 280);
             this.lblSavePropertiesOnExit.Name = "lblSavePropertiesOnExit";
-            this.lblSavePropertiesOnExit.Size = new System.Drawing.Size(262, 17);
+            this.lblSavePropertiesOnExit.Size = new System.Drawing.Size(197, 13);
             this.lblSavePropertiesOnExit.TabIndex = 36;
             this.lblSavePropertiesOnExit.Text = "Save Message Properties to File on Exit:";
             // 
@@ -499,10 +477,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblSenderThinkTime.AutoSize = true;
             this.lblSenderThinkTime.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblSenderThinkTime.Location = new System.Drawing.Point(17, 187);
-            this.lblSenderThinkTime.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblSenderThinkTime.Location = new System.Drawing.Point(13, 152);
             this.lblSenderThinkTime.Name = "lblSenderThinkTime";
-            this.lblSenderThinkTime.Size = new System.Drawing.Size(222, 17);
+            this.lblSenderThinkTime.Size = new System.Drawing.Size(165, 13);
             this.lblSenderThinkTime.TabIndex = 19;
             this.lblSenderThinkTime.Text = "Sender Think Time (milliseconds):";
             // 
@@ -513,15 +490,14 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             0,
             0,
             0});
-            this.senderThinkTimeNumericUpDown.Location = new System.Drawing.Point(251, 182);
-            this.senderThinkTimeNumericUpDown.Margin = new System.Windows.Forms.Padding(4);
+            this.senderThinkTimeNumericUpDown.Location = new System.Drawing.Point(188, 148);
             this.senderThinkTimeNumericUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
             0,
             0});
             this.senderThinkTimeNumericUpDown.Name = "senderThinkTimeNumericUpDown";
-            this.senderThinkTimeNumericUpDown.Size = new System.Drawing.Size(107, 23);
+            this.senderThinkTimeNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.senderThinkTimeNumericUpDown.TabIndex = 20;
             this.senderThinkTimeNumericUpDown.Value = new decimal(new int[] {
             100,
@@ -534,10 +510,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblReceiverThinkTime.AutoSize = true;
             this.lblReceiverThinkTime.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblReceiverThinkTime.Location = new System.Drawing.Point(379, 187);
-            this.lblReceiverThinkTime.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblReceiverThinkTime.Location = new System.Drawing.Point(284, 152);
             this.lblReceiverThinkTime.Name = "lblReceiverThinkTime";
-            this.lblReceiverThinkTime.Size = new System.Drawing.Size(232, 17);
+            this.lblReceiverThinkTime.Size = new System.Drawing.Size(174, 13);
             this.lblReceiverThinkTime.TabIndex = 21;
             this.lblReceiverThinkTime.Text = "Receiver Think Time (milliseconds):";
             // 
@@ -548,15 +523,14 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             0,
             0,
             0});
-            this.receiverThinkTimeNumericUpDown.Location = new System.Drawing.Point(625, 182);
-            this.receiverThinkTimeNumericUpDown.Margin = new System.Windows.Forms.Padding(4);
+            this.receiverThinkTimeNumericUpDown.Location = new System.Drawing.Point(469, 148);
             this.receiverThinkTimeNumericUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
             0,
             0});
             this.receiverThinkTimeNumericUpDown.Name = "receiverThinkTimeNumericUpDown";
-            this.receiverThinkTimeNumericUpDown.Size = new System.Drawing.Size(107, 23);
+            this.receiverThinkTimeNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.receiverThinkTimeNumericUpDown.TabIndex = 22;
             this.receiverThinkTimeNumericUpDown.Value = new decimal(new int[] {
             100,
@@ -569,10 +543,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblLabel.AutoSize = true;
             this.lblLabel.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblLabel.Location = new System.Drawing.Point(17, 385);
-            this.lblLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblLabel.Location = new System.Drawing.Point(13, 314);
             this.lblLabel.Name = "lblLabel";
-            this.lblLabel.Size = new System.Drawing.Size(47, 17);
+            this.lblLabel.Size = new System.Drawing.Size(36, 13);
             this.lblLabel.TabIndex = 38;
             this.lblLabel.Text = "Label:";
             // 
@@ -580,10 +553,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.txtLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtLabel.Location = new System.Drawing.Point(251, 382);
-            this.txtLabel.Margin = new System.Windows.Forms.Padding(4);
+            this.txtLabel.Location = new System.Drawing.Point(188, 310);
             this.txtLabel.Name = "txtLabel";
-            this.txtLabel.Size = new System.Drawing.Size(477, 23);
+            this.txtLabel.Size = new System.Drawing.Size(359, 20);
             this.txtLabel.TabIndex = 39;
             this.txtLabel.TextChanged += new System.EventHandler(this.txtLabel_TextChanged);
             // 
@@ -591,10 +563,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblMessageText.AutoSize = true;
             this.lblMessageText.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblMessageText.Location = new System.Drawing.Point(17, 461);
-            this.lblMessageText.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblMessageText.Location = new System.Drawing.Point(13, 374);
             this.lblMessageText.Name = "lblMessageText";
-            this.lblMessageText.Size = new System.Drawing.Size(100, 17);
+            this.lblMessageText.Size = new System.Drawing.Size(77, 13);
             this.lblMessageText.TabIndex = 42;
             this.lblMessageText.Text = "Message Text:";
             // 
@@ -602,10 +573,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.txtMessageText.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtMessageText.Location = new System.Drawing.Point(251, 456);
-            this.txtMessageText.Margin = new System.Windows.Forms.Padding(4);
+            this.txtMessageText.Location = new System.Drawing.Point(188, 370);
             this.txtMessageText.Name = "txtMessageText";
-            this.txtMessageText.Size = new System.Drawing.Size(425, 23);
+            this.txtMessageText.Size = new System.Drawing.Size(320, 20);
             this.txtMessageText.TabIndex = 43;
             this.txtMessageText.TextChanged += new System.EventHandler(this.txtMessageText_TextChanged);
             // 
@@ -613,10 +583,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblMessageFile.AutoSize = true;
             this.lblMessageFile.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblMessageFile.Location = new System.Drawing.Point(17, 423);
-            this.lblMessageFile.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblMessageFile.Location = new System.Drawing.Point(13, 344);
             this.lblMessageFile.Name = "lblMessageFile";
-            this.lblMessageFile.Size = new System.Drawing.Size(102, 17);
+            this.lblMessageFile.Size = new System.Drawing.Size(78, 13);
             this.lblMessageFile.TabIndex = 40;
             this.lblMessageFile.Text = "Message Path:";
             // 
@@ -624,10 +593,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.txtMessageFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtMessageFile.Location = new System.Drawing.Point(251, 419);
-            this.txtMessageFile.Margin = new System.Windows.Forms.Padding(4);
+            this.txtMessageFile.Location = new System.Drawing.Point(188, 340);
             this.txtMessageFile.Name = "txtMessageFile";
-            this.txtMessageFile.Size = new System.Drawing.Size(477, 23);
+            this.txtMessageFile.Size = new System.Drawing.Size(359, 20);
             this.txtMessageFile.TabIndex = 41;
             this.txtMessageFile.TextChanged += new System.EventHandler(this.txtMessageFile_TextChanged);
             // 
@@ -640,10 +608,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.btnOpen.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnOpen.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnOpen.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnOpen.Location = new System.Drawing.Point(696, 454);
-            this.btnOpen.Margin = new System.Windows.Forms.Padding(4);
+            this.btnOpen.Location = new System.Drawing.Point(522, 369);
             this.btnOpen.Name = "btnOpen";
-            this.btnOpen.Size = new System.Drawing.Size(32, 26);
+            this.btnOpen.Size = new System.Drawing.Size(24, 21);
             this.btnOpen.TabIndex = 44;
             this.btnOpen.Text = "...";
             this.btnOpen.TextAlign = System.Drawing.ContentAlignment.TopCenter;
@@ -656,10 +623,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblMonitorRefreshInterval.AutoSize = true;
             this.lblMonitorRefreshInterval.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblMonitorRefreshInterval.Location = new System.Drawing.Point(17, 227);
-            this.lblMonitorRefreshInterval.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblMonitorRefreshInterval.Location = new System.Drawing.Point(13, 184);
             this.lblMonitorRefreshInterval.Name = "lblMonitorRefreshInterval";
-            this.lblMonitorRefreshInterval.Size = new System.Drawing.Size(230, 17);
+            this.lblMonitorRefreshInterval.Size = new System.Drawing.Size(172, 13);
             this.lblMonitorRefreshInterval.TabIndex = 23;
             this.lblMonitorRefreshInterval.Text = "Monitor Refresh Interval (seconds):";
             // 
@@ -670,15 +636,14 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             0,
             0,
             0});
-            this.monitorRefreshIntervalNumericUpDown.Location = new System.Drawing.Point(251, 222);
-            this.monitorRefreshIntervalNumericUpDown.Margin = new System.Windows.Forms.Padding(4);
+            this.monitorRefreshIntervalNumericUpDown.Location = new System.Drawing.Point(188, 180);
             this.monitorRefreshIntervalNumericUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
             0,
             0});
             this.monitorRefreshIntervalNumericUpDown.Name = "monitorRefreshIntervalNumericUpDown";
-            this.monitorRefreshIntervalNumericUpDown.Size = new System.Drawing.Size(107, 23);
+            this.monitorRefreshIntervalNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.monitorRefreshIntervalNumericUpDown.TabIndex = 24;
             this.monitorRefreshIntervalNumericUpDown.Value = new decimal(new int[] {
             30,
@@ -691,10 +656,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblConnectivityMode.AutoSize = true;
             this.lblConnectivityMode.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblConnectivityMode.Location = new System.Drawing.Point(379, 227);
-            this.lblConnectivityMode.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblConnectivityMode.Location = new System.Drawing.Point(284, 184);
             this.lblConnectivityMode.Name = "lblConnectivityMode";
-            this.lblConnectivityMode.Size = new System.Drawing.Size(127, 17);
+            this.lblConnectivityMode.Size = new System.Drawing.Size(98, 13);
             this.lblConnectivityMode.TabIndex = 25;
             this.lblConnectivityMode.Text = "Connectivity Mode:";
             // 
@@ -703,10 +667,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.cboConnectivityMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboConnectivityMode.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cboConnectivityMode.FormattingEnabled = true;
-            this.cboConnectivityMode.Location = new System.Drawing.Point(625, 222);
-            this.cboConnectivityMode.Margin = new System.Windows.Forms.Padding(4);
+            this.cboConnectivityMode.Location = new System.Drawing.Point(469, 180);
             this.cboConnectivityMode.Name = "cboConnectivityMode";
-            this.cboConnectivityMode.Size = new System.Drawing.Size(105, 25);
+            this.cboConnectivityMode.Size = new System.Drawing.Size(80, 21);
             this.cboConnectivityMode.TabIndex = 26;
             this.cboConnectivityMode.SelectedIndexChanged += new System.EventHandler(this.cboConnectivityMode_SelectedIndexChanged);
             // 
@@ -721,10 +684,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             "UTF8",
             "UTF32",
             "Unicode"});
-            this.cboEncodingType.Location = new System.Drawing.Point(625, 261);
-            this.cboEncodingType.Margin = new System.Windows.Forms.Padding(4);
+            this.cboEncodingType.Location = new System.Drawing.Point(469, 212);
             this.cboEncodingType.Name = "cboEncodingType";
-            this.cboEncodingType.Size = new System.Drawing.Size(105, 25);
+            this.cboEncodingType.Size = new System.Drawing.Size(80, 21);
             this.cboEncodingType.TabIndex = 30;
             this.cboEncodingType.SelectedIndexChanged += new System.EventHandler(this.cboEncoding_SelectedIndexChanged);
             // 
@@ -732,10 +694,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblEncoding.AutoSize = true;
             this.lblEncoding.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblEncoding.Location = new System.Drawing.Point(379, 266);
-            this.lblEncoding.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblEncoding.Location = new System.Drawing.Point(284, 216);
             this.lblEncoding.Name = "lblEncoding";
-            this.lblEncoding.Size = new System.Drawing.Size(71, 17);
+            this.lblEncoding.Size = new System.Drawing.Size(55, 13);
             this.lblEncoding.TabIndex = 29;
             this.lblEncoding.Text = "Encoding:";
             // 
@@ -745,10 +706,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.showMessageCountCheckBox.Checked = true;
             this.showMessageCountCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.showMessageCountCheckBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.showMessageCountCheckBox.Location = new System.Drawing.Point(251, 306);
-            this.showMessageCountCheckBox.Margin = new System.Windows.Forms.Padding(4);
+            this.showMessageCountCheckBox.Location = new System.Drawing.Point(188, 249);
             this.showMessageCountCheckBox.Name = "showMessageCountCheckBox";
-            this.showMessageCountCheckBox.Size = new System.Drawing.Size(18, 17);
+            this.showMessageCountCheckBox.Size = new System.Drawing.Size(15, 14);
             this.showMessageCountCheckBox.TabIndex = 32;
             this.showMessageCountCheckBox.UseVisualStyleBackColor = true;
             this.showMessageCountCheckBox.CheckedChanged += new System.EventHandler(this.showMessageCountCheckBox_CheckedChanged);
@@ -757,10 +717,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblShowMessageCount.AutoSize = true;
             this.lblShowMessageCount.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblShowMessageCount.Location = new System.Drawing.Point(17, 305);
-            this.lblShowMessageCount.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblShowMessageCount.Location = new System.Drawing.Point(13, 248);
             this.lblShowMessageCount.Name = "lblShowMessageCount";
-            this.lblShowMessageCount.Size = new System.Drawing.Size(148, 17);
+            this.lblShowMessageCount.Size = new System.Drawing.Size(114, 13);
             this.lblShowMessageCount.TabIndex = 31;
             this.lblShowMessageCount.Text = "Show Message Count:";
             // 
@@ -768,11 +727,10 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblSelectedEntities.AutoSize = true;
             this.lblSelectedEntities.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblSelectedEntities.Location = new System.Drawing.Point(17, 499);
-            this.lblSelectedEntities.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblSelectedEntities.Location = new System.Drawing.Point(13, 435);
             this.lblSelectedEntities.Name = "lblSelectedEntities";
-            this.lblSelectedEntities.Size = new System.Drawing.Size(117, 17);
-            this.lblSelectedEntities.TabIndex = 45;
+            this.lblSelectedEntities.Size = new System.Drawing.Size(89, 13);
+            this.lblSelectedEntities.TabIndex = 47;
             this.lblSelectedEntities.Text = "Selected Entities:";
             // 
             // saveCheckpointsToFileCheckBox
@@ -781,10 +739,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.saveCheckpointsToFileCheckBox.Checked = true;
             this.saveCheckpointsToFileCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.saveCheckpointsToFileCheckBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.saveCheckpointsToFileCheckBox.Location = new System.Drawing.Point(710, 306);
-            this.saveCheckpointsToFileCheckBox.Margin = new System.Windows.Forms.Padding(4);
+            this.saveCheckpointsToFileCheckBox.Location = new System.Drawing.Point(532, 249);
             this.saveCheckpointsToFileCheckBox.Name = "saveCheckpointsToFileCheckBox";
-            this.saveCheckpointsToFileCheckBox.Size = new System.Drawing.Size(18, 17);
+            this.saveCheckpointsToFileCheckBox.Size = new System.Drawing.Size(15, 14);
             this.saveCheckpointsToFileCheckBox.TabIndex = 33;
             this.saveCheckpointsToFileCheckBox.UseVisualStyleBackColor = true;
             this.saveCheckpointsToFileCheckBox.CheckedChanged += new System.EventHandler(this.saveCheckpointsToFileCheckBox_CheckedChanged);
@@ -793,10 +750,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblSaveCheckpointsOnExit.AutoSize = true;
             this.lblSaveCheckpointsOnExit.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblSaveCheckpointsOnExit.Location = new System.Drawing.Point(379, 306);
-            this.lblSaveCheckpointsOnExit.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblSaveCheckpointsOnExit.Location = new System.Drawing.Point(284, 249);
             this.lblSaveCheckpointsOnExit.Name = "lblSaveCheckpointsOnExit";
-            this.lblSaveCheckpointsOnExit.Size = new System.Drawing.Size(297, 17);
+            this.lblSaveCheckpointsOnExit.Size = new System.Drawing.Size(227, 13);
             this.lblSaveCheckpointsOnExit.TabIndex = 33;
             this.lblSaveCheckpointsOnExit.Text = "Save Event Hub Partition Checkpoints on Exit:";
             // 
@@ -804,10 +760,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             this.lblUseAscii.AutoSize = true;
             this.lblUseAscii.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblUseAscii.Location = new System.Drawing.Point(17, 266);
-            this.lblUseAscii.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblUseAscii.Location = new System.Drawing.Point(13, 216);
             this.lblUseAscii.Name = "lblUseAscii";
-            this.lblUseAscii.Size = new System.Drawing.Size(74, 17);
+            this.lblUseAscii.Size = new System.Drawing.Size(59, 13);
             this.lblUseAscii.TabIndex = 27;
             this.lblUseAscii.Text = "Use ASCII:";
             // 
@@ -817,10 +772,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.useAsciiCheckBox.Checked = true;
             this.useAsciiCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.useAsciiCheckBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.useAsciiCheckBox.Location = new System.Drawing.Point(251, 266);
-            this.useAsciiCheckBox.Margin = new System.Windows.Forms.Padding(4);
+            this.useAsciiCheckBox.Location = new System.Drawing.Point(188, 216);
             this.useAsciiCheckBox.Name = "useAsciiCheckBox";
-            this.useAsciiCheckBox.Size = new System.Drawing.Size(18, 17);
+            this.useAsciiCheckBox.Size = new System.Drawing.Size(15, 14);
             this.useAsciiCheckBox.TabIndex = 28;
             this.useAsciiCheckBox.UseVisualStyleBackColor = true;
             this.useAsciiCheckBox.CheckedChanged += new System.EventHandler(this.useAscii_CheckedChanged);
@@ -835,10 +789,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.mainPanel.Controls.Add(this.cboConfigFile);
             this.mainPanel.Controls.Add(this.label1);
             this.mainPanel.Controls.Add(this.grouperSettings);
-            this.mainPanel.Location = new System.Drawing.Point(9, 0);
-            this.mainPanel.Margin = new System.Windows.Forms.Padding(4);
+            this.mainPanel.Location = new System.Drawing.Point(7, 0);
             this.mainPanel.Name = "mainPanel";
-            this.mainPanel.Size = new System.Drawing.Size(779, 625);
+            this.mainPanel.Size = new System.Drawing.Size(584, 538);
             this.mainPanel.TabIndex = 1;
             this.mainPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.mainPanel_Paint);
             // 
@@ -852,10 +805,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.btnOpenConfig.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnOpenConfig.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnOpenConfig.ImageAlign = System.Drawing.ContentAlignment.TopRight;
-            this.btnOpenConfig.Location = new System.Drawing.Point(648, 11);
-            this.btnOpenConfig.Margin = new System.Windows.Forms.Padding(4);
+            this.btnOpenConfig.Location = new System.Drawing.Point(486, 9);
             this.btnOpenConfig.Name = "btnOpenConfig";
-            this.btnOpenConfig.Size = new System.Drawing.Size(96, 30);
+            this.btnOpenConfig.Size = new System.Drawing.Size(72, 24);
             this.btnOpenConfig.TabIndex = 2;
             this.btnOpenConfig.Text = "O&pen";
             this.btnOpenConfig.UseVisualStyleBackColor = false;
@@ -867,20 +819,18 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.cboConfigFile.DropDownWidth = 156;
             this.cboConfigFile.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cboConfigFile.FormattingEnabled = true;
-            this.cboConfigFile.Location = new System.Drawing.Point(361, 12);
-            this.cboConfigFile.Margin = new System.Windows.Forms.Padding(4);
+            this.cboConfigFile.Location = new System.Drawing.Point(271, 10);
             this.cboConfigFile.Name = "cboConfigFile";
-            this.cboConfigFile.Size = new System.Drawing.Size(262, 24);
+            this.cboConfigFile.Size = new System.Drawing.Size(198, 21);
             this.cboConfigFile.TabIndex = 1;
             this.cboConfigFile.SelectionChangeCommitted += new System.EventHandler(this.cboConfigFile_SelectionChangeCommitted);
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(9, 16);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(7, 13);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(349, 17);
+            this.label1.Size = new System.Drawing.Size(260, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Configuration File for Settings and Connection Strings:";
             // 
@@ -891,6 +841,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.grouperSettings.BackgroundGradientMode = Microsoft.Azure.ServiceBusExplorer.Controls.Grouper.GroupBoxGradientMode.None;
             this.grouperSettings.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.grouperSettings.BorderThickness = 1F;
+            this.grouperSettings.Controls.Add(this.lblMessageContentType);
+            this.grouperSettings.Controls.Add(this.txtMessageContentType);
             this.grouperSettings.Controls.Add(this.cboDefaultMessageBodyType);
             this.grouperSettings.Controls.Add(this.LabelDefaultMessageBodyType);
             this.grouperSettings.Controls.Add(this.useAsciiCheckBox);
@@ -943,17 +895,36 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.grouperSettings.ForeColor = System.Drawing.Color.White;
             this.grouperSettings.GroupImage = null;
             this.grouperSettings.GroupTitle = "Settings";
-            this.grouperSettings.Location = new System.Drawing.Point(12, 49);
-            this.grouperSettings.Margin = new System.Windows.Forms.Padding(4);
+            this.grouperSettings.Location = new System.Drawing.Point(9, 40);
             this.grouperSettings.Name = "grouperSettings";
-            this.grouperSettings.Padding = new System.Windows.Forms.Padding(27, 25, 27, 25);
+            this.grouperSettings.Padding = new System.Windows.Forms.Padding(20);
             this.grouperSettings.PaintGroupBox = true;
             this.grouperSettings.RoundCorners = 4;
             this.grouperSettings.ShadowColor = System.Drawing.Color.DarkGray;
             this.grouperSettings.ShadowControl = false;
             this.grouperSettings.ShadowThickness = 1;
-            this.grouperSettings.Size = new System.Drawing.Size(755, 569);
+            this.grouperSettings.Size = new System.Drawing.Size(566, 492);
             this.grouperSettings.TabIndex = 50;
+            // 
+            // lblMessageContentType
+            // 
+            this.lblMessageContentType.AutoSize = true;
+            this.lblMessageContentType.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.lblMessageContentType.Location = new System.Drawing.Point(13, 404);
+            this.lblMessageContentType.Name = "lblMessageContentType";
+            this.lblMessageContentType.Size = new System.Drawing.Size(120, 13);
+            this.lblMessageContentType.TabIndex = 45;
+            this.lblMessageContentType.Text = "Message Content Type:";
+            // 
+            // txtMessageContentType
+            // 
+            this.txtMessageContentType.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtMessageContentType.Location = new System.Drawing.Point(188, 400);
+            this.txtMessageContentType.Name = "txtMessageContentType";
+            this.txtMessageContentType.Size = new System.Drawing.Size(359, 20);
+            this.txtMessageContentType.TabIndex = 46;
+            this.txtMessageContentType.TextChanged += new System.EventHandler(this.txtMessageContentType_TextChanged);
             // 
             // cboDefaultMessageBodyType
             // 
@@ -965,22 +936,20 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             "Stream",
             "String",
             "WCF"});
-            this.cboDefaultMessageBodyType.Location = new System.Drawing.Point(251, 532);
-            this.cboDefaultMessageBodyType.Margin = new System.Windows.Forms.Padding(4);
+            this.cboDefaultMessageBodyType.Location = new System.Drawing.Point(188, 462);
             this.cboDefaultMessageBodyType.Name = "cboDefaultMessageBodyType";
-            this.cboDefaultMessageBodyType.Size = new System.Drawing.Size(479, 25);
-            this.cboDefaultMessageBodyType.TabIndex = 48;
+            this.cboDefaultMessageBodyType.Size = new System.Drawing.Size(360, 21);
+            this.cboDefaultMessageBodyType.TabIndex = 50;
             this.cboDefaultMessageBodyType.SelectedIndexChanged += new System.EventHandler(this.cboDefaultMessageBodyType_SelectedIndexChanged);
             // 
             // LabelDefaultMessageBodyType
             // 
             this.LabelDefaultMessageBodyType.AutoSize = true;
             this.LabelDefaultMessageBodyType.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.LabelDefaultMessageBodyType.Location = new System.Drawing.Point(15, 537);
-            this.LabelDefaultMessageBodyType.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.LabelDefaultMessageBodyType.Location = new System.Drawing.Point(11, 466);
             this.LabelDefaultMessageBodyType.Name = "LabelDefaultMessageBodyType";
-            this.LabelDefaultMessageBodyType.Size = new System.Drawing.Size(184, 17);
-            this.LabelDefaultMessageBodyType.TabIndex = 47;
+            this.LabelDefaultMessageBodyType.Size = new System.Drawing.Size(138, 13);
+            this.LabelDefaultMessageBodyType.TabIndex = 49;
             this.LabelDefaultMessageBodyType.Text = "Default message body type:";
             // 
             // cboSelectedEntities
@@ -991,11 +960,10 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.cboSelectedEntities.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboSelectedEntities.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cboSelectedEntities.FormattingEnabled = true;
-            this.cboSelectedEntities.Location = new System.Drawing.Point(251, 493);
-            this.cboSelectedEntities.Margin = new System.Windows.Forms.Padding(4);
+            this.cboSelectedEntities.Location = new System.Drawing.Point(188, 431);
             this.cboSelectedEntities.Name = "cboSelectedEntities";
-            this.cboSelectedEntities.Size = new System.Drawing.Size(479, 25);
-            this.cboSelectedEntities.TabIndex = 46;
+            this.cboSelectedEntities.Size = new System.Drawing.Size(360, 21);
+            this.cboSelectedEntities.TabIndex = 48;
             // 
             // groupBox1
             // 
@@ -1017,7 +985,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.numericUpDown1.Location = new System.Drawing.Point(441, 273);
             this.numericUpDown1.Margin = new System.Windows.Forms.Padding(4);
             this.numericUpDown1.Name = "numericUpDown1";
-            this.numericUpDown1.Size = new System.Drawing.Size(107, 22);
+            this.numericUpDown1.Size = new System.Drawing.Size(107, 20);
             this.numericUpDown1.TabIndex = 51;
             // 
             // label2
@@ -1041,7 +1009,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.numericUpDown2.Location = new System.Drawing.Point(278, 31);
             this.numericUpDown2.Margin = new System.Windows.Forms.Padding(4);
             this.numericUpDown2.Name = "numericUpDown2";
-            this.numericUpDown2.Size = new System.Drawing.Size(107, 22);
+            this.numericUpDown2.Size = new System.Drawing.Size(107, 20);
             this.numericUpDown2.TabIndex = 53;
             // 
             // label3
@@ -1057,11 +1025,11 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // OptionForm
             // 
             this.AcceptButton = this.btnOk;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(801, 674);
+            this.ClientSize = new System.Drawing.Size(601, 578);
             this.Controls.Add(this.btnSave);
             this.Controls.Add(this.btnDefault);
             this.Controls.Add(this.btnCancel);
@@ -1070,7 +1038,6 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.KeyPreview = true;
-            this.Margin = new System.Windows.Forms.Padding(4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "OptionForm";
@@ -1161,5 +1128,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.NumericUpDown numericUpDown1;
         private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label lblMessageContentType;
+        private System.Windows.Forms.TextBox txtMessageContentType;
     }
 }

--- a/src/ServiceBusExplorer/Forms/OptionForm.cs
+++ b/src/ServiceBusExplorer/Forms/OptionForm.cs
@@ -298,6 +298,11 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             MainSettings.MessageText = txtMessageText.Text;
         }
 
+        void txtMessageContentType_TextChanged(object sender, EventArgs e)
+        {
+            MainSettings.MessageContentType = txtMessageContentType.Text;
+        }
+
         void cboConnectivityMode_SelectedIndexChanged(object sender, EventArgs e)
         {
             if (Enum.TryParse<ConnectivityMode>(cboConnectivityMode.Text, true, out var connectivityMode))
@@ -522,6 +527,8 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
                 MainSettings.MessageText);
             SaveSetting(configuration, readSettings, ConfigurationParameters.FileParameter,
                 MainSettings.MessageFile);
+            SaveSetting(configuration, readSettings, ConfigurationParameters.MessageContentTypeParameter,
+                MainSettings.MessageContentType);
 
             SaveSetting(configuration, readSettings, ConfigurationParameters.ConnectivityMode,
                 MainSettings.ConnectivityMode);
@@ -575,6 +582,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             txtLabel.Text = mainSettings.Label;
             txtMessageFile.Text = mainSettings.MessageFile;
             txtMessageText.Text = mainSettings.MessageText;
+            txtMessageContentType.Text = mainSettings.MessageContentType;
             logNumericUpDown.Value = mainSettings.LogFontSize;
             treeViewNumericUpDown.Value = mainSettings.TreeViewFontSize;
             retryCountNumericUpDown.Value = mainSettings.RetryCount;


### PR DESCRIPTION
This PR ensures that the Content Type configured for sending message is part of the options, and will be persisted.

The rationale behind this proposal is that it is very useful for people working with systems or libraries that require specific content type to allow retaining it across executions of the tool.

An example which is very frequent for my company is to set the @MassTransit  `application/vnd.masstransit+json` content type when sending messages manually, so that the library can consume them. It would save a lot of time to be able to have the tool retain it!

# Screenshots
The new Options UI:
![image](https://user-images.githubusercontent.com/8553578/71583445-c0a81980-2b0e-11ea-83a5-a8adf986deb2.png)

The Send Message UI after doing this configuration:
![image](https://user-images.githubusercontent.com/8553578/71583519-1ed4fc80-2b0f-11ea-999a-ec299d20849c.png)

