### PR TITLE
Refactored several properties and their fields in the MainForm into autoproperties.

### DIFF
--- a/src/Common/Helpers/MessageAndPropertiesHelper.cs
+++ b/src/Common/Helpers/MessageAndPropertiesHelper.cs
@@ -168,40 +168,6 @@ namespace ServiceBusExplorer.Helpers
             }
         }
 
-
-        /// <summary>
-        /// Reads a relay message from an XML file in the current directory.
-        /// </summary>
-        /// <returns>The message read from the XML file.</returns>
-        public static string ReadRelayMessage()
-        {
-            try
-            {
-                if (!File.Exists(relayMessageFilePath))
-                {
-                    return null;
-                }
-
-                using (var reader = new StreamReader(messageFilePath))
-                {
-                    using (var xmlReader = XmlReader.Create(reader))
-                    {
-                        var root = XElement.Load(xmlReader);
-                        var cdata = root.DescendantNodes().OfType<XCData>().FirstOrDefault();
-                        if (cdata != null)
-                        {
-                            return cdata.Value;
-                        }
-                    }
-                }
-            }
-            // ReSharper disable once EmptyGeneralCatchClause
-            catch (Exception)
-            {
-            }
-            return null;
-        }
-
         /// <summary>
         /// Write a message to an XML file in the current directory.
         /// </summary>

--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -3808,7 +3808,6 @@ namespace ServiceBusExplorer.Forms
 
             serviceBusHelper.Scheme = configuration.GetStringValue(ConfigurationParameters.SchemeParameter,
                 serviceBusHelper.Scheme);
-            relayMessageText = MessageAndPropertiesHelper.ReadRelayMessage();
 
             var messageDeferProvider = configuration.GetStringValue(ConfigurationParameters.MessageDeferProviderParameter);
 
@@ -3891,8 +3890,6 @@ namespace ServiceBusExplorer.Forms
         public string MessageText { get; set; }
 
         public string MessageContentType { get; set; }
-
-        public string RelayMessageText { get; set; }
 
         public string Label { get; set; }
 

--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -207,33 +207,20 @@ namespace ServiceBusExplorer.Forms
         private TreeNode currentNode;
         private readonly FieldInfo eventClickFieldInfo;
         private readonly PropertyInfo eventsPropertyInfo;
-        private string messageText;
-        private string messageContentType;
-        private string relayMessageText;
         private string messageFile;
-        private string label;
         private bool importing;
         private readonly int mainSplitterDistance;
         private readonly int splitterContainerDistance;
         private ConfigFileUse configFileUse;
         private decimal treeViewFontSize;
         private decimal logFontSize;
-        private int topCount = 10;
-        private int receiveTimeout = 1;
-        private int serverTimeout = 5;
-        private int prefetchCount;
-        private int senderThinkTime = 100;
-        private int receiverThinkTime = 100;
-        private int monitorRefreshInterval = 30;
         private bool showMessageCount = true;
         private bool saveMessageToFile = true;
         private bool savePropertiesToFile = true;
         private bool saveCheckpointsToFile = true;
-        private bool useAscii = true;
         private readonly List<Tuple<string, string>> fileNames = new List<Tuple<string, string>>();
         private readonly string argumentName;
         private readonly string argumentValue;
-        private List<string> selectedEntites = new List<string>();
         private string messageBodyType = BodyType.Stream.ToString();
         private BlockingCollection<string> logCollection = new BlockingCollection<string>();
         private CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
@@ -378,26 +365,26 @@ namespace ServiceBusExplorer.Forms
                 TreeViewFontSize = (decimal)serviceBusTreeView.Font.Size,
                 RetryCount = RetryHelper.RetryCount,
                 RetryTimeout = RetryHelper.RetryTimeout,
-                ReceiveTimeout = receiveTimeout,
-                ServerTimeout = serverTimeout,
-                PrefetchCount = prefetchCount,
-                TopCount = topCount,
-                SenderThinkTime = senderThinkTime,
-                ReceiverThinkTime = receiverThinkTime,
-                MonitorRefreshInterval = monitorRefreshInterval,
+                ReceiveTimeout = ReceiveTimeout,
+                ServerTimeout = ServerTimeout,
+                PrefetchCount = PrefetchCount,
+                TopCount = TopCount,
+                SenderThinkTime = SenderThinkTime,
+                ReceiverThinkTime = ReceiverThinkTime,
+                MonitorRefreshInterval = MonitorRefreshInterval,
 
                 ShowMessageCount = showMessageCount,
-                UseAscii = useAscii,
+                UseAscii = UseAscii,
                 SaveMessageToFile = saveMessageToFile,
                 SavePropertiesToFile = savePropertiesToFile,
                 SaveCheckpointsToFile = saveCheckpointsToFile,
 
-                Label = label,
+                Label = Label,
                 MessageFile = messageFile,
-                MessageText = messageText,
-                MessageContentType = messageContentType,
+                MessageText = MessageText,
+                MessageContentType = MessageContentType,
 
-                SelectedEntities = selectedEntites,
+                SelectedEntities = SelectedEntities,
                 MessageBodyType = messageBodyType,
                 ConnectivityMode = ServiceBusHelper.ConnectivityMode,
                 EncodingType = ServiceBusHelper.EncodingType
@@ -429,13 +416,13 @@ namespace ServiceBusExplorer.Forms
                     (float)optionForm.MainSettings.TreeViewFontSize);
                 RetryHelper.RetryCount = optionForm.MainSettings.RetryCount;
                 RetryHelper.RetryTimeout = optionForm.MainSettings.RetryTimeout;
-                receiveTimeout = optionForm.MainSettings.ReceiveTimeout;
-                serverTimeout = optionForm.MainSettings.ServerTimeout;
-                prefetchCount = optionForm.MainSettings.PrefetchCount;
-                topCount = optionForm.MainSettings.TopCount;
-                senderThinkTime = optionForm.MainSettings.SenderThinkTime;
-                receiverThinkTime = optionForm.MainSettings.ReceiverThinkTime;
-                monitorRefreshInterval = optionForm.MainSettings.MonitorRefreshInterval;
+                ReceiveTimeout = optionForm.MainSettings.ReceiveTimeout;
+                ServerTimeout = optionForm.MainSettings.ServerTimeout;
+                PrefetchCount = optionForm.MainSettings.PrefetchCount;
+                TopCount = optionForm.MainSettings.TopCount;
+                SenderThinkTime = optionForm.MainSettings.SenderThinkTime;
+                ReceiverThinkTime = optionForm.MainSettings.ReceiverThinkTime;
+                MonitorRefreshInterval = optionForm.MainSettings.MonitorRefreshInterval;
 
                 if (showMessageCount != optionForm.MainSettings.ShowMessageCount)
                 {
@@ -443,17 +430,17 @@ namespace ServiceBusExplorer.Forms
                     GetEntities(EntityType.All);
                 }
 
-                useAscii = optionForm.MainSettings.UseAscii;
+                UseAscii = optionForm.MainSettings.UseAscii;
                 saveMessageToFile = optionForm.MainSettings.SaveMessageToFile;
                 savePropertiesToFile = optionForm.MainSettings.SavePropertiesToFile;
                 saveCheckpointsToFile = optionForm.MainSettings.SaveCheckpointsToFile;
 
-                label = optionForm.MainSettings.Label;
+                Label = optionForm.MainSettings.Label;
                 messageFile = optionForm.MainSettings.MessageFile;
-                messageText = optionForm.MainSettings.MessageText;
-                messageContentType = optionForm.MainSettings.MessageContentType;
+                MessageText = optionForm.MainSettings.MessageText;
+                MessageContentType = optionForm.MainSettings.MessageContentType;
 
-                selectedEntites = optionForm.MainSettings.SelectedEntities;
+                SelectedEntities = optionForm.MainSettings.SelectedEntities;
                 messageBodyType = optionForm.MainSettings.MessageBodyType;
                 ServiceBusHelper.ConnectivityMode = optionForm.MainSettings.ConnectivityMode;
                 ServiceBusHelper.EncodingType = optionForm.MainSettings.EncodingType;
@@ -1340,7 +1327,7 @@ namespace ServiceBusExplorer.Forms
                         return;
                     }
                     UpdateSavedConnectionsMenu();
-                    selectedEntites = connectForm.SelectedEntities;
+                    SelectedEntities = connectForm.SelectedEntities;
                     ServiceBusHelper.ConnectivityMode = connectForm.ConnectivityMode;
                     if (!string.IsNullOrWhiteSpace(connectForm.ConnectionString))
                     {
@@ -3711,23 +3698,23 @@ namespace ServiceBusExplorer.Forms
                 TreeViewFontSize = treeViewFontSize,
                 RetryCount = RetryHelper.RetryCount,
                 RetryTimeout = RetryHelper.RetryTimeout,
-                ReceiveTimeout = receiveTimeout,
-                ServerTimeout = serverTimeout,
-                PrefetchCount = prefetchCount,
-                TopCount = topCount,
-                SenderThinkTime = senderThinkTime,
-                ReceiverThinkTime = receiverThinkTime,
-                MonitorRefreshInterval = monitorRefreshInterval,
+                ReceiveTimeout = ReceiveTimeout,
+                ServerTimeout = ServerTimeout,
+                PrefetchCount = PrefetchCount,
+                TopCount = TopCount,
+                SenderThinkTime = SenderThinkTime,
+                ReceiverThinkTime = ReceiverThinkTime,
+                MonitorRefreshInterval = MonitorRefreshInterval,
                 ShowMessageCount = showMessageCount,
-                UseAscii = useAscii,
+                UseAscii = UseAscii,
                 SaveMessageToFile = saveMessageToFile,
                 SavePropertiesToFile = savePropertiesToFile,
                 SaveCheckpointsToFile = saveCheckpointsToFile,
-                Label = label,
+                Label = Label,
                 MessageFile = messageFile,
-                MessageText = messageText,
-                MessageContentType = messageContentType,
-                SelectedEntities = selectedEntites,
+                MessageText = MessageText,
+                MessageContentType = MessageContentType,
+                SelectedEntities = SelectedEntities,
                 MessageBodyType = messageBodyType,
                 ConnectivityMode = ServiceBusHelper.ConnectivityMode
             };
@@ -3754,58 +3741,58 @@ namespace ServiceBusExplorer.Forms
             var tempReceiveTimeout = readSettings.ReceiveTimeout;
             if (tempReceiveTimeout >= 0)
             {
-                receiveTimeout = tempReceiveTimeout;
+                ReceiveTimeout = tempReceiveTimeout;
             }
 
             var tempServerTimeout = readSettings.ServerTimeout;
             if (tempServerTimeout >= 0)
             {
-                serverTimeout = tempServerTimeout;
+                ServerTimeout = tempServerTimeout;
             }
 
             var tempPrefetchCount = readSettings.PrefetchCount;
             if (tempPrefetchCount >= 0)
             {
-                prefetchCount = tempPrefetchCount;
+                PrefetchCount = tempPrefetchCount;
             }
 
             var tempTopValue = readSettings.TopCount;
             if (tempTopValue > 0)
             {
-                topCount = tempTopValue;
+                TopCount = tempTopValue;
             }
 
             var tempSenderThinkTime = readSettings.SenderThinkTime;
             if (tempSenderThinkTime >= 0)
             {
-                senderThinkTime = tempSenderThinkTime;
+                SenderThinkTime = tempSenderThinkTime;
             }
 
             var tempReceiverThinkTime = readSettings.ReceiverThinkTime;
             if (tempReceiverThinkTime >= 0)
             {
-                receiverThinkTime = tempReceiverThinkTime;
+                ReceiverThinkTime = tempReceiverThinkTime;
             }
 
             var tempMonitorRefreshIntervalValue = readSettings.MonitorRefreshInterval;
             if (tempMonitorRefreshIntervalValue >= 0)
             {
-                monitorRefreshInterval = tempMonitorRefreshIntervalValue;
+                MonitorRefreshInterval = tempMonitorRefreshIntervalValue;
             }
 
             showMessageCount = readSettings.ShowMessageCount;
-            useAscii = readSettings.UseAscii;
+            UseAscii = readSettings.UseAscii;
             saveMessageToFile = readSettings.SaveMessageToFile;
             savePropertiesToFile = readSettings.SavePropertiesToFile;
             saveCheckpointsToFile = readSettings.SaveCheckpointsToFile;
 
-            label = readSettings.Label;
+            Label = readSettings.Label;
 
-            messageText = readSettings.MessageText;
-            messageContentType = readSettings.MessageContentType;
+            MessageText = readSettings.MessageText;
+            MessageContentType = readSettings.MessageContentType;
             messageFile = readSettings.MessageFile;
 
-            selectedEntites = readSettings.SelectedEntities;
+            SelectedEntities = readSettings.SelectedEntities;
             messageBodyType = readSettings.MessageBodyType;
             ServiceBusHelper.ConnectivityMode = readSettings.ConnectivityMode;
             ServiceBusHelper.EncodingType = readSettings.EncodingType;
@@ -3901,158 +3888,31 @@ namespace ServiceBusExplorer.Forms
             }
         }
 
-        public string MessageText
-        {
-            get
-            {
-                return messageText;
-            }
-            set
-            {
-                messageText = value;
-            }
-        }
+        public string MessageText { get; set; }
 
-        public string MessageContentType
-        {
-            get
-            {
-                return messageContentType;
-            }
-            set
-            {
-                messageContentType = value;
-            }
-        }
+        public string MessageContentType { get; set; }
 
-        public string RelayMessageText
-        {
-            get
-            {
-                return messageText;
-            }
-            set
-            {
-                messageText = value;
-            }
-        }
+        public string RelayMessageText { get; set; }
 
-        public string Label
-        {
-            get
-            {
-                return label;
-            }
-            set
-            {
-                label = value;
-            }
-        }
+        public string Label { get; set; }
 
-        public int ReceiveTimeout
-        {
-            get
-            {
-                return receiveTimeout;
-            }
-            set
-            {
-                receiveTimeout = value;
-            }
-        }
+        public int ReceiveTimeout { get; set; } = 1;
 
-        public int ServerTimeout
-        {
-            get
-            {
-                return serverTimeout;
-            }
-            set
-            {
-                serverTimeout = value;
-            }
-        }
+        public int ServerTimeout { get; set; } = 5;
 
-        public int PrefetchCount
-        {
-            get
-            {
-                return prefetchCount;
-            }
-            set
-            {
-                prefetchCount = value;
-            }
-        }
+        public int PrefetchCount { get; set; }
 
-        public int TopCount
-        {
-            get
-            {
-                return topCount;
-            }
-            set
-            {
-                topCount = value;
-            }
-        }
+        public int TopCount { get; set; } = 10;
 
-        public int SenderThinkTime
-        {
-            get
-            {
-                return senderThinkTime;
-            }
-            set
-            {
-                senderThinkTime = value;
-            }
-        }
+        public int SenderThinkTime { get; set; } = 100;
 
-        public int ReceiverThinkTime
-        {
-            get
-            {
-                return receiverThinkTime;
-            }
-            set
-            {
-                receiverThinkTime = value;
-            }
-        }
+        public int ReceiverThinkTime { get; set; } = 100;
 
-        public int MonitorRefreshInterval
-        {
-            get
-            {
-                return monitorRefreshInterval;
-            }
-            set
-            {
-                monitorRefreshInterval = value;
-            }
-        }
+        public int MonitorRefreshInterval { get; set; } = 30;
 
+        public bool UseAscii { get; set; } = true;
 
-        public bool UseAscii
-        {
-            get
-            {
-                return useAscii;
-            }
-            set
-            {
-                useAscii = value;
-            }
-        }
-
-        public List<string> SelectedEntities
-        {
-            get
-            {
-                return selectedEntites;
-            }
-        }
+        public List<string> SelectedEntities { get; private set; } = new List<string>();
 
         public BodyType MessageBodyType
         {
@@ -4318,12 +4178,12 @@ namespace ServiceBusExplorer.Forms
                         serviceBusTreeView.Nodes.Clear();
                         rootNode = serviceBusTreeView.Nodes.Add(serviceBusHelper.NamespaceUri.AbsoluteUri, serviceBusHelper.NamespaceUri.AbsoluteUri, AzureIconIndex, AzureIconIndex);
                         rootNode.ContextMenuStrip = rootContextMenuStrip;
-                        if (selectedEntites.Contains(Constants.QueueEntities))
+                        if (SelectedEntities.Contains(Constants.QueueEntities))
                         {
                             queueListNode = rootNode.Nodes.Add(Constants.QueueEntities, Constants.QueueEntities, QueueListIconIndex, QueueListIconIndex);
                             queueListNode.ContextMenuStrip = queuesContextMenuStrip;
                         }
-                        if (selectedEntites.Contains(Constants.TopicEntities))
+                        if (SelectedEntities.Contains(Constants.TopicEntities))
                         {
                             topicListNode = rootNode.Nodes.Add(Constants.TopicEntities, Constants.TopicEntities, TopicListIconIndex, TopicListIconIndex);
                             topicListNode.ContextMenuStrip = topicsContextMenuStrip;
@@ -4332,17 +4192,17 @@ namespace ServiceBusExplorer.Forms
                         // NOTE: Relays are not actually supported by Service Bus for Windows Server
                         if (serviceBusHelper.IsCloudNamespace)
                         {
-                            if (selectedEntites.Contains(Constants.EventHubEntities))
+                            if (SelectedEntities.Contains(Constants.EventHubEntities))
                             {
                                 eventHubListNode = rootNode.Nodes.Add(Constants.EventHubEntities, Constants.EventHubEntities, EventHubListIconIndex, EventHubListIconIndex);
                                 eventHubListNode.ContextMenuStrip = eventHubsContextMenuStrip;
                             }
-                            if (selectedEntites.Contains(Constants.NotificationHubEntities))
+                            if (SelectedEntities.Contains(Constants.NotificationHubEntities))
                             {
                                 notificationHubListNode = rootNode.Nodes.Add(Constants.NotificationHubEntities, Constants.NotificationHubEntities, NotificationHubListIconIndex, NotificationHubListIconIndex);
                                 notificationHubListNode.ContextMenuStrip = notificationHubsContextMenuStrip;
                             }
-                            if (selectedEntites.Contains(Constants.RelayEntities))
+                            if (SelectedEntities.Contains(Constants.RelayEntities))
                             {
                                 relayServiceListNode = rootNode.Nodes.Add(Constants.RelayEntities, Constants.RelayEntities, RelayListIconIndex, RelayListIconIndex);
                                 relayServiceListNode.ContextMenuStrip = relayServicesContextMenuStrip;
@@ -4352,7 +4212,7 @@ namespace ServiceBusExplorer.Forms
                     updating = true;
                     if (serviceBusHelper.IsCloudNamespace)
                     {
-                        if (selectedEntites.Contains(Constants.EventHubEntities) &&
+                        if (SelectedEntities.Contains(Constants.EventHubEntities) &&
                             (entityType == EntityType.All ||
                             entityType == EntityType.EventHub))
                         {
@@ -4387,7 +4247,7 @@ namespace ServiceBusExplorer.Forms
                                 serviceBusTreeView.Nodes.Remove(eventHubListNode);
                             }
                         }
-                        if (selectedEntites.Contains(Constants.NotificationHubEntities) &&
+                        if (SelectedEntities.Contains(Constants.NotificationHubEntities) &&
                             (entityType == EntityType.All ||
                             entityType == EntityType.NotificationHub))
                         {
@@ -4431,7 +4291,7 @@ namespace ServiceBusExplorer.Forms
                                 serviceBusTreeView.Nodes.Remove(notificationHubListNode);
                             }
                         }
-                        if (selectedEntites.Contains(Constants.RelayEntities) &&
+                        if (SelectedEntities.Contains(Constants.RelayEntities) &&
                             (entityType == EntityType.All ||
                             entityType == EntityType.Relay))
                         {
@@ -4468,7 +4328,7 @@ namespace ServiceBusExplorer.Forms
                         }
                     }
 
-                    if (selectedEntites.Contains(Constants.QueueEntities) &&
+                    if (SelectedEntities.Contains(Constants.QueueEntities) &&
                         (entityType == EntityType.All ||
                          entityType == EntityType.Queue))
                     {
@@ -4505,7 +4365,7 @@ namespace ServiceBusExplorer.Forms
                             serviceBusTreeView.Nodes.Remove(queueListNode);
                         }
                     }
-                    if (selectedEntites.Contains(Constants.TopicEntities) &&
+                    if (SelectedEntities.Contains(Constants.TopicEntities) &&
                         (entityType == EntityType.All ||
                          entityType == EntityType.Topic))
                     {
@@ -6236,8 +6096,7 @@ namespace ServiceBusExplorer.Forms
             cancellationTokenSource.Cancel(false);
             if (saveMessageToFile)
             {
-                MessageAndPropertiesHelper.WriteMessage(messageText);
-                MessageAndPropertiesHelper.WriteRelayMessage(relayMessageText);
+                MessageAndPropertiesHelper.WriteMessage(MessageText);
             }
             if (savePropertiesToFile)
             {


### PR DESCRIPTION
* Refactored several properties and their fields into autoproperties.
* Removed the RelayMessageText property since it was only being saved, never used.

I got into this when looking at these properties to determine where they are used to divide them into appropriate groups for the creation of tabs in the Options dialog, #403.