### PR TITLE
Change Options form buttons

### DIFF
--- a/src/ServiceBusExplorer/Forms/OptionForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/OptionForm.Designer.cs
@@ -58,7 +58,7 @@ namespace ServiceBusExplorer.Forms
             this.btnOk = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
             this.btnReset = new System.Windows.Forms.Button();
-            this.btnApply = new System.Windows.Forms.Button();
+            this.btnSave = new System.Windows.Forms.Button();
             this.lblLogFontSize = new System.Windows.Forms.Label();
             this.logNumericUpDown = new System.Windows.Forms.NumericUpDown();
             this.lblTreeViewFontSize = new System.Windows.Forms.Label();
@@ -193,19 +193,19 @@ namespace ServiceBusExplorer.Forms
             // 
             // btnApply
             // 
-            this.btnApply.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnApply.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
-            this.btnApply.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnApply.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnApply.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnApply.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnApply.Location = new System.Drawing.Point(435, 544);
-            this.btnApply.Name = "btnApply";
-            this.btnApply.Size = new System.Drawing.Size(72, 24);
-            this.btnApply.TabIndex = 2;
-            this.btnApply.Text = "&Apply";
-            this.btnApply.UseVisualStyleBackColor = false;
-            this.btnApply.Click += new System.EventHandler(this.btnApply_Click);
+            this.btnSave.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnSave.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
+            this.btnSave.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnSave.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnSave.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnSave.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnSave.Location = new System.Drawing.Point(435, 544);
+            this.btnSave.Name = "btnSave";
+            this.btnSave.Size = new System.Drawing.Size(72, 24);
+            this.btnSave.TabIndex = 2;
+            this.btnSave.Text = "&Save";
+            this.btnSave.UseVisualStyleBackColor = false;
+            this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
             // 
             // lblLogFontSize
             // 
@@ -1031,7 +1031,7 @@ namespace ServiceBusExplorer.Forms
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
             this.CancelButton = this.btnCancel;
             this.ClientSize = new System.Drawing.Size(601, 578);
-            this.Controls.Add(this.btnApply);
+            this.Controls.Add(this.btnSave);
             this.Controls.Add(this.btnReset);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnOk);
@@ -1071,7 +1071,7 @@ namespace ServiceBusExplorer.Forms
         private System.Windows.Forms.Button btnOk;
         private System.Windows.Forms.Button btnCancel;
         private System.Windows.Forms.Button btnReset;
-        private System.Windows.Forms.Button btnApply;
+        private System.Windows.Forms.Button btnSave;
         private System.Windows.Forms.Label lblLogFontSize;
         private System.Windows.Forms.NumericUpDown logNumericUpDown;
         private System.Windows.Forms.Label lblTreeViewFontSize;

--- a/src/ServiceBusExplorer/Forms/OptionForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/OptionForm.Designer.cs
@@ -57,8 +57,8 @@ namespace ServiceBusExplorer.Forms
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(OptionForm));
             this.btnOk = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
-            this.btnDefault = new System.Windows.Forms.Button();
-            this.btnSave = new System.Windows.Forms.Button();
+            this.btnReset = new System.Windows.Forms.Button();
+            this.btnApply = new System.Windows.Forms.Button();
             this.lblLogFontSize = new System.Windows.Forms.Label();
             this.logNumericUpDown = new System.Windows.Forms.NumericUpDown();
             this.lblTreeViewFontSize = new System.Windows.Forms.Label();
@@ -143,7 +143,7 @@ namespace ServiceBusExplorer.Forms
             this.btnOk.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnOk.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnOk.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnOk.Location = new System.Drawing.Point(432, 544);
+            this.btnOk.Location = new System.Drawing.Point(275, 544);
             this.btnOk.Name = "btnOk";
             this.btnOk.Size = new System.Drawing.Size(72, 24);
             this.btnOk.TabIndex = 4;
@@ -157,12 +157,13 @@ namespace ServiceBusExplorer.Forms
             // 
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnCancel.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
+            this.btnCancel.CausesValidation = false;
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.btnCancel.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCancel.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCancel.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnCancel.Location = new System.Drawing.Point(511, 544);
+            this.btnCancel.Location = new System.Drawing.Point(355, 544);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(72, 24);
             this.btnCancel.TabIndex = 0;
@@ -172,39 +173,39 @@ namespace ServiceBusExplorer.Forms
             this.btnCancel.MouseEnter += new System.EventHandler(this.button_MouseEnter);
             this.btnCancel.MouseLeave += new System.EventHandler(this.button_MouseLeave);
             // 
-            // btnDefault
+            // btnReset
             // 
-            this.btnDefault.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnDefault.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
-            this.btnDefault.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnDefault.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnDefault.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnDefault.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnDefault.Location = new System.Drawing.Point(353, 544);
-            this.btnDefault.Name = "btnDefault";
-            this.btnDefault.Size = new System.Drawing.Size(72, 24);
-            this.btnDefault.TabIndex = 3;
-            this.btnDefault.Text = "&Default";
-            this.btnDefault.UseVisualStyleBackColor = false;
-            this.btnDefault.Click += new System.EventHandler(this.btnDefault_Click);
-            this.btnDefault.MouseEnter += new System.EventHandler(this.button_MouseEnter);
-            this.btnDefault.MouseLeave += new System.EventHandler(this.button_MouseLeave);
+            this.btnReset.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnReset.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
+            this.btnReset.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnReset.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnReset.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnReset.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnReset.Location = new System.Drawing.Point(515, 544);
+            this.btnReset.Name = "btnReset";
+            this.btnReset.Size = new System.Drawing.Size(72, 24);
+            this.btnReset.TabIndex = 3;
+            this.btnReset.Text = "&Reset";
+            this.btnReset.UseVisualStyleBackColor = false;
+            this.btnReset.Click += new System.EventHandler(this.btnDefault_Click);
+            this.btnReset.MouseEnter += new System.EventHandler(this.button_MouseEnter);
+            this.btnReset.MouseLeave += new System.EventHandler(this.button_MouseLeave);
             // 
-            // btnSave
+            // btnApply
             // 
-            this.btnSave.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnSave.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
-            this.btnSave.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnSave.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnSave.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnSave.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnSave.Location = new System.Drawing.Point(274, 544);
-            this.btnSave.Name = "btnSave";
-            this.btnSave.Size = new System.Drawing.Size(72, 24);
-            this.btnSave.TabIndex = 2;
-            this.btnSave.Text = "&Save";
-            this.btnSave.UseVisualStyleBackColor = false;
-            this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
+            this.btnApply.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnApply.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
+            this.btnApply.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnApply.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnApply.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnApply.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnApply.Location = new System.Drawing.Point(435, 544);
+            this.btnApply.Name = "btnApply";
+            this.btnApply.Size = new System.Drawing.Size(72, 24);
+            this.btnApply.TabIndex = 2;
+            this.btnApply.Text = "&Apply";
+            this.btnApply.UseVisualStyleBackColor = false;
+            this.btnApply.Click += new System.EventHandler(this.btnSave_Click);
             // 
             // lblLogFontSize
             // 
@@ -1030,8 +1031,8 @@ namespace ServiceBusExplorer.Forms
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
             this.CancelButton = this.btnCancel;
             this.ClientSize = new System.Drawing.Size(601, 578);
-            this.Controls.Add(this.btnSave);
-            this.Controls.Add(this.btnDefault);
+            this.Controls.Add(this.btnApply);
+            this.Controls.Add(this.btnReset);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnOk);
             this.Controls.Add(this.mainPanel);
@@ -1069,8 +1070,8 @@ namespace ServiceBusExplorer.Forms
 
         private System.Windows.Forms.Button btnOk;
         private System.Windows.Forms.Button btnCancel;
-        private System.Windows.Forms.Button btnDefault;
-        private System.Windows.Forms.Button btnSave;
+        private System.Windows.Forms.Button btnReset;
+        private System.Windows.Forms.Button btnApply;
         private System.Windows.Forms.Label lblLogFontSize;
         private System.Windows.Forms.NumericUpDown logNumericUpDown;
         private System.Windows.Forms.Label lblTreeViewFontSize;

--- a/src/ServiceBusExplorer/Forms/OptionForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/OptionForm.Designer.cs
@@ -187,7 +187,7 @@ namespace ServiceBusExplorer.Forms
             this.btnReset.TabIndex = 3;
             this.btnReset.Text = "&Reset";
             this.btnReset.UseVisualStyleBackColor = false;
-            this.btnReset.Click += new System.EventHandler(this.btnDefault_Click);
+            this.btnReset.Click += new System.EventHandler(this.btnReset_Click);
             this.btnReset.MouseEnter += new System.EventHandler(this.button_MouseEnter);
             this.btnReset.MouseLeave += new System.EventHandler(this.button_MouseLeave);
             // 
@@ -205,7 +205,7 @@ namespace ServiceBusExplorer.Forms
             this.btnApply.TabIndex = 2;
             this.btnApply.Text = "&Apply";
             this.btnApply.UseVisualStyleBackColor = false;
-            this.btnApply.Click += new System.EventHandler(this.btnSave_Click);
+            this.btnApply.Click += new System.EventHandler(this.btnApply_Click);
             // 
             // lblLogFontSize
             // 

--- a/src/ServiceBusExplorer/Forms/OptionForm.cs
+++ b/src/ServiceBusExplorer/Forms/OptionForm.cs
@@ -150,7 +150,7 @@ namespace ServiceBusExplorer.Forms
             Close();
         }
 
-        void btnApply_Click(object sender, EventArgs e)
+        void btnSave_Click(object sender, EventArgs e)
         {
             // Get selected items
             MainSettings.SelectedEntities = GetSelectedEntities();

--- a/src/ServiceBusExplorer/Forms/OptionForm.cs
+++ b/src/ServiceBusExplorer/Forms/OptionForm.cs
@@ -94,7 +94,46 @@ namespace ServiceBusExplorer.Forms
         public ConfigFileUse ConfigFileUse { get; private set; }
         #endregion
 
-        #region Event Handlers
+        #region Command button event Handlers
+        void btnOpenConfig_Click(object sender, EventArgs e)
+        {
+            var selected = GetConfigFileUseFromUIIndex(cboConfigFile.SelectedIndex);
+
+            if (selected == ConfigFileUse.None)
+            {
+                MessageBox.Show("No file was selected in the list.", "No file opened",
+                    MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            // Open the file(s) depending on what's selected. Create an instance of the 
+            // TwoFilesConfiguration just to get the paths
+            var configuration = TwoFilesConfiguration.Create(selected);
+
+            if (cboConfigFile.SelectedIndex == ApplicationConfigFileIndex ||
+                cboConfigFile.SelectedIndex == BothConfigFileIndex)
+            {
+                // Open the application config file
+                Process.Start(configuration.ApplicationFilePath);
+            }
+
+            if (cboConfigFile.SelectedIndex == UserConfigFileIndex ||
+                cboConfigFile.SelectedIndex == BothConfigFileIndex)
+            {
+                // Open the user config file. It might not exist though
+                if (File.Exists(configuration.UserConfigFilePath))
+                {
+                    Process.Start(configuration.UserConfigFilePath);
+                }
+                else
+                {
+                    MessageBox.Show($"The file {configuration.UserConfigFilePath} does not exist. Click the Save"
+                        + " button to create it.",
+                        "File does exist", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
+            }
+        }
+
         private void btnOk_Click(object sender, EventArgs e)
         {
             MainSettings.SelectedEntities = GetSelectedEntities();
@@ -110,6 +149,28 @@ namespace ServiceBusExplorer.Forms
             DialogResult = DialogResult.Cancel;
             Close();
         }
+
+        void btnApply_Click(object sender, EventArgs e)
+        {
+            // Get selected items
+            MainSettings.SelectedEntities = GetSelectedEntities();
+
+            SaveSettings(GetConfigFileUseFromUIIndex(cboConfigFile.SelectedIndex));
+        }
+
+        void btnOpen_Click(object sender, EventArgs e)
+        {
+            using (var form = new TextForm(MessageTextTitle, txtMessageText.Text))
+            {
+                if (form.ShowDialog() == DialogResult.OK)
+                {
+                    txtMessageText.Text = form.Content;
+                }
+            }
+        }
+        #endregion
+
+        #region Event Handlers
 
         private void logNumericUpDown_ValueChanged(object sender, EventArgs e)
         {
@@ -318,68 +379,11 @@ namespace ServiceBusExplorer.Forms
             MainSettings.MessageBodyType = cboDefaultMessageBodyType.Text;
         }
 
-        void btnApply_Click(object sender, EventArgs e)
-        {
-            // Get selected items
-            MainSettings.SelectedEntities = GetSelectedEntities();
-
-            SaveSettings(GetConfigFileUseFromUIIndex(cboConfigFile.SelectedIndex));
-        }
-
-        void btnOpen_Click(object sender, EventArgs e)
-        {
-            using (var form = new TextForm(MessageTextTitle, txtMessageText.Text))
-            {
-                if (form.ShowDialog() == DialogResult.OK)
-                {
-                    txtMessageText.Text = form.Content;
-                }
-            }
-        }
-
         void cboEncoding_SelectedIndexChanged(object sender, EventArgs e)
         {
             if (cboEncodingType.SelectedItem is EncodingType)
             {
                 MainSettings.EncodingType = (EncodingType)cboEncodingType.SelectedItem;
-            }
-        }
-        void btnOpenConfig_Click(object sender, EventArgs e)
-        {
-            var selected = GetConfigFileUseFromUIIndex(cboConfigFile.SelectedIndex);
-
-            if (selected == ConfigFileUse.None)
-            {
-                MessageBox.Show("No file was selected in the list.", "No file opened",
-                    MessageBoxButtons.OK, MessageBoxIcon.Information);
-                return;
-            }
-
-            // Open the file(s) depending on what's selected. Create an instance of the 
-            // TwoFilesConfiguration just to get the paths
-            var configuration = TwoFilesConfiguration.Create(selected);
-
-            if (cboConfigFile.SelectedIndex == ApplicationConfigFileIndex ||
-                cboConfigFile.SelectedIndex == BothConfigFileIndex)
-            {
-                // Open the application config file
-                Process.Start(configuration.ApplicationFilePath);
-            }
-
-            if (cboConfigFile.SelectedIndex == UserConfigFileIndex ||
-                cboConfigFile.SelectedIndex == BothConfigFileIndex)
-            {
-                // Open the user config file. It might not exist though
-                if (File.Exists(configuration.UserConfigFilePath))
-                {
-                    Process.Start(configuration.UserConfigFilePath);
-                }
-                else
-                {
-                    MessageBox.Show($"The file {configuration.UserConfigFilePath} does not exist. Click the Save"
-                        + " button to create it.",
-                        "File does exist", MessageBoxButtons.OK, MessageBoxIcon.Information);
-                }
             }
         }
 

--- a/src/ServiceBusExplorer/Forms/OptionForm.cs
+++ b/src/ServiceBusExplorer/Forms/OptionForm.cs
@@ -98,6 +98,8 @@ namespace ServiceBusExplorer.Forms
         private void btnOk_Click(object sender, EventArgs e)
         {
             MainSettings.SelectedEntities = GetSelectedEntities();
+            
+            SaveSettings(GetConfigFileUseFromUIIndex(cboConfigFile.SelectedIndex));
 
             DialogResult = DialogResult.OK;
             Close();
@@ -128,7 +130,7 @@ namespace ServiceBusExplorer.Forms
             }
         }
 
-        private void btnDefault_Click(object sender, EventArgs e)
+        private void btnReset_Click(object sender, EventArgs e)
         {
             MainSettings.SetDefault();
 
@@ -316,7 +318,7 @@ namespace ServiceBusExplorer.Forms
             MainSettings.MessageBodyType = cboDefaultMessageBodyType.Text;
         }
 
-        void btnSave_Click(object sender, EventArgs e)
+        void btnApply_Click(object sender, EventArgs e)
         {
             // Get selected items
             MainSettings.SelectedEntities = GetSelectedEntities();


### PR DESCRIPTION
This fixes #270. 

The buttons now look like this:
![image](https://user-images.githubusercontent.com/9644248/73122881-0a5b1700-3f8a-11ea-83c2-55cc05fccec8.png)

The OK button now saves the values to file. The Reset button sets the parameters to their defaults.