### PR TITLE
Added prefix ServiceBusExplorer. to assembly names

### DIFF
--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{DE07DBEB-D772-49BA-BCEB-A7CE29308AE3}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Common</RootNamespace>
-    <AssemblyName>Common</AssemblyName>
+    <RootNamespace>ServiceBusExplorer.Common</RootNamespace>
+    <AssemblyName>ServiceBusExplorer.Common</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>

--- a/src/EventHubs/EventHubs.csproj
+++ b/src/EventHubs/EventHubs.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
+    <AssemblyName>ServiceBusExplorer.EventHubs</AssemblyName>
+    <RootNamespace>ServiceBusExplorer.EventHubs</RootNamespace>
   </PropertyGroup>
 
 

--- a/src/NotificationHubs/NotificationHubs.csproj
+++ b/src/NotificationHubs/NotificationHubs.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{E836C914-9BFE-4C1C-96E5-6A414CDEF485}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>NotificationHubs</RootNamespace>
-    <AssemblyName>NotificationHubs</AssemblyName>
+    <RootNamespace>ServiceBusExplorer.NotificationHubs</RootNamespace>
+    <AssemblyName>ServiceBusExplorer.NotificationHubs</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>

--- a/src/Relay/Relay.csproj
+++ b/src/Relay/Relay.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
+    <AssemblyName>ServiceBusExplorer.Relay</AssemblyName>
   </PropertyGroup>
 
 

--- a/src/ServiceBus/ServiceBus.csproj
+++ b/src/ServiceBus/ServiceBus.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
+    <AssemblyName>ServiceBusExplorer.ServiceBus</AssemblyName>
   </PropertyGroup>
 
 

--- a/src/ServiceBusExplorer.Tests/ServiceBusExplorer.Tests.csproj
+++ b/src/ServiceBusExplorer.Tests/ServiceBusExplorer.Tests.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{41D3C27D-37FF-43B8-AAC0-4F483E507698}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Microsoft.Azure.ServiceBusExplorer.Tests</RootNamespace>
-    <AssemblyName>Microsoft.Azure.ServiceBusExplorer.Tests</AssemblyName>
+    <RootNamespace>ServiceBusExplorer.Tests</RootNamespace>
+    <AssemblyName>ServiceBusExplorer.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />

--- a/src/ServiceBusExplorer/Properties/Settings.Designer.cs
+++ b/src/ServiceBusExplorer/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.2.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/src/Utilities/Utilities.csproj
+++ b/src/Utilities/Utilities.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>ServiceBusExplorer.Utilities</PackageId>
     <LangVersion>7.3</LangVersion>
+    <AssemblyName>ServiceBusExplorer.Utilities</AssemblyName>
+    <RootNamespace>ServiceBusExplorer.Utilities</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #404

The test assembly was renamed too.

Did the same for the default namespaces.

