### PR TITLE
Fixed the FQDN of classes in the App.config

### DIFF
--- a/App.config
+++ b/App.config
@@ -13,20 +13,20 @@
     <add key="SASConnectionString" value="Endpoint=sb://NAMESPACE.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=" />
   </serviceBusNamespaces>
   <brokeredMessageInspectors>
-    <add key="LogBrokeredMessageInspector" value="Microsoft.Azure.ServiceBusExplorer.Helpers.LogBrokeredMessageInspector,ServiceBusExplorer" />
-    <add key="ZipBrokeredMessageInspector" value="Microsoft.Azure.ServiceBusExplorer.Helpers.ZipBrokeredMessageInspector,ServiceBusExplorer" />
+    <add key="LogBrokeredMessageInspector" value="ServiceBusExplorer.Helpers.LogBrokeredMessageInspector,ServiceBusExplorer.Common" />
+    <add key="ZipBrokeredMessageInspector" value="ServiceBusExplorer.Helpers.ZipBrokeredMessageInspector,ServiceBusExplorer.Common" />
   </brokeredMessageInspectors>
   <eventDataInspectors>
-    <add key="LogEventDataInspector" value="Microsoft.Azure.ServiceBusExplorer.Helpers.LogEventDataInspector,ServiceBusExplorer" />
-    <add key="ZipEventDataInspector" value="Microsoft.Azure.ServiceBusExplorer.Helpers.ZipEventDataInspector,ServiceBusExplorer" />
+    <add key="LogEventDataInspector" value="ServiceBusExplorer.Helpers.LogEventDataInspector,ServiceBusExplorer.Common" />
+    <add key="ZipEventDataInspector" value="ServiceBusExplorer.Helpers.ZipEventDataInspector,ServiceBusExplorer.Common" />
   </eventDataInspectors>
   <brokeredMessageGenerators>
-    <add key="OnOffDeviceBrokeredMessageGenerator" value="Microsoft.Azure.ServiceBusExplorer.Helpers.OnOffDeviceBrokeredMessageGenerator,ServiceBusExplorer" />
-    <add key="ThresholdDeviceBrokeredMessageGenerator" value="Microsoft.Azure.ServiceBusExplorer.Helpers.ThresholdDeviceBrokeredMessageGenerator,ServiceBusExplorer" />
+    <add key="OnOffDeviceBrokeredMessageGenerator" value="ServiceBusExplorer.Helpers.OnOffDeviceBrokeredMessageGenerator,ServiceBusExplorer.Common" />
+    <add key="ThresholdDeviceBrokeredMessageGenerator" value="ServiceBusExplorer.Helpers.ThresholdDeviceBrokeredMessageGenerator,ServiceBusExplorer.Common" />
   </brokeredMessageGenerators>
   <eventDataGenerators>
-    <add key="OnOffDeviceEventDataGenerator" value="Microsoft.Azure.ServiceBusExplorer.Helpers.OnOffDeviceEventDataGenerator,ServiceBusExplorer" />
-    <add key="ThresholdDeviceEventDataGenerator" value="Microsoft.Azure.ServiceBusExplorer.Helpers.ThresholdDeviceEventDataGenerator,ServiceBusExplorer" />
+    <add key="OnOffDeviceEventDataGenerator" value="ServiceBusExplorer.Helpers.OnOffDeviceEventDataGenerator,ServiceBusExplorer.Common" />
+    <add key="ThresholdDeviceEventDataGenerator" value="ServiceBusExplorer.Helpers.ThresholdDeviceEventDataGenerator,ServiceBusExplorer.Common" />
   </eventDataGenerators>
   <appSettings>
     <add key="debug" value="true" />
@@ -53,7 +53,7 @@
     <add key="useAscii" value="true" />
     <add key="subscriptionId" value="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" />
     <add key="certificateThumbprint" value="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" />
-    <add key="messageDeferProvider" value="Microsoft.Azure.ServiceBusExplorer.InMemoryMessageDeferProvider,ServiceBusExplorer" />
+    <add key="messageDeferProvider" value="ServiceBusExplorer.Helpers.InMemoryMessageDeferProvider,ServiceBusExplorer.Common" />
     <add key="Microsoft.ServiceBus.X509RevocationMode" value="NoCheck" />
     <add key="ClientSettingsProvider.ServiceUri" value="" />
   </appSettings>  


### PR DESCRIPTION
This PR fixes the wrong FQDN of helper components such as message generators and message inspectors. This bug was introduced by the split of the solution into multiple projects as the helper components in question have been moved to a separate assembly and project (Common) and the namespace of these classes has been changed to ServiceBusExplorer.Helpers.