### PR TITLE
Allow configuring AMQP Web Sockets usage

### DIFF
--- a/src/Common/Helpers/ConfigurationHelper.cs
+++ b/src/Common/Helpers/ConfigurationHelper.cs
@@ -194,7 +194,8 @@ namespace ServiceBusExplorer.Helpers
 
             resultProperties.ConnectivityMode = configuration.GetEnumValue
                 (ConfigurationParameters.ConnectivityMode, currentSettings.ConnectivityMode, writeToLog);
-
+            resultProperties.UseAmqpWebSockets = configuration.GetBoolValue
+                (ConfigurationParameters.UseAmqpWebSockets, currentSettings.UseAmqpWebSockets, writeToLog);
             resultProperties.EncodingType = configuration.GetEnumValue
                 (ConfigurationParameters.Encoding, currentSettings.EncodingType, writeToLog);
 

--- a/src/Common/Helpers/ConfigurationParameters.cs
+++ b/src/Common/Helpers/ConfigurationParameters.cs
@@ -53,6 +53,7 @@ namespace ServiceBusExplorer.Helpers
         public const string TreeViewFontSize = "treeViewFontSize";
         public const string MessageBodyType = "messageBodyType";
         public const string ConnectivityMode = "connectivityMode";
+        public const string UseAmqpWebSockets = "useAmqpWebSockets";
         public const string Encoding = "encoding";
         public const string SelectedEntitiesParameter = "selectedEntities";
         public const string MicrosoftServiceBusConnectionString = "Microsoft.ServiceBus.ConnectionString";

--- a/src/Common/Helpers/MainSettings.cs
+++ b/src/Common/Helpers/MainSettings.cs
@@ -62,7 +62,7 @@ namespace ServiceBusExplorer.Helpers
 
         public string MessageBodyType { get; set; }
         public ConnectivityMode ConnectivityMode { get; set; }
-
+        public bool UseAmqpWebSockets { get; set; }
         public Enums.EncodingType EncodingType { get; set; }
 
         #endregion
@@ -113,6 +113,7 @@ namespace ServiceBusExplorer.Helpers
 
             MessageBodyType = BodyType.Stream.ToString();
             ConnectivityMode = ConnectivityMode.AutoDetect;
+            UseAmqpWebSockets = false;
         }
 
         public override bool Equals(object other)
@@ -149,6 +150,7 @@ namespace ServiceBusExplorer.Helpers
 
             if (MessageBodyType != otherProperties.MessageBodyType) return false;
             if (ConnectivityMode != otherProperties.ConnectivityMode) return false;
+            if (UseAmqpWebSockets != otherProperties.UseAmqpWebSockets) return false;
 
             return true;
         }
@@ -242,6 +244,9 @@ namespace ServiceBusExplorer.Helpers
 
                 case ConfigurationParameters.ConnectivityMode:
                     return ConnectivityMode;
+
+                case ConfigurationParameters.UseAmqpWebSockets:
+                    return UseAmqpWebSockets;
 
                 case ConfigurationParameters.Encoding:
                     return EncodingType;

--- a/src/Common/Helpers/ServiceBusHelper.cs
+++ b/src/Common/Helpers/ServiceBusHelper.cs
@@ -526,7 +526,7 @@ namespace ServiceBusExplorer
         }
 
         /// <summary>
-        /// Gets or sets the issuer secret.
+        /// Gets or sets the transport type.
         /// </summary>
         public TransportType TransportType
         {
@@ -678,6 +678,8 @@ namespace ServiceBusExplorer
                 Microsoft.ServiceBus.ServiceBusEnvironment.SystemConnectivity.Mode = value;
             }
         }
+
+        public static bool UseAmqpWebSockets { get; set; }
 
         /// <summary>
         /// Gets or sets the encodingType of sent messages
@@ -5338,6 +5340,9 @@ namespace ServiceBusExplorer
         {
             var serviceBusHelper2 = new ServiceBusHelper2();
             serviceBusHelper2.ConnectionString = ConnectionString;
+            serviceBusHelper2.TransportType = UseAmqpWebSockets
+                ? Microsoft.Azure.ServiceBus.TransportType.AmqpWebSockets
+                : Microsoft.Azure.ServiceBus.TransportType.Amqp;
             return serviceBusHelper2;
         }
 

--- a/src/ServiceBus/Helpers/ServiceBusHelper2.cs
+++ b/src/ServiceBus/Helpers/ServiceBusHelper2.cs
@@ -26,8 +26,11 @@
 namespace ServiceBusExplorer.ServiceBus.Helpers
 // ReSharper restore CheckNamespace
 {
+    using Microsoft.Azure.ServiceBus;
+
     public class ServiceBusHelper2 
     {
         public string ConnectionString { get; set; }
+        public TransportType TransportType { get; set; }
     }
 }

--- a/src/ServiceBus/Helpers/ServiceBusPurger.cs
+++ b/src/ServiceBus/Helpers/ServiceBusPurger.cs
@@ -85,9 +85,11 @@ namespace ServiceBusExplorer.ServiceBus.Helpers
             ISessionClient sessionClient = new SessionClient(
                 serviceBusHelper.ConnectionString, 
                 GetEntityPath(deadLetterQueue: false),
-                ReceiveMode.ReceiveAndDelete, 
-                RetryPolicy.Default, 
-                prefetchCount: 10);
+                null,
+                receiveMode: ReceiveMode.ReceiveAndDelete, 
+                retryPolicy: RetryPolicy.Default, 
+                prefetchCount: 10,
+                transportType: serviceBusHelper.TransportType);
 
             var consecutiveSessionTimeOuts = 0;
             try

--- a/src/ServiceBusExplorer/Forms/ConnectForm.cs
+++ b/src/ServiceBusExplorer/Forms/ConnectForm.cs
@@ -30,7 +30,6 @@ using System.Globalization;
 using System.Linq;
 using System.Windows.Forms;
 using ServiceBusExplorer.Helpers;
-using ServiceBusExplorer.Utilities.Helpers;
 using Microsoft.ServiceBus;
 using Microsoft.ServiceBus.Messaging;
 
@@ -132,6 +131,8 @@ namespace ServiceBusExplorer.Forms
             ConnectivityMode = ServiceBusHelper.ConnectivityMode;
             cboConnectivityMode.DataSource = Enum.GetValues(typeof(ConnectivityMode));
             cboConnectivityMode.SelectedItem = ConnectivityMode;
+            UseAmqpWebSockets = ServiceBusHelper.UseAmqpWebSockets;
+            useAmqpWebSocketsCheckBox.Checked = UseAmqpWebSockets;
 
             cboTransportType.DataSource = Enum.GetValues(typeof(TransportType));
             var settings = new MessagingFactorySettings();
@@ -205,6 +206,7 @@ namespace ServiceBusExplorer.Forms
         public string ConnectionString { get; private set; }
         public string EntityPath { get; private set; }
         public ConnectivityMode ConnectivityMode { get; private set; }
+        public bool UseAmqpWebSockets { get; private set; }
         public TransportType TransportType { get; set; }
 
         public List<string> SelectedEntities
@@ -231,6 +233,7 @@ namespace ServiceBusExplorer.Forms
             }
             DialogResult = DialogResult.OK;
             ConnectivityMode = (ConnectivityMode)cboConnectivityMode.SelectedItem;
+            UseAmqpWebSockets = useAmqpWebSocketsCheckBox.Checked;
             FilterExpressionHelper.QueueFilterExpression = txtQueueFilterExpression.Text;
             FilterExpressionHelper.TopicFilterExpression = txtTopicFilterExpression.Text;
             FilterExpressionHelper.SubscriptionFilterExpression = txtSubscriptionFilterExpression.Text;

--- a/src/ServiceBusExplorer/Forms/ConnectForm.designer.cs
+++ b/src/ServiceBusExplorer/Forms/ConnectForm.designer.cs
@@ -85,6 +85,7 @@ namespace ServiceBusExplorer.Forms
             this.lblQueueFilterExpression = new System.Windows.Forms.Label();
             this.lblTopicFilterExpression = new System.Windows.Forms.Label();
             this.grouperServiceBusNamespaceSettings = new ServiceBusExplorer.Controls.Grouper();
+            this.lblNewSdkTransportType = new System.Windows.Forms.Label();
             this.cboTransportType = new System.Windows.Forms.ComboBox();
             this.lblTransportType = new System.Windows.Forms.Label();
             this.cboConnectivityMode = new System.Windows.Forms.ComboBox();
@@ -97,6 +98,7 @@ namespace ServiceBusExplorer.Forms
             this.lblEntityPath = new System.Windows.Forms.Label();
             this.grouperServiceBusNamespaces = new ServiceBusExplorer.Controls.Grouper();
             this.cboServiceBusNamespace = new System.Windows.Forms.ComboBox();
+            this.useAmqpWebSocketsCheckBox = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.logoPictureBox)).BeginInit();
             this.grouperConfigFileUse.SuspendLayout();
             this.grouperFilters.SuspendLayout();
@@ -112,7 +114,7 @@ namespace ServiceBusExplorer.Forms
             this.btnOk.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnOk.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnOk.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnOk.Location = new System.Drawing.Point(616, 428);
+            this.btnOk.Location = new System.Drawing.Point(616, 443);
             this.btnOk.Name = "btnOk";
             this.btnOk.Size = new System.Drawing.Size(72, 24);
             this.btnOk.TabIndex = 4;
@@ -130,7 +132,7 @@ namespace ServiceBusExplorer.Forms
             this.btnCancel.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCancel.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnCancel.Location = new System.Drawing.Point(696, 428);
+            this.btnCancel.Location = new System.Drawing.Point(696, 443);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(72, 24);
             this.btnCancel.TabIndex = 5;
@@ -338,7 +340,6 @@ namespace ServiceBusExplorer.Forms
             this.txtNamespace.ForeColor = System.Drawing.SystemColors.ControlText;
             this.txtNamespace.Location = new System.Drawing.Point(16, 96);
             this.txtNamespace.Name = "txtNamespace";
-            this.txtNamespace.ReadOnly = true;
             this.txtNamespace.Size = new System.Drawing.Size(336, 20);
             this.txtNamespace.TabIndex = 1;
             this.toolTip.SetToolTip(this.txtNamespace, "Gets or sets the name of the Service Bus namespace.");
@@ -375,7 +376,7 @@ namespace ServiceBusExplorer.Forms
             this.btnSave.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnSave.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnSave.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnSave.Location = new System.Drawing.Point(536, 428);
+            this.btnSave.Location = new System.Drawing.Point(536, 443);
             this.btnSave.Name = "btnSave";
             this.btnSave.Size = new System.Drawing.Size(72, 24);
             this.btnSave.TabIndex = 3;
@@ -394,7 +395,7 @@ namespace ServiceBusExplorer.Forms
             this.btnRename.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnRename.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnRename.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnRename.Location = new System.Drawing.Point(16, 428);
+            this.btnRename.Location = new System.Drawing.Point(16, 443);
             this.btnRename.Name = "btnRename";
             this.btnRename.Size = new System.Drawing.Size(72, 24);
             this.btnRename.TabIndex = 35;
@@ -411,7 +412,7 @@ namespace ServiceBusExplorer.Forms
             this.btnDelete.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnDelete.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnDelete.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnDelete.Location = new System.Drawing.Point(94, 428);
+            this.btnDelete.Location = new System.Drawing.Point(94, 443);
             this.btnDelete.Name = "btnDelete";
             this.btnDelete.Size = new System.Drawing.Size(72, 24);
             this.btnDelete.TabIndex = 36;
@@ -433,22 +434,22 @@ namespace ServiceBusExplorer.Forms
             this.grouperConfigFileUse.ForeColor = System.Drawing.Color.White;
             this.grouperConfigFileUse.GroupImage = null;
             this.grouperConfigFileUse.GroupTitle = "Configuration File for Connections and Settings";
-            this.grouperConfigFileUse.Location = new System.Drawing.Point(16, 339);
+            this.grouperConfigFileUse.Location = new System.Drawing.Point(16, 344);
             this.grouperConfigFileUse.Name = "grouperConfigFileUse";
-            this.grouperConfigFileUse.Padding = new System.Windows.Forms.Padding(20, 20, 20, 20);
+            this.grouperConfigFileUse.Padding = new System.Windows.Forms.Padding(20);
             this.grouperConfigFileUse.PaintGroupBox = true;
             this.grouperConfigFileUse.RoundCorners = 4;
             this.grouperConfigFileUse.ShadowColor = System.Drawing.Color.DarkGray;
             this.grouperConfigFileUse.ShadowControl = false;
             this.grouperConfigFileUse.ShadowThickness = 1;
-            this.grouperConfigFileUse.Size = new System.Drawing.Size(368, 72);
+            this.grouperConfigFileUse.Size = new System.Drawing.Size(368, 88);
             this.grouperConfigFileUse.TabIndex = 37;
             // 
             // lblConfigFileUse
             // 
             this.lblConfigFileUse.AutoSize = true;
             this.lblConfigFileUse.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblConfigFileUse.Location = new System.Drawing.Point(16, 24);
+            this.lblConfigFileUse.Location = new System.Drawing.Point(16, 29);
             this.lblConfigFileUse.Name = "lblConfigFileUse";
             this.lblConfigFileUse.Size = new System.Drawing.Size(237, 39);
             this.lblConfigFileUse.TabIndex = 39;
@@ -483,7 +484,7 @@ namespace ServiceBusExplorer.Forms
             this.grouperFilters.GroupTitle = "Filter Expressions";
             this.grouperFilters.Location = new System.Drawing.Point(16, 104);
             this.grouperFilters.Name = "grouperFilters";
-            this.grouperFilters.Padding = new System.Windows.Forms.Padding(20, 20, 20, 20);
+            this.grouperFilters.Padding = new System.Windows.Forms.Padding(20);
             this.grouperFilters.PaintGroupBox = true;
             this.grouperFilters.RoundCorners = 4;
             this.grouperFilters.ShadowColor = System.Drawing.Color.DarkGray;
@@ -553,6 +554,8 @@ namespace ServiceBusExplorer.Forms
             this.grouperServiceBusNamespaceSettings.BackgroundGradientMode = ServiceBusExplorer.Controls.Grouper.GroupBoxGradientMode.None;
             this.grouperServiceBusNamespaceSettings.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.grouperServiceBusNamespaceSettings.BorderThickness = 1F;
+            this.grouperServiceBusNamespaceSettings.Controls.Add(this.useAmqpWebSocketsCheckBox);
+            this.grouperServiceBusNamespaceSettings.Controls.Add(this.lblNewSdkTransportType);
             this.grouperServiceBusNamespaceSettings.Controls.Add(this.cboTransportType);
             this.grouperServiceBusNamespaceSettings.Controls.Add(this.lblTransportType);
             this.grouperServiceBusNamespaceSettings.Controls.Add(this.cboConnectivityMode);
@@ -574,15 +577,25 @@ namespace ServiceBusExplorer.Forms
             this.grouperServiceBusNamespaceSettings.GroupTitle = "Connection Settings";
             this.grouperServiceBusNamespaceSettings.Location = new System.Drawing.Point(400, 24);
             this.grouperServiceBusNamespaceSettings.Name = "grouperServiceBusNamespaceSettings";
-            this.grouperServiceBusNamespaceSettings.Padding = new System.Windows.Forms.Padding(20, 20, 20, 20);
+            this.grouperServiceBusNamespaceSettings.Padding = new System.Windows.Forms.Padding(20);
             this.grouperServiceBusNamespaceSettings.PaintGroupBox = true;
             this.grouperServiceBusNamespaceSettings.RoundCorners = 4;
             this.grouperServiceBusNamespaceSettings.ShadowColor = System.Drawing.Color.DarkGray;
             this.grouperServiceBusNamespaceSettings.ShadowControl = false;
             this.grouperServiceBusNamespaceSettings.ShadowThickness = 1;
-            this.grouperServiceBusNamespaceSettings.Size = new System.Drawing.Size(368, 387);
+            this.grouperServiceBusNamespaceSettings.Size = new System.Drawing.Size(368, 408);
             this.grouperServiceBusNamespaceSettings.TabIndex = 2;
             this.grouperServiceBusNamespaceSettings.CustomPaint += new System.Action<System.Windows.Forms.PaintEventArgs>(this.grouperServiceBusNamespaceSettings_CustomPaint);
+            // 
+            // lblNewSdkTransportType
+            // 
+            this.lblNewSdkTransportType.AutoSize = true;
+            this.lblNewSdkTransportType.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.lblNewSdkTransportType.Location = new System.Drawing.Point(16, 368);
+            this.lblNewSdkTransportType.Name = "lblNewSdkTransportType";
+            this.lblNewSdkTransportType.Size = new System.Drawing.Size(346, 13);
+            this.lblNewSdkTransportType.TabIndex = 74;
+            this.lblNewSdkTransportType.Text = "Use AMQP Web Sockets for Microsoft.Azure.ServiceBus.dll (new client)";
             // 
             // cboTransportType
             // 
@@ -702,7 +715,7 @@ namespace ServiceBusExplorer.Forms
             this.grouperServiceBusNamespaces.GroupTitle = "Service Bus Namespaces";
             this.grouperServiceBusNamespaces.Location = new System.Drawing.Point(16, 24);
             this.grouperServiceBusNamespaces.Name = "grouperServiceBusNamespaces";
-            this.grouperServiceBusNamespaces.Padding = new System.Windows.Forms.Padding(20, 20, 20, 20);
+            this.grouperServiceBusNamespaces.Padding = new System.Windows.Forms.Padding(20);
             this.grouperServiceBusNamespaces.PaintGroupBox = true;
             this.grouperServiceBusNamespaces.RoundCorners = 4;
             this.grouperServiceBusNamespaces.ShadowColor = System.Drawing.Color.DarkGray;
@@ -726,12 +739,22 @@ namespace ServiceBusExplorer.Forms
             this.cboServiceBusNamespace.TabIndex = 0;
             this.cboServiceBusNamespace.SelectedIndexChanged += new System.EventHandler(this.cboServiceBusNamespace_SelectedIndexChanged);
             // 
+            // useAmqpWebSocketsCheckBox
+            // 
+            this.useAmqpWebSocketsCheckBox.AutoSize = true;
+            this.useAmqpWebSocketsCheckBox.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.useAmqpWebSocketsCheckBox.Location = new System.Drawing.Point(337, 384);
+            this.useAmqpWebSocketsCheckBox.Name = "useAmqpWebSocketsCheckBox";
+            this.useAmqpWebSocketsCheckBox.Size = new System.Drawing.Size(15, 14);
+            this.useAmqpWebSocketsCheckBox.TabIndex = 75;
+            this.useAmqpWebSocketsCheckBox.UseVisualStyleBackColor = true;
+            // 
             // ConnectForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
-            this.ClientSize = new System.Drawing.Size(784, 462);
+            this.ClientSize = new System.Drawing.Size(784, 477);
             this.Controls.Add(this.grouperConfigFileUse);
             this.Controls.Add(this.btnDelete);
             this.Controls.Add(this.btnRename);
@@ -806,5 +829,7 @@ namespace ServiceBusExplorer.Forms
         private System.Windows.Forms.Button btnDelete;
         private Grouper grouperConfigFileUse;
         private System.Windows.Forms.Label lblConfigFileUse;
+        private System.Windows.Forms.Label lblNewSdkTransportType;
+        private System.Windows.Forms.CheckBox useAmqpWebSocketsCheckBox;
     }
 }

--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -389,6 +389,7 @@ namespace ServiceBusExplorer.Forms
                 SelectedEntities = SelectedEntities,
                 MessageBodyType = messageBodyType,
                 ConnectivityMode = ServiceBusHelper.ConnectivityMode,
+                UseAmqpWebSockets = ServiceBusHelper.UseAmqpWebSockets,
                 EncodingType = ServiceBusHelper.EncodingType
             };
 
@@ -445,6 +446,7 @@ namespace ServiceBusExplorer.Forms
                 SelectedEntities = optionForm.MainSettings.SelectedEntities;
                 messageBodyType = optionForm.MainSettings.MessageBodyType;
                 ServiceBusHelper.ConnectivityMode = optionForm.MainSettings.ConnectivityMode;
+                ServiceBusHelper.UseAmqpWebSockets = optionForm.MainSettings.UseAmqpWebSockets;
                 ServiceBusHelper.EncodingType = optionForm.MainSettings.EncodingType;
             }
         }
@@ -1337,6 +1339,7 @@ namespace ServiceBusExplorer.Forms
                     UpdateSavedConnectionsMenu();
                     SelectedEntities = connectForm.SelectedEntities;
                     ServiceBusHelper.ConnectivityMode = connectForm.ConnectivityMode;
+                    ServiceBusHelper.UseAmqpWebSockets = connectForm.UseAmqpWebSockets;
                     var serviceBusNamespace = ServiceBusNamespace.GetServiceBusNamespace(connectForm.Key ?? "Manual",
                         connectForm.ConnectionString, StaticWriteToLog);
                     serviceBusHelper.Connect(serviceBusNamespace);
@@ -3687,7 +3690,8 @@ namespace ServiceBusExplorer.Forms
                 MessageContentType = MessageContentType,
                 SelectedEntities = SelectedEntities,
                 MessageBodyType = messageBodyType,
-                ConnectivityMode = ServiceBusHelper.ConnectivityMode
+                ConnectivityMode = ServiceBusHelper.ConnectivityMode,
+                UseAmqpWebSockets = ServiceBusHelper.UseAmqpWebSockets
             };
 
             var readSettings = ConfigurationHelper.GetMainProperties(configFileUse, currentSettings, WriteToLog);
@@ -3766,6 +3770,7 @@ namespace ServiceBusExplorer.Forms
             SelectedEntities = readSettings.SelectedEntities;
             messageBodyType = readSettings.MessageBodyType;
             ServiceBusHelper.ConnectivityMode = readSettings.ConnectivityMode;
+            ServiceBusHelper.UseAmqpWebSockets = readSettings.UseAmqpWebSockets;
             ServiceBusHelper.EncodingType = readSettings.EncodingType;
 
             // Get values for settings that are not part of MainSettings

--- a/src/ServiceBusExplorer/Forms/OptionForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/OptionForm.Designer.cs
@@ -71,7 +71,6 @@ namespace ServiceBusExplorer.Forms
             this.tabPageGeneral = new System.Windows.Forms.TabPage();
             this.lblSaveCheckpointsOnExit = new System.Windows.Forms.Label();
             this.saveCheckpointsToFileCheckBox = new System.Windows.Forms.CheckBox();
-            this.cboSelectedEntities = new ServiceBusExplorer.Controls.CheckBoxComboBox();
             this.lblSelectedEntities = new System.Windows.Forms.Label();
             this.monitorRefreshIntervalNumericUpDown = new System.Windows.Forms.NumericUpDown();
             this.lblMonitorRefreshInterval = new System.Windows.Forms.Label();
@@ -124,6 +123,7 @@ namespace ServiceBusExplorer.Forms
             this.cboConnectivityMode = new System.Windows.Forms.ComboBox();
             this.lblConnectivityMode = new System.Windows.Forms.Label();
             this.mainPanel = new System.Windows.Forms.Panel();
+            this.cboSelectedEntities = new ServiceBusExplorer.Controls.CheckBoxComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).BeginInit();
             this.tabOptionsControl.SuspendLayout();
@@ -1093,7 +1093,6 @@ namespace ServiceBusExplorer.Forms
             // useAmqpWebSocketsCheckBox
             // 
             this.useAmqpWebSocketsCheckBox.AutoSize = true;
-            this.useAmqpWebSocketsCheckBox.Enabled = false;
             this.useAmqpWebSocketsCheckBox.ForeColor = System.Drawing.SystemColors.ControlText;
             this.useAmqpWebSocketsCheckBox.Location = new System.Drawing.Point(768, 108);
             this.useAmqpWebSocketsCheckBox.Margin = new System.Windows.Forms.Padding(6);
@@ -1101,6 +1100,7 @@ namespace ServiceBusExplorer.Forms
             this.useAmqpWebSocketsCheckBox.Size = new System.Drawing.Size(28, 27);
             this.useAmqpWebSocketsCheckBox.TabIndex = 68;
             this.useAmqpWebSocketsCheckBox.UseVisualStyleBackColor = true;
+            this.useAmqpWebSocketsCheckBox.CheckedChanged += new System.EventHandler(this.useAmqpWebSocketsCheckBox_CheckedChanged);
             // 
             // label4
             // 
@@ -1152,6 +1152,19 @@ namespace ServiceBusExplorer.Forms
             this.mainPanel.Size = new System.Drawing.Size(1229, 724);
             this.mainPanel.TabIndex = 1;
             this.mainPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.mainPanel_Paint);
+            // 
+            // cboSelectedEntities
+            // 
+            checkBoxProperties1.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.cboSelectedEntities.CheckBoxProperties = checkBoxProperties1;
+            this.cboSelectedEntities.DisplayMemberSingleItem = "";
+            this.cboSelectedEntities.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cboSelectedEntities.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cboSelectedEntities.FormattingEnabled = true;
+            this.cboSelectedEntities.Location = new System.Drawing.Point(135, 348);
+            this.cboSelectedEntities.Name = "cboSelectedEntities";
+            this.cboSelectedEntities.Size = new System.Drawing.Size(360, 21);
+            this.cboSelectedEntities.TabIndex = 50;
             // 
             // OptionForm
             // 

--- a/src/ServiceBusExplorer/Forms/OptionForm.cs
+++ b/src/ServiceBusExplorer/Forms/OptionForm.cs
@@ -212,7 +212,8 @@ namespace ServiceBusExplorer.Forms
             receiverThinkTimeNumericUpDown.Value = MainSettings.ReceiverThinkTime;
 
             monitorRefreshIntervalNumericUpDown.Value = MainSettings.MonitorRefreshInterval;
-            cboConnectivityMode.SelectedItem = ConnectivityMode.AutoDetect;
+            cboConnectivityMode.SelectedItem = MainSettings.ConnectivityMode;
+            useAmqpWebSocketsCheckBox.Checked = MainSettings.UseAmqpWebSockets;
             cboEncodingType.SelectedItem = EncodingType.ASCII;
 
             saveMessageToFileCheckBox.Checked = MainSettings.SaveMessageToFile;
@@ -357,6 +358,11 @@ namespace ServiceBusExplorer.Forms
             {
                 MainSettings.ConnectivityMode = connectivityMode;
             }
+        }
+
+        private void useAmqpWebSocketsCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            MainSettings.UseAmqpWebSockets = useAmqpWebSocketsCheckBox.Checked;
         }
 
         void cboDefaultMessageBodyType_SelectedIndexChanged(object sender, EventArgs e)
@@ -523,6 +529,8 @@ namespace ServiceBusExplorer.Forms
 
             SaveSetting(configuration, readSettings, ConfigurationParameters.ConnectivityMode,
                 MainSettings.ConnectivityMode);
+            SaveSetting(configuration, readSettings, ConfigurationParameters.UseAmqpWebSockets,
+                MainSettings.UseAmqpWebSockets);
             SaveSetting(configuration, readSettings, ConfigurationParameters.Encoding,
                 MainSettings.EncodingType);
 
@@ -592,6 +600,7 @@ namespace ServiceBusExplorer.Forms
             useAsciiCheckBox.Checked = mainSettings.UseAscii;
 
             cboConnectivityMode.SelectedItem = mainSettings.ConnectivityMode;
+            useAmqpWebSocketsCheckBox.Checked = mainSettings.UseAmqpWebSockets;
             cboEncodingType.SelectedItem = mainSettings.EncodingType;
 
             foreach (var item in mainSettings.SelectedEntities)


### PR DESCRIPTION
This PR aims to fix #396
It also replugs all the event handlers lost on the OptionForm

# Screenshots
Amqp setting is now enabled:
![image](https://user-images.githubusercontent.com/8553578/77221978-4a381800-6b4f-11ea-8dbf-8102302429cd.png)


Amqp settings and Connectivity mode are now taken from the options:
![image](https://user-images.githubusercontent.com/8553578/76995768-a719af80-6950-11ea-8e30-2c6db0d559bf.png)
