### PR TITLE
Added UI flow to reduce the likelihood of accidental mass deletions

### DIFF
--- a/src/Common/Helpers/ConfigurationHelper.cs
+++ b/src/Common/Helpers/ConfigurationHelper.cs
@@ -199,6 +199,9 @@ namespace ServiceBusExplorer.Helpers
             resultProperties.EncodingType = configuration.GetEnumValue
                 (ConfigurationParameters.Encoding, currentSettings.EncodingType, writeToLog);
 
+            resultProperties.DisableAccidentalDeletionPrevention = configuration.GetBoolValue
+                (ConfigurationParameters.DisableAccidentalDeletionPrevention, currentSettings.DisableAccidentalDeletionPrevention, writeToLog);
+
             resultProperties.ProxyOverrideDefault = configuration.GetBoolValue(ConfigurationParameters.ProxyOverrideDefault, currentSettings.ProxyOverrideDefault, writeToLog);
             resultProperties.ProxyUseDefaultCredentials = configuration.GetBoolValue(ConfigurationParameters.ProxyUseDefaultCredentials, currentSettings.ProxyUseDefaultCredentials, writeToLog);
             resultProperties.ProxyBypassOnLocal = configuration.GetBoolValue(ConfigurationParameters.ProxyBypassOnLocal, currentSettings.ProxyBypassOnLocal, writeToLog);

--- a/src/Common/Helpers/ConfigurationParameters.cs
+++ b/src/Common/Helpers/ConfigurationParameters.cs
@@ -57,6 +57,7 @@ namespace ServiceBusExplorer.Helpers
         public const string Encoding = "encoding";
         public const string SelectedEntitiesParameter = "selectedEntities";
         public const string MicrosoftServiceBusConnectionString = "Microsoft.ServiceBus.ConnectionString";
+        public const string DisableAccidentalDeletionPrevention = "disableAccidentalDeletionPrevention";
 
         public const string ProxyOverrideDefault = "Proxy.OverrideDefault";
         public const string ProxyAddress = "Proxy.Address";

--- a/src/Common/Helpers/MainSettings.cs
+++ b/src/Common/Helpers/MainSettings.cs
@@ -65,6 +65,8 @@ namespace ServiceBusExplorer.Helpers
         public bool UseAmqpWebSockets { get; set; }
         public Enums.EncodingType EncodingType { get; set; }
 
+        public bool DisableAccidentalDeletionPrevention { get; set; }
+
         public bool ProxyOverrideDefault { get; set; }
         public string ProxyAddress { get; set; }
         public string ProxyBypassList { get; set; }
@@ -271,6 +273,9 @@ namespace ServiceBusExplorer.Helpers
 
                 case ConfigurationParameters.UseAmqpWebSockets:
                     return UseAmqpWebSockets;
+
+                case ConfigurationParameters.DisableAccidentalDeletionPrevention:
+                    return DisableAccidentalDeletionPrevention;
 
                 case ConfigurationParameters.Encoding:
                     return EncodingType;

--- a/src/ServiceBusExplorer/Controls/AccidentalDeletionPreventionCheckControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/AccidentalDeletionPreventionCheckControl.Designer.cs
@@ -30,9 +30,10 @@
         {
 			this.pnlFlowLayout = new System.Windows.Forms.FlowLayoutPanel();
 			this.lblMessage = new System.Windows.Forms.Label();
-			this.lblEntityName = new System.Windows.Forms.Label();
-			this.txtEntityNameCheck = new System.Windows.Forms.TextBox();
+			this.lblDeletionScopePromptText = new System.Windows.Forms.Label();
+			this.txtDeletionScopePromptCheck = new System.Windows.Forms.TextBox();
 			this.lblExplanation = new System.Windows.Forms.Label();
+			this.chkDisableAccidentalDeletionPrevention = new System.Windows.Forms.CheckBox();
 			this.pnlFlowLayout.SuspendLayout();
 			this.SuspendLayout();
 			// 
@@ -42,15 +43,15 @@
             | System.Windows.Forms.AnchorStyles.Right)));
 			this.pnlFlowLayout.AutoSize = true;
 			this.pnlFlowLayout.Controls.Add(this.lblMessage);
-			this.pnlFlowLayout.Controls.Add(this.lblEntityName);
-			this.pnlFlowLayout.Controls.Add(this.txtEntityNameCheck);
+			this.pnlFlowLayout.Controls.Add(this.lblDeletionScopePromptText);
+			this.pnlFlowLayout.Controls.Add(this.txtDeletionScopePromptCheck);
 			this.pnlFlowLayout.Controls.Add(this.lblExplanation);
+			this.pnlFlowLayout.Controls.Add(this.chkDisableAccidentalDeletionPrevention);
 			this.pnlFlowLayout.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
 			this.pnlFlowLayout.Location = new System.Drawing.Point(0, 0);
 			this.pnlFlowLayout.Name = "pnlFlowLayout";
-			this.pnlFlowLayout.Size = new System.Drawing.Size(484, 100);
+			this.pnlFlowLayout.Size = new System.Drawing.Size(484, 141);
 			this.pnlFlowLayout.TabIndex = 3;
-			this.pnlFlowLayout.SizeChanged += new System.EventHandler(this.pnlFlowLayout_SizeChanged);
 			// 
 			// lblMessage
 			// 
@@ -58,33 +59,34 @@
 			this.lblMessage.Location = new System.Drawing.Point(3, 8);
 			this.lblMessage.Margin = new System.Windows.Forms.Padding(3, 8, 3, 0);
 			this.lblMessage.Name = "lblMessage";
-			this.lblMessage.Size = new System.Drawing.Size(362, 13);
+			this.lblMessage.Size = new System.Drawing.Size(478, 13);
 			this.lblMessage.TabIndex = 0;
-			this.lblMessage.Text = "To prevent accidental deletion, please type the name of item being deleted:";
+			this.lblMessage.Text = "To prevent accidental deletion of multiple items, please type the description of " +
+    "what is being deleted:";
 			// 
-			// lblEntityName
+			// lblDeletionScopePromptText
 			// 
-			this.lblEntityName.AutoSize = true;
-			this.lblEntityName.Font = new System.Drawing.Font("Consolas", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.lblEntityName.ForeColor = System.Drawing.Color.Red;
-			this.lblEntityName.Location = new System.Drawing.Point(30, 29);
-			this.lblEntityName.Margin = new System.Windows.Forms.Padding(30, 8, 3, 0);
-			this.lblEntityName.Name = "lblEntityName";
-			this.lblEntityName.Size = new System.Drawing.Size(84, 14);
-			this.lblEntityName.TabIndex = 1;
-			this.lblEntityName.Text = "Entity Name";
+			this.lblDeletionScopePromptText.AutoSize = true;
+			this.lblDeletionScopePromptText.Font = new System.Drawing.Font("Consolas", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.lblDeletionScopePromptText.ForeColor = System.Drawing.Color.Red;
+			this.lblDeletionScopePromptText.Location = new System.Drawing.Point(30, 29);
+			this.lblDeletionScopePromptText.Margin = new System.Windows.Forms.Padding(30, 8, 3, 0);
+			this.lblDeletionScopePromptText.Name = "lblDeletionScopePromptText";
+			this.lblDeletionScopePromptText.Size = new System.Drawing.Size(98, 14);
+			this.lblDeletionScopePromptText.TabIndex = 1;
+			this.lblDeletionScopePromptText.Text = "Deletion Type";
 			// 
-			// txtEntityNameCheck
+			// txtDeletionScopePromptCheck
 			// 
-			this.txtEntityNameCheck.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			this.txtDeletionScopePromptCheck.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.txtEntityNameCheck.Font = new System.Drawing.Font("Consolas", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.txtEntityNameCheck.ForeColor = System.Drawing.Color.Red;
-			this.txtEntityNameCheck.Location = new System.Drawing.Point(30, 46);
-			this.txtEntityNameCheck.Margin = new System.Windows.Forms.Padding(30, 3, 30, 3);
-			this.txtEntityNameCheck.Name = "txtEntityNameCheck";
-			this.txtEntityNameCheck.Size = new System.Drawing.Size(419, 22);
-			this.txtEntityNameCheck.TabIndex = 2;
+			this.txtDeletionScopePromptCheck.Font = new System.Drawing.Font("Consolas", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.txtDeletionScopePromptCheck.ForeColor = System.Drawing.Color.Red;
+			this.txtDeletionScopePromptCheck.Location = new System.Drawing.Point(30, 46);
+			this.txtDeletionScopePromptCheck.Margin = new System.Windows.Forms.Padding(30, 3, 30, 3);
+			this.txtDeletionScopePromptCheck.Name = "txtDeletionScopePromptCheck";
+			this.txtDeletionScopePromptCheck.Size = new System.Drawing.Size(424, 22);
+			this.txtDeletionScopePromptCheck.TabIndex = 2;
 			// 
 			// lblExplanation
 			// 
@@ -92,19 +94,31 @@
 			this.lblExplanation.Location = new System.Drawing.Point(3, 79);
 			this.lblExplanation.Margin = new System.Windows.Forms.Padding(3, 8, 3, 8);
 			this.lblExplanation.Name = "lblExplanation";
-			this.lblExplanation.Size = new System.Drawing.Size(473, 13);
+			this.lblExplanation.Size = new System.Drawing.Size(448, 26);
 			this.lblExplanation.TabIndex = 3;
-			this.lblExplanation.Text = "If you type the full name of the item, then that item and all of its children wil" +
-    "l be permanently deleted.";
+			this.lblExplanation.Text = "If you type the full text shown, then the selected item and all of its children w" +
+    "ill be permanently deleted.";
+			// 
+			// chkDisableAccidentalDeletionPrevention
+			// 
+			this.chkDisableAccidentalDeletionPrevention.AutoSize = true;
+			this.chkDisableAccidentalDeletionPrevention.Location = new System.Drawing.Point(8, 116);
+			this.chkDisableAccidentalDeletionPrevention.Margin = new System.Windows.Forms.Padding(8, 3, 3, 8);
+			this.chkDisableAccidentalDeletionPrevention.Name = "chkDisableAccidentalDeletionPrevention";
+			this.chkDisableAccidentalDeletionPrevention.Size = new System.Drawing.Size(256, 17);
+			this.chkDisableAccidentalDeletionPrevention.TabIndex = 4;
+			this.chkDisableAccidentalDeletionPrevention.Text = "Delete multiple items without this check next time";
+			this.chkDisableAccidentalDeletionPrevention.UseVisualStyleBackColor = true;
 			// 
 			// AccidentalDeletionPreventionCheckControl
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.AutoSize = true;
 			this.BackColor = System.Drawing.Color.Cornsilk;
 			this.Controls.Add(this.pnlFlowLayout);
 			this.Name = "AccidentalDeletionPreventionCheckControl";
-			this.Size = new System.Drawing.Size(484, 102);
+			this.Size = new System.Drawing.Size(484, 144);
 			this.pnlFlowLayout.ResumeLayout(false);
 			this.pnlFlowLayout.PerformLayout();
 			this.ResumeLayout(false);
@@ -116,8 +130,9 @@
 
         private System.Windows.Forms.FlowLayoutPanel pnlFlowLayout;
         private System.Windows.Forms.Label lblMessage;
-        private System.Windows.Forms.Label lblEntityName;
-        private System.Windows.Forms.TextBox txtEntityNameCheck;
+        private System.Windows.Forms.Label lblDeletionScopePromptText;
+        private System.Windows.Forms.TextBox txtDeletionScopePromptCheck;
         private System.Windows.Forms.Label lblExplanation;
+        private System.Windows.Forms.CheckBox chkDisableAccidentalDeletionPrevention;
     }
 }

--- a/src/ServiceBusExplorer/Controls/AccidentalDeletionPreventionCheckControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/AccidentalDeletionPreventionCheckControl.Designer.cs
@@ -1,0 +1,123 @@
+﻿namespace ServiceBusExplorer.Controls
+{
+    partial class AccidentalDeletionPreventionCheckControl
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+			this.pnlFlowLayout = new System.Windows.Forms.FlowLayoutPanel();
+			this.lblMessage = new System.Windows.Forms.Label();
+			this.lblEntityName = new System.Windows.Forms.Label();
+			this.txtEntityNameCheck = new System.Windows.Forms.TextBox();
+			this.lblExplanation = new System.Windows.Forms.Label();
+			this.pnlFlowLayout.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// pnlFlowLayout
+			// 
+			this.pnlFlowLayout.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.pnlFlowLayout.AutoSize = true;
+			this.pnlFlowLayout.Controls.Add(this.lblMessage);
+			this.pnlFlowLayout.Controls.Add(this.lblEntityName);
+			this.pnlFlowLayout.Controls.Add(this.txtEntityNameCheck);
+			this.pnlFlowLayout.Controls.Add(this.lblExplanation);
+			this.pnlFlowLayout.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+			this.pnlFlowLayout.Location = new System.Drawing.Point(0, 0);
+			this.pnlFlowLayout.Name = "pnlFlowLayout";
+			this.pnlFlowLayout.Size = new System.Drawing.Size(484, 100);
+			this.pnlFlowLayout.TabIndex = 3;
+			this.pnlFlowLayout.SizeChanged += new System.EventHandler(this.pnlFlowLayout_SizeChanged);
+			// 
+			// lblMessage
+			// 
+			this.lblMessage.AutoSize = true;
+			this.lblMessage.Location = new System.Drawing.Point(3, 8);
+			this.lblMessage.Margin = new System.Windows.Forms.Padding(3, 8, 3, 0);
+			this.lblMessage.Name = "lblMessage";
+			this.lblMessage.Size = new System.Drawing.Size(362, 13);
+			this.lblMessage.TabIndex = 0;
+			this.lblMessage.Text = "To prevent accidental deletion, please type the name of item being deleted:";
+			// 
+			// lblEntityName
+			// 
+			this.lblEntityName.AutoSize = true;
+			this.lblEntityName.Font = new System.Drawing.Font("Consolas", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.lblEntityName.ForeColor = System.Drawing.Color.Red;
+			this.lblEntityName.Location = new System.Drawing.Point(30, 29);
+			this.lblEntityName.Margin = new System.Windows.Forms.Padding(30, 8, 3, 0);
+			this.lblEntityName.Name = "lblEntityName";
+			this.lblEntityName.Size = new System.Drawing.Size(84, 14);
+			this.lblEntityName.TabIndex = 1;
+			this.lblEntityName.Text = "Entity Name";
+			// 
+			// txtEntityNameCheck
+			// 
+			this.txtEntityNameCheck.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.txtEntityNameCheck.Font = new System.Drawing.Font("Consolas", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.txtEntityNameCheck.ForeColor = System.Drawing.Color.Red;
+			this.txtEntityNameCheck.Location = new System.Drawing.Point(30, 46);
+			this.txtEntityNameCheck.Margin = new System.Windows.Forms.Padding(30, 3, 30, 3);
+			this.txtEntityNameCheck.Name = "txtEntityNameCheck";
+			this.txtEntityNameCheck.Size = new System.Drawing.Size(419, 22);
+			this.txtEntityNameCheck.TabIndex = 2;
+			// 
+			// lblExplanation
+			// 
+			this.lblExplanation.AutoSize = true;
+			this.lblExplanation.Location = new System.Drawing.Point(3, 79);
+			this.lblExplanation.Margin = new System.Windows.Forms.Padding(3, 8, 3, 8);
+			this.lblExplanation.Name = "lblExplanation";
+			this.lblExplanation.Size = new System.Drawing.Size(473, 13);
+			this.lblExplanation.TabIndex = 3;
+			this.lblExplanation.Text = "If you type the full name of the item, then that item and all of its children wil" +
+    "l be permanently deleted.";
+			// 
+			// AccidentalDeletionPreventionCheckControl
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.BackColor = System.Drawing.Color.Cornsilk;
+			this.Controls.Add(this.pnlFlowLayout);
+			this.Name = "AccidentalDeletionPreventionCheckControl";
+			this.Size = new System.Drawing.Size(484, 102);
+			this.pnlFlowLayout.ResumeLayout(false);
+			this.pnlFlowLayout.PerformLayout();
+			this.ResumeLayout(false);
+			this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.FlowLayoutPanel pnlFlowLayout;
+        private System.Windows.Forms.Label lblMessage;
+        private System.Windows.Forms.Label lblEntityName;
+        private System.Windows.Forms.TextBox txtEntityNameCheck;
+        private System.Windows.Forms.Label lblExplanation;
+    }
+}

--- a/src/ServiceBusExplorer/Controls/AccidentalDeletionPreventionCheckControl.cs
+++ b/src/ServiceBusExplorer/Controls/AccidentalDeletionPreventionCheckControl.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace ServiceBusExplorer.Controls
+{
+    public partial class AccidentalDeletionPreventionCheckControl : UserControl
+    {
+        #region Private Constants
+        private const string DeletionBlockedTitle = "Deletion Blocked";
+        private const string DeletionBlockedMessage = "The deletion will not proceed unless you indicate your intention by typing the name of the item shown.";
+        #endregion
+
+        #region Public Constructors
+        public AccidentalDeletionPreventionCheckControl()
+        {
+            InitializeComponent();
+        }
+        #endregion
+
+        #region Event Handlers
+        private void pnlFlowLayout_SizeChanged(object sender, EventArgs e)
+        {
+            this.ClientSize = new Size(
+                this.ClientSize.Width,
+                pnlFlowLayout.Height);
+        }
+        #endregion
+
+        #region Public Properties
+        public string EntityName
+        {
+            get => lblEntityName.Text;
+            set => lblEntityName.Text = value;
+        }
+        #endregion
+
+        #region Public Methods
+        public bool CheckAcceptanceAndNotifyUser()
+        {
+            bool isAccepted = string.Equals(
+                txtEntityNameCheck.Text.Trim(),
+                lblEntityName.Text,
+                StringComparison.InvariantCultureIgnoreCase);
+
+            if (!isAccepted)
+            {
+                MessageBox.Show(
+                    FindForm(),
+                    DeletionBlockedMessage,
+                    DeletionBlockedTitle,
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+            }
+
+            return isAccepted;
+        }
+        #endregion
+    }
+}

--- a/src/ServiceBusExplorer/Controls/AccidentalDeletionPreventionCheckControl.cs
+++ b/src/ServiceBusExplorer/Controls/AccidentalDeletionPreventionCheckControl.cs
@@ -18,20 +18,17 @@ namespace ServiceBusExplorer.Controls
         }
         #endregion
 
-        #region Event Handlers
-        private void pnlFlowLayout_SizeChanged(object sender, EventArgs e)
-        {
-            this.ClientSize = new Size(
-                this.ClientSize.Width,
-                pnlFlowLayout.Height);
-        }
-        #endregion
-
         #region Public Properties
-        public string EntityName
+        public string DeletionScopePromptText
         {
-            get => lblEntityName.Text;
-            set => lblEntityName.Text = value;
+            get => lblDeletionScopePromptText.Text;
+            set => lblDeletionScopePromptText.Text = value;
+        }
+
+        public bool DisableFurtherChecks
+        {
+            get => chkDisableAccidentalDeletionPrevention.Checked;
+            set => chkDisableAccidentalDeletionPrevention.Checked = value;
         }
         #endregion
 
@@ -39,8 +36,8 @@ namespace ServiceBusExplorer.Controls
         public bool CheckAcceptanceAndNotifyUser()
         {
             bool isAccepted = string.Equals(
-                txtEntityNameCheck.Text.Trim(),
-                lblEntityName.Text,
+                txtDeletionScopePromptCheck.Text.Trim(),
+                lblDeletionScopePromptText.Text,
                 StringComparison.InvariantCultureIgnoreCase);
 
             if (!isAccepted)

--- a/src/ServiceBusExplorer/Controls/AccidentalDeletionPreventionCheckControl.resx
+++ b/src/ServiceBusExplorer/Controls/AccidentalDeletionPreventionCheckControl.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/ServiceBusExplorer/Forms/DeleteForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/DeleteForm.Designer.cs
@@ -57,6 +57,8 @@ namespace ServiceBusExplorer.Forms
             this.mainPanel = new System.Windows.Forms.Panel();
             this.lblMessage = new System.Windows.Forms.Label();
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.buttonsPanel = new System.Windows.Forms.Panel();
+            this.accidentalDeletionPreventionCheckControl = new ServiceBusExplorer.Controls.AccidentalDeletionPreventionCheckControl();
             this.mainPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             this.SuspendLayout();
@@ -128,6 +130,24 @@ namespace ServiceBusExplorer.Forms
             this.pictureBox1.TabIndex = 33;
             this.pictureBox1.TabStop = false;
             // 
+            // buttonsPanel
+            // 
+            this.buttonsPanel.Location = new System.Drawing.Point(0, 63);
+            this.buttonsPanel.Name = "buttonsPanel";
+            this.buttonsPanel.Size = new System.Drawing.Size(312, 49);
+            this.buttonsPanel.TabIndex = 34;
+            // 
+            // accidentalDeletionPreventionCheckControl
+            // 
+            this.accidentalDeletionPreventionCheckControl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.accidentalDeletionPreventionCheckControl.EntityName = "Entity Name";
+            this.accidentalDeletionPreventionCheckControl.Location = new System.Drawing.Point(0, 65);
+            this.accidentalDeletionPreventionCheckControl.Name = "accidentalDeletionPreventionCheckControl";
+            this.accidentalDeletionPreventionCheckControl.Size = new System.Drawing.Size(312, 110);
+            this.accidentalDeletionPreventionCheckControl.TabIndex = 35;
+            this.accidentalDeletionPreventionCheckControl.Visible = false;
+            // 
             // DeleteForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -137,6 +157,8 @@ namespace ServiceBusExplorer.Forms
             this.Controls.Add(this.mainPanel);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnOk);
+            this.Controls.Add(this.buttonsPanel);
+            this.Controls.Add(this.accidentalDeletionPreventionCheckControl);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
@@ -158,5 +180,7 @@ namespace ServiceBusExplorer.Forms
         private System.Windows.Forms.Panel mainPanel;
         private System.Windows.Forms.Label lblMessage;
         private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.Panel buttonsPanel;
+        private Controls.AccidentalDeletionPreventionCheckControl accidentalDeletionPreventionCheckControl;
     }
 }

--- a/src/ServiceBusExplorer/Forms/DeleteForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/DeleteForm.Designer.cs
@@ -141,10 +141,13 @@ namespace ServiceBusExplorer.Forms
             // 
             this.accidentalDeletionPreventionCheckControl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.accidentalDeletionPreventionCheckControl.EntityName = "Entity Name";
+            this.accidentalDeletionPreventionCheckControl.AutoSize = true;
+            this.accidentalDeletionPreventionCheckControl.BackColor = System.Drawing.Color.Cornsilk;
+            this.accidentalDeletionPreventionCheckControl.DeletionScopePromptText = "Deletion Type";
+            this.accidentalDeletionPreventionCheckControl.DisableFurtherChecks = false;
             this.accidentalDeletionPreventionCheckControl.Location = new System.Drawing.Point(0, 65);
             this.accidentalDeletionPreventionCheckControl.Name = "accidentalDeletionPreventionCheckControl";
-            this.accidentalDeletionPreventionCheckControl.Size = new System.Drawing.Size(312, 110);
+            this.accidentalDeletionPreventionCheckControl.Size = new System.Drawing.Size(312, 157);
             this.accidentalDeletionPreventionCheckControl.TabIndex = 35;
             this.accidentalDeletionPreventionCheckControl.Visible = false;
             // 
@@ -170,6 +173,7 @@ namespace ServiceBusExplorer.Forms
             this.mainPanel.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 

--- a/src/ServiceBusExplorer/Forms/DeleteForm.cs
+++ b/src/ServiceBusExplorer/Forms/DeleteForm.cs
@@ -39,6 +39,10 @@ namespace ServiceBusExplorer.Forms
         private const string Unknown = "Unknown";
         #endregion
 
+        #region Private Fields
+        private bool useAccidentalDeletionPreventionCheck = false;
+        #endregion
+
         #region Public Constructor
         public DeleteForm(string message)
         {
@@ -57,11 +61,36 @@ namespace ServiceBusExplorer.Forms
         }
         #endregion
 
+        #region Public Methods
+        public void ShowAccidentalDeletionPreventionCheck(string entityName)
+        {
+            useAccidentalDeletionPreventionCheck = true;
+
+            accidentalDeletionPreventionCheckControl.EntityName = entityName;
+            accidentalDeletionPreventionCheckControl.Visible = true;
+
+            accidentalDeletionPreventionCheckControl.Top = mainPanel.Bottom;
+            buttonsPanel.Top = accidentalDeletionPreventionCheckControl.Bottom;
+
+            ClientSize = new Size(ClientSize.Width, buttonsPanel.Bottom);
+        }
+        #endregion
+
         #region Event Handlers
         private void btnOk_Click(object sender, EventArgs e)
         {
-            DialogResult = DialogResult.OK;
-            Close();
+            bool acceptForm = false;
+
+            if (useAccidentalDeletionPreventionCheck == false)
+                acceptForm = true;
+            else
+                acceptForm = accidentalDeletionPreventionCheckControl.CheckAcceptanceAndNotifyUser();
+
+            if (acceptForm)
+            {
+                DialogResult = DialogResult.OK;
+                Close();
+            }
         }
 
         private void btnCancel_Click(object sender, EventArgs e)

--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -2630,8 +2630,6 @@ namespace ServiceBusExplorer.Forms
                         {
                             using (var deleteForm = new DeleteForm(DeleteAllSubscriptions))
                             {
-                                deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Subscriptions");
-
                                 if (deleteForm.ShowDialog() == DialogResult.OK)
                                 {
                                     await serviceBusHelper.DeleteSubscriptions(subscriptionDescriptions);

--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -2306,6 +2306,8 @@ namespace ServiceBusExplorer.Forms
                     {
                         using (var deleteForm = new DeleteForm(DeleteAllEntities))
                         {
+                            deleteForm.ShowAccidentalDeletionPreventionCheck("Absolutely Everything");
+
                             if (deleteForm.ShowDialog() == DialogResult.OK)
                             {
                                 var queueList = new List<string>();
@@ -2324,6 +2326,8 @@ namespace ServiceBusExplorer.Forms
                     {
                         using (var deleteForm = new DeleteForm(DeleteAllQueues))
                         {
+                            deleteForm.ShowAccidentalDeletionPreventionCheck("All Queues");
+
                             if (deleteForm.ShowDialog() == DialogResult.OK)
                             {
                                 var queueList = new List<string>();
@@ -2339,6 +2343,8 @@ namespace ServiceBusExplorer.Forms
                     {
                         using (var deleteForm = new DeleteForm(DeleteAllTopics))
                         {
+                            deleteForm.ShowAccidentalDeletionPreventionCheck("All Topics");
+
                             if (deleteForm.ShowDialog() == DialogResult.OK)
                             {
                                 var topicList = new List<string>();
@@ -2354,6 +2360,8 @@ namespace ServiceBusExplorer.Forms
                     {
                         using (var deleteForm = new DeleteForm(DeleteAllRelays))
                         {
+                            deleteForm.ShowAccidentalDeletionPreventionCheck("All Relays");
+
                             if (deleteForm.ShowDialog() == DialogResult.OK)
                             {
                                 var relayServiceList = new List<string>();
@@ -2369,6 +2377,8 @@ namespace ServiceBusExplorer.Forms
                     {
                         using (var deleteForm = new DeleteForm(DeleteAllEventHubs))
                         {
+                            deleteForm.ShowAccidentalDeletionPreventionCheck("All Event Hubs");
+
                             if (deleteForm.ShowDialog() == DialogResult.OK)
                             {
                                 var eventHubList = new List<string>();
@@ -2388,6 +2398,8 @@ namespace ServiceBusExplorer.Forms
                             var eventHubDescription = parent.Tag as EventHubDescription;
                             using (var deleteForm = new DeleteForm(string.Format(DeleteAllConsumerGroups, eventHubDescription.Path)))
                             {
+                                deleteForm.ShowAccidentalDeletionPreventionCheck("All Consumer Groups");
+
                                 if (deleteForm.ShowDialog() == DialogResult.OK)
                                 {
                                     var notificationHubList = new List<string>();
@@ -2405,6 +2417,8 @@ namespace ServiceBusExplorer.Forms
                     {
                         using (var deleteForm = new DeleteForm(DeleteAllNotificationHubs))
                         {
+                            deleteForm.ShowAccidentalDeletionPreventionCheck("All Notification Hubs");
+
                             if (deleteForm.ShowDialog() == DialogResult.OK)
                             {
                                 var notificationHubList = new List<string>();
@@ -2428,6 +2442,8 @@ namespace ServiceBusExplorer.Forms
                         {
                             using (var deleteForm = new DeleteForm(string.Format(DeleteAllQueuesInPath, FormatAbsolutePathForEdit(urlSegmentWrapper.Uri))))
                             {
+                                deleteForm.ShowAccidentalDeletionPreventionCheck("All Queues In Path");
+
                                 if (deleteForm.ShowDialog() == DialogResult.OK)
                                 {
                                     var queueList = new List<string>();
@@ -2440,6 +2456,8 @@ namespace ServiceBusExplorer.Forms
                         {
                             using (var deleteForm = new DeleteForm(string.Format(DeleteAllTopicsInPath, FormatAbsolutePathForEdit(urlSegmentWrapper.Uri))))
                             {
+                                deleteForm.ShowAccidentalDeletionPreventionCheck("All Topics In Path");
+
                                 if (deleteForm.ShowDialog() == DialogResult.OK)
                                 {
                                     var topicList = new List<string>();
@@ -2452,6 +2470,8 @@ namespace ServiceBusExplorer.Forms
                         {
                             using (var deleteForm = new DeleteForm(string.Format(DeleteAllRelaysInPath, FormatAbsolutePathForEdit(urlSegmentWrapper.Uri))))
                             {
+                                deleteForm.ShowAccidentalDeletionPreventionCheck("All Relays In Path");
+
                                 if (deleteForm.ShowDialog() == DialogResult.OK)
                                 {
                                     var relayServiceList = new List<string>();
@@ -2640,6 +2660,8 @@ namespace ServiceBusExplorer.Forms
                         {
                             using (var deleteForm = new DeleteForm(DeleteAllRules))
                             {
+                                deleteForm.ShowAccidentalDeletionPreventionCheck("All Rules");
+
                                 if (deleteForm.ShowDialog() == DialogResult.OK)
                                 {
                                     serviceBusHelper.RemoveRules(ruleWrappers);

--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -402,6 +402,11 @@ namespace ServiceBusExplorer.Forms
                 ProxyPassword = ProxyPassword
             };
 
+            var configuration = TwoFilesConfiguration.Create(configFileUse, WriteToLog);
+
+            mainSettings.DisableAccidentalDeletionPrevention = configuration.GetBoolValue(
+                ConfigurationParameters.DisableAccidentalDeletionPrevention, defaultValue: false, WriteToLog);
+
             var lastConfigFileUse = configFileUse;
 
             using (var optionForm = new OptionForm(mainSettings, configFileUse))
@@ -2301,12 +2306,14 @@ namespace ServiceBusExplorer.Forms
                     var eventHubListNode = FindNode(Constants.EventHubEntities, rootNode);
                     var notificationHubListNode = FindNode(Constants.NotificationHubEntities, rootNode);
 
+                    var configuration = TwoFilesConfiguration.Create(configFileUse, WriteToLog);
+
                     // Root Node
                     if (serviceBusTreeView.SelectedNode == rootNode)
                     {
                         using (var deleteForm = new DeleteForm(DeleteAllEntities))
                         {
-                            deleteForm.ShowAccidentalDeletionPreventionCheck("Absolutely Everything");
+                            deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "Absolutely Everything");
 
                             if (deleteForm.ShowDialog() == DialogResult.OK)
                             {
@@ -2326,7 +2333,7 @@ namespace ServiceBusExplorer.Forms
                     {
                         using (var deleteForm = new DeleteForm(DeleteAllQueues))
                         {
-                            deleteForm.ShowAccidentalDeletionPreventionCheck("All Queues");
+                            deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Queues");
 
                             if (deleteForm.ShowDialog() == DialogResult.OK)
                             {
@@ -2343,7 +2350,7 @@ namespace ServiceBusExplorer.Forms
                     {
                         using (var deleteForm = new DeleteForm(DeleteAllTopics))
                         {
-                            deleteForm.ShowAccidentalDeletionPreventionCheck("All Topics");
+                            deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Topics");
 
                             if (deleteForm.ShowDialog() == DialogResult.OK)
                             {
@@ -2360,7 +2367,7 @@ namespace ServiceBusExplorer.Forms
                     {
                         using (var deleteForm = new DeleteForm(DeleteAllRelays))
                         {
-                            deleteForm.ShowAccidentalDeletionPreventionCheck("All Relays");
+                            deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Relays");
 
                             if (deleteForm.ShowDialog() == DialogResult.OK)
                             {
@@ -2377,7 +2384,7 @@ namespace ServiceBusExplorer.Forms
                     {
                         using (var deleteForm = new DeleteForm(DeleteAllEventHubs))
                         {
-                            deleteForm.ShowAccidentalDeletionPreventionCheck("All Event Hubs");
+                            deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Event Hubs");
 
                             if (deleteForm.ShowDialog() == DialogResult.OK)
                             {
@@ -2398,7 +2405,7 @@ namespace ServiceBusExplorer.Forms
                             var eventHubDescription = parent.Tag as EventHubDescription;
                             using (var deleteForm = new DeleteForm(string.Format(DeleteAllConsumerGroups, eventHubDescription.Path)))
                             {
-                                deleteForm.ShowAccidentalDeletionPreventionCheck("All Consumer Groups");
+                                deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Consumer Groups");
 
                                 if (deleteForm.ShowDialog() == DialogResult.OK)
                                 {
@@ -2417,7 +2424,7 @@ namespace ServiceBusExplorer.Forms
                     {
                         using (var deleteForm = new DeleteForm(DeleteAllNotificationHubs))
                         {
-                            deleteForm.ShowAccidentalDeletionPreventionCheck("All Notification Hubs");
+                            deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Notification Hubs");
 
                             if (deleteForm.ShowDialog() == DialogResult.OK)
                             {
@@ -2442,7 +2449,7 @@ namespace ServiceBusExplorer.Forms
                         {
                             using (var deleteForm = new DeleteForm(string.Format(DeleteAllQueuesInPath, FormatAbsolutePathForEdit(urlSegmentWrapper.Uri))))
                             {
-                                deleteForm.ShowAccidentalDeletionPreventionCheck("All Queues In Path");
+                                deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Queues In Path");
 
                                 if (deleteForm.ShowDialog() == DialogResult.OK)
                                 {
@@ -2456,7 +2463,7 @@ namespace ServiceBusExplorer.Forms
                         {
                             using (var deleteForm = new DeleteForm(string.Format(DeleteAllTopicsInPath, FormatAbsolutePathForEdit(urlSegmentWrapper.Uri))))
                             {
-                                deleteForm.ShowAccidentalDeletionPreventionCheck("All Topics In Path");
+                                deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Topics In Path");
 
                                 if (deleteForm.ShowDialog() == DialogResult.OK)
                                 {
@@ -2470,7 +2477,7 @@ namespace ServiceBusExplorer.Forms
                         {
                             using (var deleteForm = new DeleteForm(string.Format(DeleteAllRelaysInPath, FormatAbsolutePathForEdit(urlSegmentWrapper.Uri))))
                             {
-                                deleteForm.ShowAccidentalDeletionPreventionCheck("All Relays In Path");
+                                deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Relays In Path");
 
                                 if (deleteForm.ShowDialog() == DialogResult.OK)
                                 {
@@ -2623,6 +2630,8 @@ namespace ServiceBusExplorer.Forms
                         {
                             using (var deleteForm = new DeleteForm(DeleteAllSubscriptions))
                             {
+                                deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Subscriptions");
+
                                 if (deleteForm.ShowDialog() == DialogResult.OK)
                                 {
                                     await serviceBusHelper.DeleteSubscriptions(subscriptionDescriptions);
@@ -2660,7 +2669,7 @@ namespace ServiceBusExplorer.Forms
                         {
                             using (var deleteForm = new DeleteForm(DeleteAllRules))
                             {
-                                deleteForm.ShowAccidentalDeletionPreventionCheck("All Rules");
+                                deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Rules");
 
                                 if (deleteForm.ShowDialog() == DialogResult.OK)
                                 {

--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -2306,6 +2306,8 @@ namespace ServiceBusExplorer.Forms
                     var eventHubListNode = FindNode(Constants.EventHubEntities, rootNode);
                     var notificationHubListNode = FindNode(Constants.NotificationHubEntities, rootNode);
 
+                    string serviceBusNamespaceLocalName = GetServiceBusNamespaceLocalName(rootNode.Text);
+
                     var configuration = TwoFilesConfiguration.Create(configFileUse, WriteToLog);
 
                     // Root Node
@@ -2313,7 +2315,7 @@ namespace ServiceBusExplorer.Forms
                     {
                         using (var deleteForm = new DeleteForm(DeleteAllEntities))
                         {
-                            deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "Absolutely Everything");
+                            deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "Everything in " + serviceBusNamespaceLocalName);
 
                             if (deleteForm.ShowDialog() == DialogResult.OK)
                             {
@@ -2333,7 +2335,7 @@ namespace ServiceBusExplorer.Forms
                     {
                         using (var deleteForm = new DeleteForm(DeleteAllQueues))
                         {
-                            deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Queues");
+                            deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All queues in " + serviceBusNamespaceLocalName);
 
                             if (deleteForm.ShowDialog() == DialogResult.OK)
                             {
@@ -2350,7 +2352,7 @@ namespace ServiceBusExplorer.Forms
                     {
                         using (var deleteForm = new DeleteForm(DeleteAllTopics))
                         {
-                            deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Topics");
+                            deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All topics in " + serviceBusNamespaceLocalName);
 
                             if (deleteForm.ShowDialog() == DialogResult.OK)
                             {
@@ -2367,7 +2369,7 @@ namespace ServiceBusExplorer.Forms
                     {
                         using (var deleteForm = new DeleteForm(DeleteAllRelays))
                         {
-                            deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Relays");
+                            deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All relays in " + serviceBusNamespaceLocalName);
 
                             if (deleteForm.ShowDialog() == DialogResult.OK)
                             {
@@ -2384,7 +2386,7 @@ namespace ServiceBusExplorer.Forms
                     {
                         using (var deleteForm = new DeleteForm(DeleteAllEventHubs))
                         {
-                            deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Event Hubs");
+                            deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All event hubs in " + serviceBusNamespaceLocalName);
 
                             if (deleteForm.ShowDialog() == DialogResult.OK)
                             {
@@ -2405,7 +2407,7 @@ namespace ServiceBusExplorer.Forms
                             var eventHubDescription = parent.Tag as EventHubDescription;
                             using (var deleteForm = new DeleteForm(string.Format(DeleteAllConsumerGroups, eventHubDescription.Path)))
                             {
-                                deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Consumer Groups");
+                                deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All consumer groups in " + serviceBusNamespaceLocalName);
 
                                 if (deleteForm.ShowDialog() == DialogResult.OK)
                                 {
@@ -2424,7 +2426,7 @@ namespace ServiceBusExplorer.Forms
                     {
                         using (var deleteForm = new DeleteForm(DeleteAllNotificationHubs))
                         {
-                            deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Notification Hubs");
+                            deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All notification hubs in " + serviceBusNamespaceLocalName);
 
                             if (deleteForm.ShowDialog() == DialogResult.OK)
                             {
@@ -2449,7 +2451,7 @@ namespace ServiceBusExplorer.Forms
                         {
                             using (var deleteForm = new DeleteForm(string.Format(DeleteAllQueuesInPath, FormatAbsolutePathForEdit(urlSegmentWrapper.Uri))))
                             {
-                                deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Queues In Path");
+                                deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "Queues in subpath of " + serviceBusNamespaceLocalName);
 
                                 if (deleteForm.ShowDialog() == DialogResult.OK)
                                 {
@@ -2463,7 +2465,7 @@ namespace ServiceBusExplorer.Forms
                         {
                             using (var deleteForm = new DeleteForm(string.Format(DeleteAllTopicsInPath, FormatAbsolutePathForEdit(urlSegmentWrapper.Uri))))
                             {
-                                deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Topics In Path");
+                                deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "Topics in subpath of " + serviceBusNamespaceLocalName);
 
                                 if (deleteForm.ShowDialog() == DialogResult.OK)
                                 {
@@ -2477,7 +2479,7 @@ namespace ServiceBusExplorer.Forms
                         {
                             using (var deleteForm = new DeleteForm(string.Format(DeleteAllRelaysInPath, FormatAbsolutePathForEdit(urlSegmentWrapper.Uri))))
                             {
-                                deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Relays In Path");
+                                deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "Relays in subpath of " + serviceBusNamespaceLocalName);
 
                                 if (deleteForm.ShowDialog() == DialogResult.OK)
                                 {
@@ -2667,7 +2669,7 @@ namespace ServiceBusExplorer.Forms
                         {
                             using (var deleteForm = new DeleteForm(DeleteAllRules))
                             {
-                                deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All Rules");
+                                deleteForm.ShowAccidentalDeletionPreventionCheck(configuration, "All rules in " + serviceBusNamespaceLocalName);
 
                                 if (deleteForm.ShowDialog() == DialogResult.OK)
                                 {
@@ -3924,6 +3926,25 @@ namespace ServiceBusExplorer.Forms
         public static void StaticWriteToLog(string message, bool async = true)
         {
             mainSingletonMainForm.WriteToLog(message);
+        }
+        #endregion
+
+        #region Private Static Methods
+        private static string GetServiceBusNamespaceLocalName(string text)
+        {
+            if (Uri.TryCreate(text, UriKind.Absolute, out var serviceBusNamespaceUri))
+            {
+                string hostNameQualified = serviceBusNamespaceUri.Host;
+
+                int separator = hostNameQualified.IndexOf('.');
+
+                if (separator < 0)
+                    return hostNameQualified;
+                else
+                    return hostNameQualified.Substring(0, separator);
+            }
+
+            return text;
         }
         #endregion
 

--- a/src/ServiceBusExplorer/Forms/OptionForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/OptionForm.Designer.cs
@@ -69,6 +69,8 @@ namespace ServiceBusExplorer.Forms
             this.btnOpenConfig = new System.Windows.Forms.Button();
             this.tabOptionsControl = new System.Windows.Forms.TabControl();
             this.tabPageGeneral = new System.Windows.Forms.TabPage();
+            this.disableAccidentalDeletionPrevention = new System.Windows.Forms.CheckBox();
+            this.lblDisableAccidentalDeletionPrevention = new System.Windows.Forms.Label();
             this.lblSaveCheckpointsOnExit = new System.Windows.Forms.Label();
             this.saveCheckpointsToFileCheckBox = new System.Windows.Forms.CheckBox();
             this.cboSelectedEntities = new ServiceBusExplorer.Controls.CheckBoxComboBox();
@@ -169,10 +171,9 @@ namespace ServiceBusExplorer.Forms
             this.btnOk.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnOk.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnOk.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnOk.Location = new System.Drawing.Point(576, 737);
-            this.btnOk.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.btnOk.Location = new System.Drawing.Point(288, 383);
             this.btnOk.Name = "btnOk";
-            this.btnOk.Size = new System.Drawing.Size(144, 46);
+            this.btnOk.Size = new System.Drawing.Size(72, 24);
             this.btnOk.TabIndex = 0;
             this.btnOk.Text = "&OK";
             this.btnOk.UseVisualStyleBackColor = false;
@@ -190,10 +191,9 @@ namespace ServiceBusExplorer.Forms
             this.btnCancel.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCancel.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnCancel.Location = new System.Drawing.Point(736, 737);
-            this.btnCancel.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.btnCancel.Location = new System.Drawing.Point(368, 383);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(144, 46);
+            this.btnCancel.Size = new System.Drawing.Size(72, 24);
             this.btnCancel.TabIndex = 1;
             this.btnCancel.Text = "&Cancel";
             this.btnCancel.UseVisualStyleBackColor = false;
@@ -209,10 +209,9 @@ namespace ServiceBusExplorer.Forms
             this.btnReset.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnReset.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnReset.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnReset.Location = new System.Drawing.Point(1056, 737);
-            this.btnReset.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.btnReset.Location = new System.Drawing.Point(528, 383);
             this.btnReset.Name = "btnReset";
-            this.btnReset.Size = new System.Drawing.Size(144, 46);
+            this.btnReset.Size = new System.Drawing.Size(72, 24);
             this.btnReset.TabIndex = 3;
             this.btnReset.Text = "&Reset";
             this.btnReset.UseVisualStyleBackColor = false;
@@ -228,10 +227,9 @@ namespace ServiceBusExplorer.Forms
             this.btnSave.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnSave.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnSave.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnSave.Location = new System.Drawing.Point(896, 737);
-            this.btnSave.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.btnSave.Location = new System.Drawing.Point(448, 383);
             this.btnSave.Name = "btnSave";
-            this.btnSave.Size = new System.Drawing.Size(144, 46);
+            this.btnSave.Size = new System.Drawing.Size(72, 24);
             this.btnSave.TabIndex = 2;
             this.btnSave.Text = "&Save";
             this.btnSave.UseVisualStyleBackColor = false;
@@ -257,7 +255,7 @@ namespace ServiceBusExplorer.Forms
             this.numericUpDown1.Location = new System.Drawing.Point(441, 273);
             this.numericUpDown1.Margin = new System.Windows.Forms.Padding(4);
             this.numericUpDown1.Name = "numericUpDown1";
-            this.numericUpDown1.Size = new System.Drawing.Size(107, 31);
+            this.numericUpDown1.Size = new System.Drawing.Size(107, 20);
             this.numericUpDown1.TabIndex = 51;
             // 
             // label2
@@ -281,7 +279,7 @@ namespace ServiceBusExplorer.Forms
             this.numericUpDown2.Location = new System.Drawing.Point(278, 31);
             this.numericUpDown2.Margin = new System.Windows.Forms.Padding(4);
             this.numericUpDown2.Name = "numericUpDown2";
-            this.numericUpDown2.Size = new System.Drawing.Size(107, 31);
+            this.numericUpDown2.Size = new System.Drawing.Size(107, 20);
             this.numericUpDown2.TabIndex = 53;
             // 
             // label3
@@ -297,10 +295,9 @@ namespace ServiceBusExplorer.Forms
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(20, 21);
-            this.label1.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.label1.Location = new System.Drawing.Point(10, 11);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(532, 25);
+            this.label1.Size = new System.Drawing.Size(260, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Configuration File for Settings and Connection Strings:";
             // 
@@ -310,10 +307,9 @@ namespace ServiceBusExplorer.Forms
             this.cboConfigFile.DropDownWidth = 156;
             this.cboConfigFile.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cboConfigFile.FormattingEnabled = true;
-            this.cboConfigFile.Location = new System.Drawing.Point(576, 19);
-            this.cboConfigFile.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.cboConfigFile.Location = new System.Drawing.Point(288, 10);
             this.cboConfigFile.Name = "cboConfigFile";
-            this.cboConfigFile.Size = new System.Drawing.Size(440, 33);
+            this.cboConfigFile.Size = new System.Drawing.Size(222, 21);
             this.cboConfigFile.TabIndex = 1;
             this.cboConfigFile.SelectionChangeCommitted += new System.EventHandler(this.cboConfigFile_SelectionChangeCommitted);
             // 
@@ -327,10 +323,9 @@ namespace ServiceBusExplorer.Forms
             this.btnOpenConfig.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnOpenConfig.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnOpenConfig.ImageAlign = System.Drawing.ContentAlignment.TopRight;
-            this.btnOpenConfig.Location = new System.Drawing.Point(1056, 15);
-            this.btnOpenConfig.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.btnOpenConfig.Location = new System.Drawing.Point(528, 8);
             this.btnOpenConfig.Name = "btnOpenConfig";
-            this.btnOpenConfig.Size = new System.Drawing.Size(144, 46);
+            this.btnOpenConfig.Size = new System.Drawing.Size(72, 24);
             this.btnOpenConfig.TabIndex = 0;
             this.btnOpenConfig.Text = "O&pen";
             this.btnOpenConfig.UseVisualStyleBackColor = false;
@@ -347,17 +342,18 @@ namespace ServiceBusExplorer.Forms
             this.tabOptionsControl.Controls.Add(this.tabPageConnectivity);
             this.tabOptionsControl.Controls.Add(this.tabPageProxy);
             this.tabOptionsControl.DrawMode = System.Windows.Forms.TabDrawMode.OwnerDrawFixed;
-            this.tabOptionsControl.Location = new System.Drawing.Point(32, 75);
-            this.tabOptionsControl.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.tabOptionsControl.Location = new System.Drawing.Point(16, 39);
             this.tabOptionsControl.Name = "tabOptionsControl";
             this.tabOptionsControl.SelectedIndex = 0;
-            this.tabOptionsControl.Size = new System.Drawing.Size(1168, 642);
+            this.tabOptionsControl.Size = new System.Drawing.Size(584, 334);
             this.tabOptionsControl.TabIndex = 51;
             this.tabOptionsControl.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.tabControlOptions_DrawItem);
             // 
             // tabPageGeneral
             // 
             this.tabPageGeneral.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
+            this.tabPageGeneral.Controls.Add(this.disableAccidentalDeletionPrevention);
+            this.tabPageGeneral.Controls.Add(this.lblDisableAccidentalDeletionPrevention);
             this.tabPageGeneral.Controls.Add(this.lblSaveCheckpointsOnExit);
             this.tabPageGeneral.Controls.Add(this.saveCheckpointsToFileCheckBox);
             this.tabPageGeneral.Controls.Add(this.cboSelectedEntities);
@@ -376,23 +372,40 @@ namespace ServiceBusExplorer.Forms
             this.tabPageGeneral.Controls.Add(this.lblTreeViewFontSize);
             this.tabPageGeneral.Controls.Add(this.logNumericUpDown);
             this.tabPageGeneral.Controls.Add(this.lblLogFontSize);
-            this.tabPageGeneral.Location = new System.Drawing.Point(4, 34);
-            this.tabPageGeneral.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.tabPageGeneral.Location = new System.Drawing.Point(4, 22);
             this.tabPageGeneral.Name = "tabPageGeneral";
-            this.tabPageGeneral.Padding = new System.Windows.Forms.Padding(6, 6, 6, 6);
-            this.tabPageGeneral.Size = new System.Drawing.Size(1160, 604);
+            this.tabPageGeneral.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPageGeneral.Size = new System.Drawing.Size(576, 308);
             this.tabPageGeneral.TabIndex = 0;
             this.tabPageGeneral.Text = "General";
             this.tabPageGeneral.Paint += new System.Windows.Forms.PaintEventHandler(this.tabPageGeneral_Paint);
+            // 
+            // disableAccidentalDeletionPrevention
+            // 
+            this.disableAccidentalDeletionPrevention.AutoSize = true;
+            this.disableAccidentalDeletionPrevention.Location = new System.Drawing.Point(260, 273);
+            this.disableAccidentalDeletionPrevention.Name = "disableAccidentalDeletionPrevention";
+            this.disableAccidentalDeletionPrevention.Size = new System.Drawing.Size(15, 14);
+            this.disableAccidentalDeletionPrevention.TabIndex = 54;
+            this.disableAccidentalDeletionPrevention.UseVisualStyleBackColor = true;
+            this.disableAccidentalDeletionPrevention.CheckedChanged += new System.EventHandler(this.disableAccidentalDeletionPrevention_CheckedChanged);
+            // 
+            // lblDisableAccidentalDeletionPrevention
+            // 
+            this.lblDisableAccidentalDeletionPrevention.AutoSize = true;
+            this.lblDisableAccidentalDeletionPrevention.Location = new System.Drawing.Point(16, 273);
+            this.lblDisableAccidentalDeletionPrevention.Name = "lblDisableAccidentalDeletionPrevention";
+            this.lblDisableAccidentalDeletionPrevention.Size = new System.Drawing.Size(194, 13);
+            this.lblDisableAccidentalDeletionPrevention.TabIndex = 53;
+            this.lblDisableAccidentalDeletionPrevention.Text = "Disable Accidental Deletion Prevention:";
             // 
             // lblSaveCheckpointsOnExit
             // 
             this.lblSaveCheckpointsOnExit.AutoSize = true;
             this.lblSaveCheckpointsOnExit.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblSaveCheckpointsOnExit.Location = new System.Drawing.Point(32, 408);
-            this.lblSaveCheckpointsOnExit.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblSaveCheckpointsOnExit.Location = new System.Drawing.Point(16, 188);
             this.lblSaveCheckpointsOnExit.Name = "lblSaveCheckpointsOnExit";
-            this.lblSaveCheckpointsOnExit.Size = new System.Drawing.Size(455, 25);
+            this.lblSaveCheckpointsOnExit.Size = new System.Drawing.Size(227, 13);
             this.lblSaveCheckpointsOnExit.TabIndex = 51;
             this.lblSaveCheckpointsOnExit.Text = "Save Event Hub Partition Checkpoints on Exit:";
             // 
@@ -402,10 +415,9 @@ namespace ServiceBusExplorer.Forms
             this.saveCheckpointsToFileCheckBox.Checked = true;
             this.saveCheckpointsToFileCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.saveCheckpointsToFileCheckBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.saveCheckpointsToFileCheckBox.Location = new System.Drawing.Point(520, 408);
-            this.saveCheckpointsToFileCheckBox.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.saveCheckpointsToFileCheckBox.Location = new System.Drawing.Point(260, 188);
             this.saveCheckpointsToFileCheckBox.Name = "saveCheckpointsToFileCheckBox";
-            this.saveCheckpointsToFileCheckBox.Size = new System.Drawing.Size(28, 27);
+            this.saveCheckpointsToFileCheckBox.Size = new System.Drawing.Size(15, 14);
             this.saveCheckpointsToFileCheckBox.TabIndex = 52;
             this.saveCheckpointsToFileCheckBox.UseVisualStyleBackColor = true;
             this.saveCheckpointsToFileCheckBox.CheckedChanged += new System.EventHandler(this.saveCheckpointsToFileCheckBox_CheckedChanged);
@@ -418,20 +430,18 @@ namespace ServiceBusExplorer.Forms
             this.cboSelectedEntities.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboSelectedEntities.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cboSelectedEntities.FormattingEnabled = true;
-            this.cboSelectedEntities.Location = new System.Drawing.Point(270, 669);
-            this.cboSelectedEntities.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.cboSelectedEntities.Location = new System.Drawing.Point(260, 244);
             this.cboSelectedEntities.Name = "cboSelectedEntities";
-            this.cboSelectedEntities.Size = new System.Drawing.Size(716, 33);
+            this.cboSelectedEntities.Size = new System.Drawing.Size(298, 21);
             this.cboSelectedEntities.TabIndex = 50;
             // 
             // lblSelectedEntities
             // 
             this.lblSelectedEntities.AutoSize = true;
             this.lblSelectedEntities.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblSelectedEntities.Location = new System.Drawing.Point(32, 529);
-            this.lblSelectedEntities.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblSelectedEntities.Location = new System.Drawing.Point(16, 244);
             this.lblSelectedEntities.Name = "lblSelectedEntities";
-            this.lblSelectedEntities.Size = new System.Drawing.Size(179, 25);
+            this.lblSelectedEntities.Size = new System.Drawing.Size(89, 13);
             this.lblSelectedEntities.TabIndex = 49;
             this.lblSelectedEntities.Text = "Selected Entities:";
             // 
@@ -442,15 +452,14 @@ namespace ServiceBusExplorer.Forms
             0,
             0,
             0});
-            this.monitorRefreshIntervalNumericUpDown.Location = new System.Drawing.Point(520, 229);
-            this.monitorRefreshIntervalNumericUpDown.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.monitorRefreshIntervalNumericUpDown.Location = new System.Drawing.Point(260, 104);
             this.monitorRefreshIntervalNumericUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
             0,
             0});
             this.monitorRefreshIntervalNumericUpDown.Name = "monitorRefreshIntervalNumericUpDown";
-            this.monitorRefreshIntervalNumericUpDown.Size = new System.Drawing.Size(160, 31);
+            this.monitorRefreshIntervalNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.monitorRefreshIntervalNumericUpDown.TabIndex = 46;
             this.monitorRefreshIntervalNumericUpDown.Value = new decimal(new int[] {
             30,
@@ -463,10 +472,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblMonitorRefreshInterval.AutoSize = true;
             this.lblMonitorRefreshInterval.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblMonitorRefreshInterval.Location = new System.Drawing.Point(32, 229);
-            this.lblMonitorRefreshInterval.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblMonitorRefreshInterval.Location = new System.Drawing.Point(16, 104);
             this.lblMonitorRefreshInterval.Name = "lblMonitorRefreshInterval";
-            this.lblMonitorRefreshInterval.Size = new System.Drawing.Size(348, 25);
+            this.lblMonitorRefreshInterval.Size = new System.Drawing.Size(172, 13);
             this.lblMonitorRefreshInterval.TabIndex = 45;
             this.lblMonitorRefreshInterval.Text = "Monitor Refresh Interval (seconds):";
             // 
@@ -476,10 +484,9 @@ namespace ServiceBusExplorer.Forms
             this.useAsciiCheckBox.Checked = true;
             this.useAsciiCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.useAsciiCheckBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.useAsciiCheckBox.Location = new System.Drawing.Point(520, 288);
-            this.useAsciiCheckBox.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.useAsciiCheckBox.Location = new System.Drawing.Point(260, 132);
             this.useAsciiCheckBox.Name = "useAsciiCheckBox";
-            this.useAsciiCheckBox.Size = new System.Drawing.Size(28, 27);
+            this.useAsciiCheckBox.Size = new System.Drawing.Size(15, 14);
             this.useAsciiCheckBox.TabIndex = 40;
             this.useAsciiCheckBox.UseVisualStyleBackColor = true;
             this.useAsciiCheckBox.CheckedChanged += new System.EventHandler(this.useAscii_CheckedChanged);
@@ -488,10 +495,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblUseAscii.AutoSize = true;
             this.lblUseAscii.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblUseAscii.Location = new System.Drawing.Point(32, 288);
-            this.lblUseAscii.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblUseAscii.Location = new System.Drawing.Point(16, 132);
             this.lblUseAscii.Name = "lblUseAscii";
-            this.lblUseAscii.Size = new System.Drawing.Size(115, 25);
+            this.lblUseAscii.Size = new System.Drawing.Size(59, 13);
             this.lblUseAscii.TabIndex = 39;
             this.lblUseAscii.Text = "Use ASCII:";
             // 
@@ -499,10 +505,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblShowMessageCount.AutoSize = true;
             this.lblShowMessageCount.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblShowMessageCount.Location = new System.Drawing.Point(32, 348);
-            this.lblShowMessageCount.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblShowMessageCount.Location = new System.Drawing.Point(16, 160);
             this.lblShowMessageCount.Name = "lblShowMessageCount";
-            this.lblShowMessageCount.Size = new System.Drawing.Size(228, 25);
+            this.lblShowMessageCount.Size = new System.Drawing.Size(114, 13);
             this.lblShowMessageCount.TabIndex = 43;
             this.lblShowMessageCount.Text = "Show Message Count:";
             // 
@@ -512,10 +517,9 @@ namespace ServiceBusExplorer.Forms
             this.showMessageCountCheckBox.Checked = true;
             this.showMessageCountCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.showMessageCountCheckBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.showMessageCountCheckBox.Location = new System.Drawing.Point(520, 348);
-            this.showMessageCountCheckBox.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.showMessageCountCheckBox.Location = new System.Drawing.Point(260, 160);
             this.showMessageCountCheckBox.Name = "showMessageCountCheckBox";
-            this.showMessageCountCheckBox.Size = new System.Drawing.Size(28, 27);
+            this.showMessageCountCheckBox.Size = new System.Drawing.Size(15, 14);
             this.showMessageCountCheckBox.TabIndex = 44;
             this.showMessageCountCheckBox.UseVisualStyleBackColor = true;
             this.showMessageCountCheckBox.CheckedChanged += new System.EventHandler(this.showMessageCountCheckBox_CheckedChanged);
@@ -524,10 +528,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblEncoding.AutoSize = true;
             this.lblEncoding.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblEncoding.Location = new System.Drawing.Point(32, 467);
-            this.lblEncoding.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblEncoding.Location = new System.Drawing.Point(16, 216);
             this.lblEncoding.Name = "lblEncoding";
-            this.lblEncoding.Size = new System.Drawing.Size(108, 25);
+            this.lblEncoding.Size = new System.Drawing.Size(55, 13);
             this.lblEncoding.TabIndex = 41;
             this.lblEncoding.Text = "Encoding:";
             // 
@@ -542,24 +545,22 @@ namespace ServiceBusExplorer.Forms
             "UTF8",
             "UTF32",
             "Unicode"});
-            this.cboEncodingType.Location = new System.Drawing.Point(520, 467);
-            this.cboEncodingType.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.cboEncodingType.Location = new System.Drawing.Point(260, 216);
             this.cboEncodingType.Name = "cboEncodingType";
-            this.cboEncodingType.Size = new System.Drawing.Size(592, 33);
+            this.cboEncodingType.Size = new System.Drawing.Size(298, 21);
             this.cboEncodingType.TabIndex = 42;
             this.cboEncodingType.SelectedIndexChanged += new System.EventHandler(this.cboEncoding_SelectedIndexChanged);
             // 
             // serverTimeoutNumericUpDown
             // 
-            this.serverTimeoutNumericUpDown.Location = new System.Drawing.Point(520, 167);
-            this.serverTimeoutNumericUpDown.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.serverTimeoutNumericUpDown.Location = new System.Drawing.Point(260, 76);
             this.serverTimeoutNumericUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
             0,
             0});
             this.serverTimeoutNumericUpDown.Name = "serverTimeoutNumericUpDown";
-            this.serverTimeoutNumericUpDown.Size = new System.Drawing.Size(160, 31);
+            this.serverTimeoutNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.serverTimeoutNumericUpDown.TabIndex = 38;
             this.serverTimeoutNumericUpDown.Value = new decimal(new int[] {
             5,
@@ -572,10 +573,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblServerTimeout.AutoSize = true;
             this.lblServerTimeout.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblServerTimeout.Location = new System.Drawing.Point(32, 167);
-            this.lblServerTimeout.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblServerTimeout.Location = new System.Drawing.Point(16, 75);
             this.lblServerTimeout.Name = "lblServerTimeout";
-            this.lblServerTimeout.Size = new System.Drawing.Size(265, 25);
+            this.lblServerTimeout.Size = new System.Drawing.Size(131, 13);
             this.lblServerTimeout.TabIndex = 37;
             this.lblServerTimeout.Text = "Server Timeout (seconds):";
             // 
@@ -587,10 +587,9 @@ namespace ServiceBusExplorer.Forms
             0,
             0,
             131072});
-            this.treeViewNumericUpDown.Location = new System.Drawing.Point(520, 108);
-            this.treeViewNumericUpDown.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.treeViewNumericUpDown.Location = new System.Drawing.Point(260, 48);
             this.treeViewNumericUpDown.Name = "treeViewNumericUpDown";
-            this.treeViewNumericUpDown.Size = new System.Drawing.Size(160, 31);
+            this.treeViewNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.treeViewNumericUpDown.TabIndex = 36;
             this.treeViewNumericUpDown.ValueChanged += new System.EventHandler(this.treeViewNumericUpDown_ValueChanged);
             // 
@@ -598,10 +597,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblTreeViewFontSize.AutoSize = true;
             this.lblTreeViewFontSize.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblTreeViewFontSize.Location = new System.Drawing.Point(32, 108);
-            this.lblTreeViewFontSize.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblTreeViewFontSize.Location = new System.Drawing.Point(16, 48);
             this.lblTreeViewFontSize.Name = "lblTreeViewFontSize";
-            this.lblTreeViewFontSize.Size = new System.Drawing.Size(211, 25);
+            this.lblTreeViewFontSize.Size = new System.Drawing.Size(105, 13);
             this.lblTreeViewFontSize.TabIndex = 35;
             this.lblTreeViewFontSize.Text = "Tree View Font Size:";
             // 
@@ -613,10 +611,9 @@ namespace ServiceBusExplorer.Forms
             0,
             0,
             131072});
-            this.logNumericUpDown.Location = new System.Drawing.Point(520, 48);
-            this.logNumericUpDown.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.logNumericUpDown.Location = new System.Drawing.Point(260, 20);
             this.logNumericUpDown.Name = "logNumericUpDown";
-            this.logNumericUpDown.Size = new System.Drawing.Size(160, 31);
+            this.logNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.logNumericUpDown.TabIndex = 34;
             this.logNumericUpDown.ValueChanged += new System.EventHandler(this.logNumericUpDown_ValueChanged);
             // 
@@ -624,10 +621,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblLogFontSize.AutoSize = true;
             this.lblLogFontSize.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblLogFontSize.Location = new System.Drawing.Point(32, 48);
-            this.lblLogFontSize.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblLogFontSize.Location = new System.Drawing.Point(16, 20);
             this.lblLogFontSize.Name = "lblLogFontSize";
-            this.lblLogFontSize.Size = new System.Drawing.Size(151, 25);
+            this.lblLogFontSize.Size = new System.Drawing.Size(75, 13);
             this.lblLogFontSize.TabIndex = 33;
             this.lblLogFontSize.Text = "Log Font Size:";
             // 
@@ -646,11 +642,10 @@ namespace ServiceBusExplorer.Forms
             this.tabPageReceiving.Controls.Add(this.lblRetryTimeout);
             this.tabPageReceiving.Controls.Add(this.retryCountNumericUpDown);
             this.tabPageReceiving.Controls.Add(this.lblRetryCount);
-            this.tabPageReceiving.Location = new System.Drawing.Point(4, 34);
-            this.tabPageReceiving.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.tabPageReceiving.Location = new System.Drawing.Point(4, 22);
             this.tabPageReceiving.Name = "tabPageReceiving";
-            this.tabPageReceiving.Padding = new System.Windows.Forms.Padding(6, 6, 6, 6);
-            this.tabPageReceiving.Size = new System.Drawing.Size(1160, 604);
+            this.tabPageReceiving.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPageReceiving.Size = new System.Drawing.Size(576, 308);
             this.tabPageReceiving.TabIndex = 1;
             this.tabPageReceiving.Text = "Receiving";
             // 
@@ -661,15 +656,14 @@ namespace ServiceBusExplorer.Forms
             0,
             0,
             0});
-            this.receiverThinkTimeNumericUpDown.Location = new System.Drawing.Point(520, 344);
-            this.receiverThinkTimeNumericUpDown.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.receiverThinkTimeNumericUpDown.Location = new System.Drawing.Point(260, 179);
             this.receiverThinkTimeNumericUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
             0,
             0});
             this.receiverThinkTimeNumericUpDown.Name = "receiverThinkTimeNumericUpDown";
-            this.receiverThinkTimeNumericUpDown.Size = new System.Drawing.Size(160, 31);
+            this.receiverThinkTimeNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.receiverThinkTimeNumericUpDown.TabIndex = 34;
             this.receiverThinkTimeNumericUpDown.Value = new decimal(new int[] {
             100,
@@ -682,10 +676,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblReceiverThinkTime.AutoSize = true;
             this.lblReceiverThinkTime.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblReceiverThinkTime.Location = new System.Drawing.Point(32, 344);
-            this.lblReceiverThinkTime.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblReceiverThinkTime.Location = new System.Drawing.Point(16, 179);
             this.lblReceiverThinkTime.Name = "lblReceiverThinkTime";
-            this.lblReceiverThinkTime.Size = new System.Drawing.Size(353, 25);
+            this.lblReceiverThinkTime.Size = new System.Drawing.Size(174, 13);
             this.lblReceiverThinkTime.TabIndex = 33;
             this.lblReceiverThinkTime.Text = "Receiver Think Time (milliseconds):";
             // 
@@ -696,15 +689,14 @@ namespace ServiceBusExplorer.Forms
             0,
             0,
             0});
-            this.prefetchCountNumericUpDown.Location = new System.Drawing.Point(520, 229);
-            this.prefetchCountNumericUpDown.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.prefetchCountNumericUpDown.Location = new System.Drawing.Point(260, 119);
             this.prefetchCountNumericUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
             0,
             0});
             this.prefetchCountNumericUpDown.Name = "prefetchCountNumericUpDown";
-            this.prefetchCountNumericUpDown.Size = new System.Drawing.Size(160, 31);
+            this.prefetchCountNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.prefetchCountNumericUpDown.TabIndex = 28;
             this.prefetchCountNumericUpDown.Value = new decimal(new int[] {
             10,
@@ -717,24 +709,22 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblPrefetchCount.AutoSize = true;
             this.lblPrefetchCount.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblPrefetchCount.Location = new System.Drawing.Point(32, 229);
-            this.lblPrefetchCount.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblPrefetchCount.Location = new System.Drawing.Point(16, 119);
             this.lblPrefetchCount.Name = "lblPrefetchCount";
-            this.lblPrefetchCount.Size = new System.Drawing.Size(161, 25);
+            this.lblPrefetchCount.Size = new System.Drawing.Size(81, 13);
             this.lblPrefetchCount.TabIndex = 27;
             this.lblPrefetchCount.Text = "Prefetch Count:";
             // 
             // receiveTimeoutNumericUpDown
             // 
-            this.receiveTimeoutNumericUpDown.Location = new System.Drawing.Point(520, 48);
-            this.receiveTimeoutNumericUpDown.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.receiveTimeoutNumericUpDown.Location = new System.Drawing.Point(260, 25);
             this.receiveTimeoutNumericUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
             0,
             0});
             this.receiveTimeoutNumericUpDown.Name = "receiveTimeoutNumericUpDown";
-            this.receiveTimeoutNumericUpDown.Size = new System.Drawing.Size(160, 31);
+            this.receiveTimeoutNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.receiveTimeoutNumericUpDown.TabIndex = 24;
             this.receiveTimeoutNumericUpDown.Value = new decimal(new int[] {
             1,
@@ -747,10 +737,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblReceiveTimeout.AutoSize = true;
             this.lblReceiveTimeout.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblReceiveTimeout.Location = new System.Drawing.Point(32, 48);
-            this.lblReceiveTimeout.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblReceiveTimeout.Location = new System.Drawing.Point(16, 25);
             this.lblReceiveTimeout.Name = "lblReceiveTimeout";
-            this.lblReceiveTimeout.Size = new System.Drawing.Size(280, 25);
+            this.lblReceiveTimeout.Size = new System.Drawing.Size(140, 13);
             this.lblReceiveTimeout.TabIndex = 23;
             this.lblReceiveTimeout.Text = "Receive Timeout (seconds):";
             // 
@@ -761,15 +750,14 @@ namespace ServiceBusExplorer.Forms
             0,
             0,
             0});
-            this.topNumericUpDown.Location = new System.Drawing.Point(520, 288);
-            this.topNumericUpDown.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.topNumericUpDown.Location = new System.Drawing.Point(260, 150);
             this.topNumericUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
             0,
             0});
             this.topNumericUpDown.Name = "topNumericUpDown";
-            this.topNumericUpDown.Size = new System.Drawing.Size(160, 31);
+            this.topNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.topNumericUpDown.TabIndex = 32;
             this.topNumericUpDown.Value = new decimal(new int[] {
             10,
@@ -782,10 +770,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblTop.AutoSize = true;
             this.lblTop.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblTop.Location = new System.Drawing.Point(32, 288);
-            this.lblTop.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblTop.Location = new System.Drawing.Point(16, 150);
             this.lblTop.Name = "lblTop";
-            this.lblTop.Size = new System.Drawing.Size(118, 25);
+            this.lblTop.Size = new System.Drawing.Size(60, 13);
             this.lblTop.TabIndex = 31;
             this.lblTop.Text = "Top Count:";
             // 
@@ -796,15 +783,14 @@ namespace ServiceBusExplorer.Forms
             0,
             0,
             0});
-            this.retryTimeoutNumericUpDown.Location = new System.Drawing.Point(520, 167);
-            this.retryTimeoutNumericUpDown.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.retryTimeoutNumericUpDown.Location = new System.Drawing.Point(260, 87);
             this.retryTimeoutNumericUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
             0,
             0});
             this.retryTimeoutNumericUpDown.Name = "retryTimeoutNumericUpDown";
-            this.retryTimeoutNumericUpDown.Size = new System.Drawing.Size(160, 31);
+            this.retryTimeoutNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.retryTimeoutNumericUpDown.TabIndex = 30;
             this.retryTimeoutNumericUpDown.ValueChanged += new System.EventHandler(this.retryTimeoutNumericUpDown_ValueChanged);
             // 
@@ -812,24 +798,22 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblRetryTimeout.AutoSize = true;
             this.lblRetryTimeout.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblRetryTimeout.Location = new System.Drawing.Point(32, 167);
-            this.lblRetryTimeout.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblRetryTimeout.Location = new System.Drawing.Point(16, 87);
             this.lblRetryTimeout.Name = "lblRetryTimeout";
-            this.lblRetryTimeout.Size = new System.Drawing.Size(290, 25);
+            this.lblRetryTimeout.Size = new System.Drawing.Size(141, 13);
             this.lblRetryTimeout.TabIndex = 29;
             this.lblRetryTimeout.Text = "Retry Timeout (milliseconds):";
             // 
             // retryCountNumericUpDown
             // 
-            this.retryCountNumericUpDown.Location = new System.Drawing.Point(520, 108);
-            this.retryCountNumericUpDown.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.retryCountNumericUpDown.Location = new System.Drawing.Point(260, 56);
             this.retryCountNumericUpDown.Maximum = new decimal(new int[] {
             1000,
             0,
             0,
             0});
             this.retryCountNumericUpDown.Name = "retryCountNumericUpDown";
-            this.retryCountNumericUpDown.Size = new System.Drawing.Size(160, 31);
+            this.retryCountNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.retryCountNumericUpDown.TabIndex = 26;
             this.retryCountNumericUpDown.ValueChanged += new System.EventHandler(this.retryCountNumericUpDown_ValueChanged);
             // 
@@ -837,10 +821,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblRetryCount.AutoSize = true;
             this.lblRetryCount.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblRetryCount.Location = new System.Drawing.Point(32, 108);
-            this.lblRetryCount.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblRetryCount.Location = new System.Drawing.Point(16, 56);
             this.lblRetryCount.Name = "lblRetryCount";
-            this.lblRetryCount.Size = new System.Drawing.Size(132, 25);
+            this.lblRetryCount.Size = new System.Drawing.Size(66, 13);
             this.lblRetryCount.TabIndex = 25;
             this.lblRetryCount.Text = "Retry Count:";
             // 
@@ -864,10 +847,9 @@ namespace ServiceBusExplorer.Forms
             this.tabPageSending.Controls.Add(this.lblSavePropertiesOnExit);
             this.tabPageSending.Controls.Add(this.lblSaveMessageOnExit);
             this.tabPageSending.Controls.Add(this.savePropertiesToFileCheckBox);
-            this.tabPageSending.Location = new System.Drawing.Point(4, 34);
-            this.tabPageSending.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.tabPageSending.Location = new System.Drawing.Point(4, 22);
             this.tabPageSending.Name = "tabPageSending";
-            this.tabPageSending.Size = new System.Drawing.Size(1160, 604);
+            this.tabPageSending.Size = new System.Drawing.Size(576, 308);
             this.tabPageSending.TabIndex = 2;
             this.tabPageSending.Text = "Sending";
             this.tabPageSending.Paint += new System.Windows.Forms.PaintEventHandler(this.tabPageSending_Paint);
@@ -878,10 +860,9 @@ namespace ServiceBusExplorer.Forms
             this.saveMessageToFileCheckBox.Checked = true;
             this.saveMessageToFileCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.saveMessageToFileCheckBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.saveMessageToFileCheckBox.Location = new System.Drawing.Point(520, 108);
-            this.saveMessageToFileCheckBox.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.saveMessageToFileCheckBox.Location = new System.Drawing.Point(260, 56);
             this.saveMessageToFileCheckBox.Name = "saveMessageToFileCheckBox";
-            this.saveMessageToFileCheckBox.Size = new System.Drawing.Size(28, 27);
+            this.saveMessageToFileCheckBox.Size = new System.Drawing.Size(15, 14);
             this.saveMessageToFileCheckBox.TabIndex = 67;
             this.saveMessageToFileCheckBox.UseVisualStyleBackColor = true;
             this.saveMessageToFileCheckBox.CheckedChanged += new System.EventHandler(this.saveMessageToFileCheckBox_CheckedChanged);
@@ -890,10 +871,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblMessageContentType.AutoSize = true;
             this.lblMessageContentType.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblMessageContentType.Location = new System.Drawing.Point(32, 467);
-            this.lblMessageContentType.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblMessageContentType.Location = new System.Drawing.Point(16, 243);
             this.lblMessageContentType.Name = "lblMessageContentType";
-            this.lblMessageContentType.Size = new System.Drawing.Size(241, 25);
+            this.lblMessageContentType.Size = new System.Drawing.Size(120, 13);
             this.lblMessageContentType.TabIndex = 63;
             this.lblMessageContentType.Text = "Message Content Type:";
             // 
@@ -901,10 +881,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.txtMessageContentType.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtMessageContentType.Location = new System.Drawing.Point(520, 467);
-            this.txtMessageContentType.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.txtMessageContentType.Location = new System.Drawing.Point(260, 243);
             this.txtMessageContentType.Name = "txtMessageContentType";
-            this.txtMessageContentType.Size = new System.Drawing.Size(600, 31);
+            this.txtMessageContentType.Size = new System.Drawing.Size(302, 20);
             this.txtMessageContentType.TabIndex = 64;
             this.txtMessageContentType.TextChanged += new System.EventHandler(this.txtMessageContentType_TextChanged);
             // 
@@ -918,10 +897,9 @@ namespace ServiceBusExplorer.Forms
             "Stream",
             "String",
             "WCF"});
-            this.cboDefaultMessageBodyType.Location = new System.Drawing.Point(520, 529);
-            this.cboDefaultMessageBodyType.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.cboDefaultMessageBodyType.Location = new System.Drawing.Point(260, 275);
             this.cboDefaultMessageBodyType.Name = "cboDefaultMessageBodyType";
-            this.cboDefaultMessageBodyType.Size = new System.Drawing.Size(600, 33);
+            this.cboDefaultMessageBodyType.Size = new System.Drawing.Size(302, 21);
             this.cboDefaultMessageBodyType.TabIndex = 66;
             this.cboDefaultMessageBodyType.SelectedIndexChanged += new System.EventHandler(this.cboDefaultMessageBodyType_SelectedIndexChanged);
             // 
@@ -929,10 +907,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.LabelDefaultMessageBodyType.AutoSize = true;
             this.LabelDefaultMessageBodyType.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.LabelDefaultMessageBodyType.Location = new System.Drawing.Point(32, 529);
-            this.LabelDefaultMessageBodyType.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.LabelDefaultMessageBodyType.Location = new System.Drawing.Point(16, 275);
             this.LabelDefaultMessageBodyType.Name = "LabelDefaultMessageBodyType";
-            this.LabelDefaultMessageBodyType.Size = new System.Drawing.Size(279, 25);
+            this.LabelDefaultMessageBodyType.Size = new System.Drawing.Size(138, 13);
             this.LabelDefaultMessageBodyType.TabIndex = 65;
             this.LabelDefaultMessageBodyType.Text = "Default message body type:";
             // 
@@ -945,10 +922,9 @@ namespace ServiceBusExplorer.Forms
             this.btnOpen.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnOpen.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.btnOpen.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnOpen.Location = new System.Drawing.Point(1074, 408);
-            this.btnOpen.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.btnOpen.Location = new System.Drawing.Point(537, 212);
             this.btnOpen.Name = "btnOpen";
-            this.btnOpen.Size = new System.Drawing.Size(48, 40);
+            this.btnOpen.Size = new System.Drawing.Size(24, 21);
             this.btnOpen.TabIndex = 62;
             this.btnOpen.Text = "...";
             this.btnOpen.TextAlign = System.Drawing.ContentAlignment.TopCenter;
@@ -959,10 +935,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.txtMessageFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtMessageFile.Location = new System.Drawing.Point(520, 348);
-            this.txtMessageFile.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.txtMessageFile.Location = new System.Drawing.Point(260, 181);
             this.txtMessageFile.Name = "txtMessageFile";
-            this.txtMessageFile.Size = new System.Drawing.Size(600, 31);
+            this.txtMessageFile.Size = new System.Drawing.Size(302, 20);
             this.txtMessageFile.TabIndex = 59;
             this.txtMessageFile.TextChanged += new System.EventHandler(this.txtMessageFile_TextChanged);
             // 
@@ -970,10 +945,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblMessageFile.AutoSize = true;
             this.lblMessageFile.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblMessageFile.Location = new System.Drawing.Point(32, 348);
-            this.lblMessageFile.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblMessageFile.Location = new System.Drawing.Point(16, 181);
             this.lblMessageFile.Name = "lblMessageFile";
-            this.lblMessageFile.Size = new System.Drawing.Size(156, 25);
+            this.lblMessageFile.Size = new System.Drawing.Size(78, 13);
             this.lblMessageFile.TabIndex = 58;
             this.lblMessageFile.Text = "Message Path:";
             // 
@@ -981,10 +955,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.txtMessageText.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtMessageText.Location = new System.Drawing.Point(520, 408);
-            this.txtMessageText.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.txtMessageText.Location = new System.Drawing.Point(260, 212);
             this.txtMessageText.Name = "txtMessageText";
-            this.txtMessageText.Size = new System.Drawing.Size(528, 31);
+            this.txtMessageText.Size = new System.Drawing.Size(266, 20);
             this.txtMessageText.TabIndex = 61;
             this.txtMessageText.TextChanged += new System.EventHandler(this.txtMessageText_TextChanged);
             // 
@@ -992,10 +965,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblMessageText.AutoSize = true;
             this.lblMessageText.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblMessageText.Location = new System.Drawing.Point(32, 408);
-            this.lblMessageText.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblMessageText.Location = new System.Drawing.Point(16, 212);
             this.lblMessageText.Name = "lblMessageText";
-            this.lblMessageText.Size = new System.Drawing.Size(154, 25);
+            this.lblMessageText.Size = new System.Drawing.Size(77, 13);
             this.lblMessageText.TabIndex = 60;
             this.lblMessageText.Text = "Message Text:";
             // 
@@ -1003,10 +975,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.txtLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtLabel.Location = new System.Drawing.Point(520, 288);
-            this.txtLabel.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.txtLabel.Location = new System.Drawing.Point(260, 150);
             this.txtLabel.Name = "txtLabel";
-            this.txtLabel.Size = new System.Drawing.Size(600, 31);
+            this.txtLabel.Size = new System.Drawing.Size(302, 20);
             this.txtLabel.TabIndex = 57;
             this.txtLabel.TextChanged += new System.EventHandler(this.txtLabel_TextChanged);
             // 
@@ -1014,10 +985,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblLabel.AutoSize = true;
             this.lblLabel.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblLabel.Location = new System.Drawing.Point(32, 288);
-            this.lblLabel.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblLabel.Location = new System.Drawing.Point(16, 150);
             this.lblLabel.Name = "lblLabel";
-            this.lblLabel.Size = new System.Drawing.Size(71, 25);
+            this.lblLabel.Size = new System.Drawing.Size(36, 13);
             this.lblLabel.TabIndex = 56;
             this.lblLabel.Text = "Label:";
             // 
@@ -1028,15 +998,14 @@ namespace ServiceBusExplorer.Forms
             0,
             0,
             0});
-            this.senderThinkTimeNumericUpDown.Location = new System.Drawing.Point(520, 48);
-            this.senderThinkTimeNumericUpDown.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.senderThinkTimeNumericUpDown.Location = new System.Drawing.Point(260, 25);
             this.senderThinkTimeNumericUpDown.Maximum = new decimal(new int[] {
             100000,
             0,
             0,
             0});
             this.senderThinkTimeNumericUpDown.Name = "senderThinkTimeNumericUpDown";
-            this.senderThinkTimeNumericUpDown.Size = new System.Drawing.Size(160, 31);
+            this.senderThinkTimeNumericUpDown.Size = new System.Drawing.Size(80, 20);
             this.senderThinkTimeNumericUpDown.TabIndex = 52;
             this.senderThinkTimeNumericUpDown.Value = new decimal(new int[] {
             100,
@@ -1049,10 +1018,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblSenderThinkTime.AutoSize = true;
             this.lblSenderThinkTime.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblSenderThinkTime.Location = new System.Drawing.Point(32, 48);
-            this.lblSenderThinkTime.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblSenderThinkTime.Location = new System.Drawing.Point(16, 25);
             this.lblSenderThinkTime.Name = "lblSenderThinkTime";
-            this.lblSenderThinkTime.Size = new System.Drawing.Size(337, 25);
+            this.lblSenderThinkTime.Size = new System.Drawing.Size(165, 13);
             this.lblSenderThinkTime.TabIndex = 51;
             this.lblSenderThinkTime.Text = "Sender Think Time (milliseconds):";
             // 
@@ -1060,10 +1028,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblSavePropertiesOnExit.AutoSize = true;
             this.lblSavePropertiesOnExit.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblSavePropertiesOnExit.Location = new System.Drawing.Point(32, 167);
-            this.lblSavePropertiesOnExit.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblSavePropertiesOnExit.Location = new System.Drawing.Point(16, 87);
             this.lblSavePropertiesOnExit.Name = "lblSavePropertiesOnExit";
-            this.lblSavePropertiesOnExit.Size = new System.Drawing.Size(402, 25);
+            this.lblSavePropertiesOnExit.Size = new System.Drawing.Size(197, 13);
             this.lblSavePropertiesOnExit.TabIndex = 54;
             this.lblSavePropertiesOnExit.Text = "Save Message Properties to File on Exit:";
             // 
@@ -1071,10 +1038,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblSaveMessageOnExit.AutoSize = true;
             this.lblSaveMessageOnExit.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblSaveMessageOnExit.Location = new System.Drawing.Point(32, 108);
-            this.lblSaveMessageOnExit.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblSaveMessageOnExit.Location = new System.Drawing.Point(16, 56);
             this.lblSaveMessageOnExit.Name = "lblSaveMessageOnExit";
-            this.lblSaveMessageOnExit.Size = new System.Drawing.Size(353, 25);
+            this.lblSaveMessageOnExit.Size = new System.Drawing.Size(174, 13);
             this.lblSaveMessageOnExit.TabIndex = 53;
             this.lblSaveMessageOnExit.Text = "Save Message Body to File on Exit:";
             // 
@@ -1084,10 +1050,9 @@ namespace ServiceBusExplorer.Forms
             this.savePropertiesToFileCheckBox.Checked = true;
             this.savePropertiesToFileCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.savePropertiesToFileCheckBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.savePropertiesToFileCheckBox.Location = new System.Drawing.Point(520, 167);
-            this.savePropertiesToFileCheckBox.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.savePropertiesToFileCheckBox.Location = new System.Drawing.Point(260, 87);
             this.savePropertiesToFileCheckBox.Name = "savePropertiesToFileCheckBox";
-            this.savePropertiesToFileCheckBox.Size = new System.Drawing.Size(28, 27);
+            this.savePropertiesToFileCheckBox.Size = new System.Drawing.Size(15, 14);
             this.savePropertiesToFileCheckBox.TabIndex = 55;
             this.savePropertiesToFileCheckBox.UseVisualStyleBackColor = true;
             this.savePropertiesToFileCheckBox.CheckedChanged += new System.EventHandler(this.savePropertiesToFileCheckBox_CheckedChanged);
@@ -1099,10 +1064,9 @@ namespace ServiceBusExplorer.Forms
             this.tabPageConnectivity.Controls.Add(this.label4);
             this.tabPageConnectivity.Controls.Add(this.cboConnectivityMode);
             this.tabPageConnectivity.Controls.Add(this.lblConnectivityMode);
-            this.tabPageConnectivity.Location = new System.Drawing.Point(4, 34);
-            this.tabPageConnectivity.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.tabPageConnectivity.Location = new System.Drawing.Point(4, 22);
             this.tabPageConnectivity.Name = "tabPageConnectivity";
-            this.tabPageConnectivity.Size = new System.Drawing.Size(1160, 604);
+            this.tabPageConnectivity.Size = new System.Drawing.Size(576, 308);
             this.tabPageConnectivity.TabIndex = 3;
             this.tabPageConnectivity.Text = "Connectivity";
             this.tabPageConnectivity.Paint += new System.Windows.Forms.PaintEventHandler(this.tabPageConnectivity_Paint);
@@ -1111,10 +1075,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.useAmqpWebSocketsCheckBox.AutoSize = true;
             this.useAmqpWebSocketsCheckBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.useAmqpWebSocketsCheckBox.Location = new System.Drawing.Point(768, 108);
-            this.useAmqpWebSocketsCheckBox.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.useAmqpWebSocketsCheckBox.Location = new System.Drawing.Point(384, 56);
             this.useAmqpWebSocketsCheckBox.Name = "useAmqpWebSocketsCheckBox";
-            this.useAmqpWebSocketsCheckBox.Size = new System.Drawing.Size(28, 27);
+            this.useAmqpWebSocketsCheckBox.Size = new System.Drawing.Size(15, 14);
             this.useAmqpWebSocketsCheckBox.TabIndex = 68;
             this.useAmqpWebSocketsCheckBox.UseVisualStyleBackColor = true;
             this.useAmqpWebSocketsCheckBox.CheckedChanged += new System.EventHandler(this.useAmqpWebSocketsCheckBox_CheckedChanged);
@@ -1123,10 +1086,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.label4.AutoSize = true;
             this.label4.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.label4.Location = new System.Drawing.Point(32, 108);
-            this.label4.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.label4.Location = new System.Drawing.Point(16, 56);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(697, 25);
+            this.label4.Size = new System.Drawing.Size(346, 13);
             this.label4.TabIndex = 29;
             this.label4.Text = "Use AMQP Web Sockets for Microsoft.Azure.ServiceBus.dll (new client)";
             // 
@@ -1135,10 +1097,9 @@ namespace ServiceBusExplorer.Forms
             this.cboConnectivityMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboConnectivityMode.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cboConnectivityMode.FormattingEnabled = true;
-            this.cboConnectivityMode.Location = new System.Drawing.Point(768, 48);
-            this.cboConnectivityMode.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.cboConnectivityMode.Location = new System.Drawing.Point(384, 25);
             this.cboConnectivityMode.Name = "cboConnectivityMode";
-            this.cboConnectivityMode.Size = new System.Drawing.Size(364, 33);
+            this.cboConnectivityMode.Size = new System.Drawing.Size(184, 21);
             this.cboConnectivityMode.TabIndex = 28;
             this.cboConnectivityMode.SelectedIndexChanged += new System.EventHandler(this.cboConnectivityMode_SelectedIndexChanged);
             // 
@@ -1146,10 +1107,9 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblConnectivityMode.AutoSize = true;
             this.lblConnectivityMode.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblConnectivityMode.Location = new System.Drawing.Point(32, 48);
-            this.lblConnectivityMode.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblConnectivityMode.Location = new System.Drawing.Point(16, 25);
             this.lblConnectivityMode.Name = "lblConnectivityMode";
-            this.lblConnectivityMode.Size = new System.Drawing.Size(619, 25);
+            this.lblConnectivityMode.Size = new System.Drawing.Size(305, 13);
             this.lblConnectivityMode.TabIndex = 27;
             this.lblConnectivityMode.Text = "Connectivity Mode for WindowsAzure.ServiceBus.dll (old client)";
             // 
@@ -1170,10 +1130,10 @@ namespace ServiceBusExplorer.Forms
             this.tabPageProxy.Controls.Add(this.lblOverrideProxy);
             this.tabPageProxy.Controls.Add(this.txtProxyAddress);
             this.tabPageProxy.Controls.Add(this.lblProxyAddress);
-            this.tabPageProxy.Location = new System.Drawing.Point(4, 34);
-            this.tabPageProxy.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.tabPageProxy.Location = new System.Drawing.Point(4, 22);
+            this.tabPageProxy.Margin = new System.Windows.Forms.Padding(2);
             this.tabPageProxy.Name = "tabPageProxy";
-            this.tabPageProxy.Size = new System.Drawing.Size(1160, 604);
+            this.tabPageProxy.Size = new System.Drawing.Size(576, 308);
             this.tabPageProxy.TabIndex = 4;
             this.tabPageProxy.Text = "Proxy";
             // 
@@ -1181,10 +1141,10 @@ namespace ServiceBusExplorer.Forms
             // 
             this.txtProxyPassword.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtProxyPassword.Location = new System.Drawing.Point(520, 408);
-            this.txtProxyPassword.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtProxyPassword.Location = new System.Drawing.Point(260, 212);
+            this.txtProxyPassword.Margin = new System.Windows.Forms.Padding(2);
             this.txtProxyPassword.Name = "txtProxyPassword";
-            this.txtProxyPassword.Size = new System.Drawing.Size(600, 31);
+            this.txtProxyPassword.Size = new System.Drawing.Size(302, 20);
             this.txtProxyPassword.TabIndex = 7;
             this.txtProxyPassword.UseSystemPasswordChar = true;
             this.txtProxyPassword.TextChanged += new System.EventHandler(this.txtProxyPassword_TextChanged);
@@ -1195,10 +1155,10 @@ namespace ServiceBusExplorer.Forms
             this.useDefaultProxyCredentialsCheckBox.Checked = true;
             this.useDefaultProxyCredentialsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.useDefaultProxyCredentialsCheckBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.useDefaultProxyCredentialsCheckBox.Location = new System.Drawing.Point(520, 288);
-            this.useDefaultProxyCredentialsCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.useDefaultProxyCredentialsCheckBox.Location = new System.Drawing.Point(260, 150);
+            this.useDefaultProxyCredentialsCheckBox.Margin = new System.Windows.Forms.Padding(2);
             this.useDefaultProxyCredentialsCheckBox.Name = "useDefaultProxyCredentialsCheckBox";
-            this.useDefaultProxyCredentialsCheckBox.Size = new System.Drawing.Size(28, 27);
+            this.useDefaultProxyCredentialsCheckBox.Size = new System.Drawing.Size(15, 14);
             this.useDefaultProxyCredentialsCheckBox.TabIndex = 5;
             this.useDefaultProxyCredentialsCheckBox.UseVisualStyleBackColor = true;
             this.useDefaultProxyCredentialsCheckBox.CheckedChanged += new System.EventHandler(this.useDefaultProxyCredentialsCheckBox_CheckedChanged);
@@ -1207,10 +1167,10 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblProxyPassword.AutoSize = true;
             this.lblProxyPassword.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblProxyPassword.Location = new System.Drawing.Point(32, 408);
-            this.lblProxyPassword.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblProxyPassword.Location = new System.Drawing.Point(16, 212);
+            this.lblProxyPassword.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblProxyPassword.Name = "lblProxyPassword";
-            this.lblProxyPassword.Size = new System.Drawing.Size(112, 25);
+            this.lblProxyPassword.Size = new System.Drawing.Size(56, 13);
             this.lblProxyPassword.TabIndex = 53;
             this.lblProxyPassword.Text = "Password:";
             // 
@@ -1218,10 +1178,10 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblProxyDefaultCredentials.AutoSize = true;
             this.lblProxyDefaultCredentials.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblProxyDefaultCredentials.Location = new System.Drawing.Point(32, 288);
-            this.lblProxyDefaultCredentials.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblProxyDefaultCredentials.Location = new System.Drawing.Point(16, 150);
+            this.lblProxyDefaultCredentials.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblProxyDefaultCredentials.Name = "lblProxyDefaultCredentials";
-            this.lblProxyDefaultCredentials.Size = new System.Drawing.Size(245, 25);
+            this.lblProxyDefaultCredentials.Size = new System.Drawing.Size(121, 13);
             this.lblProxyDefaultCredentials.TabIndex = 59;
             this.lblProxyDefaultCredentials.Text = "Use Default Credentials:";
             // 
@@ -1229,10 +1189,10 @@ namespace ServiceBusExplorer.Forms
             // 
             this.txtProxyUserName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtProxyUserName.Location = new System.Drawing.Point(520, 348);
-            this.txtProxyUserName.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtProxyUserName.Location = new System.Drawing.Point(260, 181);
+            this.txtProxyUserName.Margin = new System.Windows.Forms.Padding(2);
             this.txtProxyUserName.Name = "txtProxyUserName";
-            this.txtProxyUserName.Size = new System.Drawing.Size(600, 31);
+            this.txtProxyUserName.Size = new System.Drawing.Size(302, 20);
             this.txtProxyUserName.TabIndex = 6;
             this.txtProxyUserName.TextChanged += new System.EventHandler(this.txtProxyUser_TextChanged);
             // 
@@ -1240,10 +1200,10 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblProxyUser.AutoSize = true;
             this.lblProxyUser.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblProxyUser.Location = new System.Drawing.Point(32, 348);
-            this.lblProxyUser.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblProxyUser.Location = new System.Drawing.Point(16, 181);
+            this.lblProxyUser.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblProxyUser.Name = "lblProxyUser";
-            this.lblProxyUser.Size = new System.Drawing.Size(125, 25);
+            this.lblProxyUser.Size = new System.Drawing.Size(63, 13);
             this.lblProxyUser.TabIndex = 51;
             this.lblProxyUser.Text = "User Name:";
             // 
@@ -1253,10 +1213,10 @@ namespace ServiceBusExplorer.Forms
             this.bypassProxyOnLocalAddressesCheckBox.Checked = true;
             this.bypassProxyOnLocalAddressesCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.bypassProxyOnLocalAddressesCheckBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.bypassProxyOnLocalAddressesCheckBox.Location = new System.Drawing.Point(520, 228);
-            this.bypassProxyOnLocalAddressesCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.bypassProxyOnLocalAddressesCheckBox.Location = new System.Drawing.Point(260, 119);
+            this.bypassProxyOnLocalAddressesCheckBox.Margin = new System.Windows.Forms.Padding(2);
             this.bypassProxyOnLocalAddressesCheckBox.Name = "bypassProxyOnLocalAddressesCheckBox";
-            this.bypassProxyOnLocalAddressesCheckBox.Size = new System.Drawing.Size(28, 27);
+            this.bypassProxyOnLocalAddressesCheckBox.Size = new System.Drawing.Size(15, 14);
             this.bypassProxyOnLocalAddressesCheckBox.TabIndex = 4;
             this.bypassProxyOnLocalAddressesCheckBox.UseVisualStyleBackColor = true;
             this.bypassProxyOnLocalAddressesCheckBox.CheckedChanged += new System.EventHandler(this.bypassProxyOnLocalAddressesCheckBox_CheckedChanged);
@@ -1265,10 +1225,10 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblBypassProxyOnLocalAddresses.AutoSize = true;
             this.lblBypassProxyOnLocalAddresses.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblBypassProxyOnLocalAddresses.Location = new System.Drawing.Point(32, 228);
-            this.lblBypassProxyOnLocalAddresses.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblBypassProxyOnLocalAddresses.Location = new System.Drawing.Point(16, 119);
+            this.lblBypassProxyOnLocalAddresses.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblBypassProxyOnLocalAddresses.Name = "lblBypassProxyOnLocalAddresses";
-            this.lblBypassProxyOnLocalAddresses.Size = new System.Drawing.Size(338, 25);
+            this.lblBypassProxyOnLocalAddresses.Size = new System.Drawing.Size(164, 13);
             this.lblBypassProxyOnLocalAddresses.TabIndex = 57;
             this.lblBypassProxyOnLocalAddresses.Text = "Bypass Proxy for local addresses:";
             // 
@@ -1276,10 +1236,10 @@ namespace ServiceBusExplorer.Forms
             // 
             this.txtProxyBypassList.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtProxyBypassList.Location = new System.Drawing.Point(520, 168);
-            this.txtProxyBypassList.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtProxyBypassList.Location = new System.Drawing.Point(260, 87);
+            this.txtProxyBypassList.Margin = new System.Windows.Forms.Padding(2);
             this.txtProxyBypassList.Name = "txtProxyBypassList";
-            this.txtProxyBypassList.Size = new System.Drawing.Size(600, 31);
+            this.txtProxyBypassList.Size = new System.Drawing.Size(302, 20);
             this.txtProxyBypassList.TabIndex = 3;
             this.txtProxyBypassList.TextChanged += new System.EventHandler(this.txtProxyBypassList_TextChanged);
             // 
@@ -1287,10 +1247,10 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblProxyBypass.AutoSize = true;
             this.lblProxyBypass.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblProxyBypass.Location = new System.Drawing.Point(32, 168);
-            this.lblProxyBypass.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblProxyBypass.Location = new System.Drawing.Point(16, 87);
+            this.lblProxyBypass.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblProxyBypass.Name = "lblProxyBypass";
-            this.lblProxyBypass.Size = new System.Drawing.Size(181, 25);
+            this.lblProxyBypass.Size = new System.Drawing.Size(88, 13);
             this.lblProxyBypass.TabIndex = 55;
             this.lblProxyBypass.Text = "Bypass Proxy for:";
             // 
@@ -1300,10 +1260,10 @@ namespace ServiceBusExplorer.Forms
             this.overrideDefaultProxyCheckBox.Checked = true;
             this.overrideDefaultProxyCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.overrideDefaultProxyCheckBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.overrideDefaultProxyCheckBox.Location = new System.Drawing.Point(520, 48);
-            this.overrideDefaultProxyCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.overrideDefaultProxyCheckBox.Location = new System.Drawing.Point(260, 25);
+            this.overrideDefaultProxyCheckBox.Margin = new System.Windows.Forms.Padding(2);
             this.overrideDefaultProxyCheckBox.Name = "overrideDefaultProxyCheckBox";
-            this.overrideDefaultProxyCheckBox.Size = new System.Drawing.Size(28, 27);
+            this.overrideDefaultProxyCheckBox.Size = new System.Drawing.Size(15, 14);
             this.overrideDefaultProxyCheckBox.TabIndex = 1;
             this.overrideDefaultProxyCheckBox.UseVisualStyleBackColor = true;
             this.overrideDefaultProxyCheckBox.CheckedChanged += new System.EventHandler(this.overrideDefaultProxyCheckBox_CheckedChanged);
@@ -1312,10 +1272,10 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblOverrideProxy.AutoSize = true;
             this.lblOverrideProxy.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblOverrideProxy.Location = new System.Drawing.Point(32, 48);
-            this.lblOverrideProxy.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblOverrideProxy.Location = new System.Drawing.Point(16, 25);
+            this.lblOverrideProxy.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblOverrideProxy.Name = "lblOverrideProxy";
-            this.lblOverrideProxy.Size = new System.Drawing.Size(339, 25);
+            this.lblOverrideProxy.Size = new System.Drawing.Size(168, 13);
             this.lblOverrideProxy.TabIndex = 54;
             this.lblOverrideProxy.Text = "Override system/app.config proxy:";
             // 
@@ -1323,10 +1283,10 @@ namespace ServiceBusExplorer.Forms
             // 
             this.txtProxyAddress.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtProxyAddress.Location = new System.Drawing.Point(520, 108);
-            this.txtProxyAddress.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.txtProxyAddress.Location = new System.Drawing.Point(260, 56);
+            this.txtProxyAddress.Margin = new System.Windows.Forms.Padding(2);
             this.txtProxyAddress.Name = "txtProxyAddress";
-            this.txtProxyAddress.Size = new System.Drawing.Size(600, 31);
+            this.txtProxyAddress.Size = new System.Drawing.Size(302, 20);
             this.txtProxyAddress.TabIndex = 2;
             this.txtProxyAddress.TextChanged += new System.EventHandler(this.txtProxyAddress_TextChanged);
             // 
@@ -1334,10 +1294,10 @@ namespace ServiceBusExplorer.Forms
             // 
             this.lblProxyAddress.AutoSize = true;
             this.lblProxyAddress.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblProxyAddress.Location = new System.Drawing.Point(32, 108);
-            this.lblProxyAddress.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblProxyAddress.Location = new System.Drawing.Point(16, 56);
+            this.lblProxyAddress.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblProxyAddress.Name = "lblProxyAddress";
-            this.lblProxyAddress.Size = new System.Drawing.Size(158, 25);
+            this.lblProxyAddress.Size = new System.Drawing.Size(77, 13);
             this.lblProxyAddress.TabIndex = 52;
             this.lblProxyAddress.Text = "Proxy Address:";
             // 
@@ -1352,20 +1312,19 @@ namespace ServiceBusExplorer.Forms
             this.mainPanel.Controls.Add(this.cboConfigFile);
             this.mainPanel.Controls.Add(this.label1);
             this.mainPanel.Location = new System.Drawing.Point(0, 0);
-            this.mainPanel.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
             this.mainPanel.Name = "mainPanel";
-            this.mainPanel.Size = new System.Drawing.Size(1228, 723);
+            this.mainPanel.Size = new System.Drawing.Size(614, 376);
             this.mainPanel.TabIndex = 1;
             this.mainPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.mainPanel_Paint);
             // 
             // OptionForm
             // 
             this.AcceptButton = this.btnOk;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(1230, 802);
+            this.ClientSize = new System.Drawing.Size(615, 417);
             this.Controls.Add(this.btnSave);
             this.Controls.Add(this.btnReset);
             this.Controls.Add(this.btnCancel);
@@ -1374,7 +1333,6 @@ namespace ServiceBusExplorer.Forms
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.KeyPreview = true;
-            this.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "OptionForm";
@@ -1497,5 +1455,7 @@ namespace ServiceBusExplorer.Forms
         private System.Windows.Forms.Label lblOverrideProxy;
         private System.Windows.Forms.TextBox txtProxyAddress;
         private System.Windows.Forms.Label lblProxyAddress;
+        private System.Windows.Forms.Label lblDisableAccidentalDeletionPrevention;
+        private System.Windows.Forms.CheckBox disableAccidentalDeletionPrevention;
     }
 }

--- a/src/ServiceBusExplorer/Forms/OptionForm.cs
+++ b/src/ServiceBusExplorer/Forms/OptionForm.cs
@@ -229,6 +229,8 @@ namespace ServiceBusExplorer.Forms
 
             MainSettings.MessageBodyType = MainSettings.MessageBodyType; // .Stream.ToString();
 
+            disableAccidentalDeletionPrevention.Checked = MainSettings.DisableAccidentalDeletionPrevention;
+
             overrideDefaultProxyCheckBox.Checked = MainSettings.ProxyOverrideDefault;
             txtProxyAddress.Text = MainSettings.ProxyAddress;
             txtProxyBypassList.Text = MainSettings.ProxyBypassList;
@@ -384,6 +386,11 @@ namespace ServiceBusExplorer.Forms
             {
                 MainSettings.EncodingType = (EncodingType)cboEncodingType.SelectedItem;
             }
+        }
+
+        void disableAccidentalDeletionPrevention_CheckedChanged(object sender, EventArgs e)
+        {
+            MainSettings.DisableAccidentalDeletionPrevention = disableAccidentalDeletionPrevention.Checked;
         }
 
         void cboConfigFile_SelectionChangeCommitted(object sender, EventArgs e)
@@ -584,6 +591,9 @@ namespace ServiceBusExplorer.Forms
             SaveSetting(configuration, readSettings, ConfigurationParameters.MessageBodyType,
                 MainSettings.MessageBodyType);
 
+            SaveSetting(configuration, readSettings, ConfigurationParameters.DisableAccidentalDeletionPrevention,
+                MainSettings.DisableAccidentalDeletionPrevention);
+
             SaveSetting(configuration, readSettings, ConfigurationParameters.ProxyOverrideDefault,
                 MainSettings.ProxyOverrideDefault);
             SaveSetting(configuration, readSettings, ConfigurationParameters.ProxyAddress,
@@ -673,6 +683,8 @@ namespace ServiceBusExplorer.Forms
             }
 
             cboDefaultMessageBodyType.SelectedIndex = (int)bodyType;
+
+            disableAccidentalDeletionPrevention.Checked = mainSettings.DisableAccidentalDeletionPrevention;
 
             overrideDefaultProxyCheckBox.Checked = mainSettings.ProxyOverrideDefault;
             txtProxyAddress.Text = mainSettings.ProxyAddress;

--- a/src/ServiceBusExplorer/ServiceBusExplorer.csproj
+++ b/src/ServiceBusExplorer/ServiceBusExplorer.csproj
@@ -119,6 +119,12 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommandLineOptions.cs" />
+    <Compile Include="Controls\AccidentalDeletionPreventionCheckControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Controls\AccidentalDeletionPreventionCheckControl.Designer.cs">
+      <DependentUpon>AccidentalDeletionPreventionCheckControl.cs</DependentUpon>
+    </Compile>
     <Compile Include="Controls\CheckBoxComboBox.cs">
       <SubType>Component</SubType>
     </Compile>
@@ -424,6 +430,9 @@
     <Compile Include="UIHelpers\StandardValuesConverter.cs" />
     <Compile Include="UIHelpers\TabControlHelper.cs" />
     <Compile Include="UIHelpers\TreeViewHelper.cs" />
+    <EmbeddedResource Include="Controls\AccidentalDeletionPreventionCheckControl.resx">
+      <DependentUpon>AccidentalDeletionPreventionCheckControl.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="Controls\HandleConsumerGroupControl.resx">
       <DependentUpon>HandleConsumerGroupControl.cs</DependentUpon>
       <SubType>Designer</SubType>


### PR DESCRIPTION
I was recently working with our production environment with Service Bus Explorer, and an accidental Delete keystroke was sent to the tree view with the root node selected, and I realized with alarm that I was one errant mouse or key action away from completely annihilating every single Service Bus queue, topic, subscription for our production environment.

This PR adds a new feature so that if a deletion has a broad scope, the delete form prompts the user to explicitly type in what it is they want to delete. If they don't actually type the words "Absolutely Everything", for instance, then Service Bus Explorer will not in fact delete absolutely everything.

When I was first writing this, I imagined actually putting the name of the item to be deleted into the input box -- this could still be done, but I couldn't think of obvious ways to a) keep the text short, and b) deal with tree nodes like "Queues" and "Topics". I am open to suggestions in this area -- as of right now, I gave up on trying to inject customized names and instead just use strings like "Absolutely Everything" and "All Topics In Path".

I have tried to follow the code style I saw elsewhere as best as possible. Let me know if any aspect of this doesn't pass muster. :-)