### PR TITLE
Feature: Retrieve queue messages from a specific session only

### DIFF
--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -356,7 +356,7 @@ namespace ServiceBusExplorer.Controls
         {
             using (
                 var receiveModeForm = new ReceiveModeForm(RetrieveMessagesFromQueue, MainForm.SingletonMainForm.TopCount,
-                    serviceBusHelper.BrokeredMessageInspectors.Keys))
+                    serviceBusHelper.BrokeredMessageInspectors.Keys, queueDescription.RequiresSession))
             {
                 if (receiveModeForm.ShowDialog() == DialogResult.OK)
                 {

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -23,6 +23,7 @@
 
 #region Using Directives
 
+#nullable enable
 using System;
 using System.ComponentModel;
 using System.Drawing;
@@ -371,11 +372,11 @@ namespace ServiceBusExplorer.Controls
                     if (queueDescription.EnablePartitioning)
                     {
                         ReadMessagesOneAtTheTime(receiveModeForm.Peek, receiveModeForm.All, receiveModeForm.Count,
-                            messageInspector, receiveModeForm.FromSequenceNumber);
+                            messageInspector, receiveModeForm.FromSequenceNumber, receiveModeForm.FromSession);
                     }
                     else
                     {
-                        GetMessages(receiveModeForm.Peek, receiveModeForm.All, receiveModeForm.Count, messageInspector, receiveModeForm.FromSequenceNumber);
+                        GetMessages(receiveModeForm.Peek, receiveModeForm.All, receiveModeForm.Count, messageInspector, receiveModeForm.FromSequenceNumber, receiveModeForm.FromSession);
                     }
                 }
             }
@@ -1332,7 +1333,7 @@ namespace ServiceBusExplorer.Controls
             }
         }
 
-        private void GetMessages(bool peek, bool all, int count, IBrokeredMessageInspector messageInspector, long? fromSequenceNumber = null)
+        private void GetMessages(bool peek, bool all, int count, IBrokeredMessageInspector messageInspector, long? fromSequenceNumber = null, string? fromSession = null)
         {
             try
             {
@@ -1345,20 +1346,31 @@ namespace ServiceBusExplorer.Controls
                 var brokeredMessages = new List<BrokeredMessage>();
                 if (peek)
                 {
+                    var totalRetrieved = 0;
+
+                    MessageReceiver receiver;
+                    if (fromSession != null)
+                    {
                     var queueClient = serviceBusHelper.MessagingFactory.CreateQueueClient(queueDescription.Path,
                         ReceiveMode.PeekLock);
-                    var totalRetrieved = 0;
+                        receiver = queueClient.AcceptMessageSession(fromSession);
+                    }
+                    else
+                    {
+                        receiver = serviceBusHelper.MessagingFactory.CreateMessageReceiver(queueDescription.Path, ReceiveMode.PeekLock);
+                    }
+
                     while (totalRetrieved < count)
                     {
                         IEnumerable<BrokeredMessage> messageEnumerable;
 
                         if (totalRetrieved == 0 && fromSequenceNumber.HasValue)
                         {
-                            messageEnumerable = queueClient.PeekBatch(fromSequenceNumber.Value, count);
+                            messageEnumerable = receiver.PeekBatch(fromSequenceNumber.Value, count);
                         }
                         else
                         {
-                            messageEnumerable = queueClient.PeekBatch(count);
+                            messageEnumerable = receiver.PeekBatch(count);
                         }
 
                         if (messageEnumerable == null)
@@ -1385,9 +1397,17 @@ namespace ServiceBusExplorer.Controls
                     {
                         var queueClient = serviceBusHelper.MessagingFactory.CreateQueueClient(queueDescription.Path,
                             ReceiveMode.ReceiveAndDelete);
-                        messageReceiver =
-                            queueClient.AcceptMessageSession(
+                        if (fromSession != null)
+                        {
+                            messageReceiver = queueClient.AcceptMessageSession(fromSession,
                                 TimeSpan.FromSeconds(MainForm.SingletonMainForm.ReceiveTimeout));
+                        }
+                        else
+                        {
+                            messageReceiver =
+                                queueClient.AcceptMessageSession(
+                                    TimeSpan.FromSeconds(MainForm.SingletonMainForm.ReceiveTimeout));
+                        }
                     }
                     else
                     {
@@ -1469,26 +1489,36 @@ namespace ServiceBusExplorer.Controls
             }
         }
 
-        private void ReadMessagesOneAtTheTime(bool peek, bool all, int count, IBrokeredMessageInspector messageInspector, long? fromSequenceNumber = null)
+        private void ReadMessagesOneAtTheTime(bool peek, bool all, int count, IBrokeredMessageInspector messageInspector, long? fromSequenceNumber = null, string? fromSession = null)
         {
             try
             {
                 var brokeredMessages = new List<BrokeredMessage>();
                 if (peek)
                 {
+                    MessageReceiver messageReceiver;
+                    if (fromSession != null)
+                    {
                     var queueClient = serviceBusHelper.MessagingFactory.CreateQueueClient(queueDescription.Path,
                         ReceiveMode.PeekLock);
+                        messageReceiver = queueClient.AcceptMessageSession(fromSession);
+                    }
+                    else
+                    {
+                        messageReceiver = serviceBusHelper.MessagingFactory.CreateMessageReceiver(queueDescription.Path, ReceiveMode.PeekLock);
+                    }
+    
                     for (var i = 0; i < count; i++)
                     {
                         BrokeredMessage message;
 
                         if (i == 0 && fromSequenceNumber.HasValue)
                         {
-                            message = queueClient.Peek(fromSequenceNumber.Value);
+                            message = messageReceiver.Peek(fromSequenceNumber.Value);
                         }
                         else
                         {
-                            message = queueClient.Peek();
+                            message = messageReceiver.Peek();
                         }
 
                         if (message != null)
@@ -1509,9 +1539,18 @@ namespace ServiceBusExplorer.Controls
                     {
                         var queueClient = serviceBusHelper.MessagingFactory.CreateQueueClient(queueDescription.Path,
                             ReceiveMode.ReceiveAndDelete);
-                        messageReceiver =
+                        if (fromSession != null)
+                        {
+                            messageReceiver =
+                                queueClient.AcceptMessageSession(fromSession,
+                                    TimeSpan.FromSeconds(MainForm.SingletonMainForm.ReceiveTimeout));
+                        }
+                        else
+                        {
+                            messageReceiver =
                             queueClient.AcceptMessageSession(
                                 TimeSpan.FromSeconds(MainForm.SingletonMainForm.ReceiveTimeout));
+                        }
                     }
                     else
                     {

--- a/src/ServiceBusExplorer/Forms/ReceiveModeForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/ReceiveModeForm.Designer.cs
@@ -57,6 +57,10 @@ namespace ServiceBusExplorer.Forms
             this.btnOk = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
             this.mainPanel = new System.Windows.Forms.Panel();
+            this.grouperSession = new ServiceBusExplorer.Controls.Grouper();
+            this.txtFromSession = new System.Windows.Forms.TextBox();
+            this.grouperFrom = new ServiceBusExplorer.Controls.Grouper();
+            this.txtFromSequenceNumber = new System.Windows.Forms.TextBox();
             this.grouperInspector = new ServiceBusExplorer.Controls.Grouper();
             this.cboReceiverInspector = new System.Windows.Forms.ComboBox();
             this.grouperMessages = new ServiceBusExplorer.Controls.Grouper();
@@ -66,13 +70,12 @@ namespace ServiceBusExplorer.Forms
             this.grouperReadMode = new ServiceBusExplorer.Controls.Grouper();
             this.btnReceive = new System.Windows.Forms.RadioButton();
             this.btnPeek = new System.Windows.Forms.RadioButton();
-            this.grouperFrom = new ServiceBusExplorer.Controls.Grouper();
-            this.txtFromSequenceNumber = new System.Windows.Forms.TextBox();
             this.mainPanel.SuspendLayout();
+            this.grouperSession.SuspendLayout();
+            this.grouperFrom.SuspendLayout();
             this.grouperInspector.SuspendLayout();
             this.grouperMessages.SuspendLayout();
             this.grouperReadMode.SuspendLayout();
-            this.grouperFrom.SuspendLayout();
             this.SuspendLayout();
             // 
             // btnOk
@@ -83,7 +86,7 @@ namespace ServiceBusExplorer.Forms
             this.btnOk.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnOk.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnOk.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnOk.Location = new System.Drawing.Point(523, 181);
+            this.btnOk.Location = new System.Drawing.Point(522, 169);
             this.btnOk.Name = "btnOk";
             this.btnOk.Size = new System.Drawing.Size(72, 24);
             this.btnOk.TabIndex = 1;
@@ -101,7 +104,7 @@ namespace ServiceBusExplorer.Forms
             this.btnCancel.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCancel.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnCancel.Location = new System.Drawing.Point(603, 181);
+            this.btnCancel.Location = new System.Drawing.Point(602, 169);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(72, 24);
             this.btnCancel.TabIndex = 2;
@@ -116,15 +119,83 @@ namespace ServiceBusExplorer.Forms
             this.mainPanel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.mainPanel.BackColor = System.Drawing.SystemColors.Window;
+            this.mainPanel.Controls.Add(this.grouperSession);
             this.mainPanel.Controls.Add(this.grouperFrom);
             this.mainPanel.Controls.Add(this.grouperInspector);
             this.mainPanel.Controls.Add(this.grouperMessages);
             this.mainPanel.Controls.Add(this.grouperReadMode);
             this.mainPanel.Location = new System.Drawing.Point(0, 0);
             this.mainPanel.Name = "mainPanel";
-            this.mainPanel.Size = new System.Drawing.Size(691, 168);
+            this.mainPanel.Size = new System.Drawing.Size(690, 155);
             this.mainPanel.TabIndex = 0;
             this.mainPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.mainPanel_Paint);
+            // 
+            // grouperSession
+            // 
+            this.grouperSession.BackgroundColor = System.Drawing.Color.White;
+            this.grouperSession.BackgroundGradientColor = System.Drawing.Color.White;
+            this.grouperSession.BackgroundGradientMode = ServiceBusExplorer.Controls.Grouper.GroupBoxGradientMode.None;
+            this.grouperSession.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.grouperSession.BorderThickness = 1F;
+            this.grouperSession.Controls.Add(this.txtFromSession);
+            this.grouperSession.CustomGroupBoxColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.grouperSession.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
+            this.grouperSession.ForeColor = System.Drawing.Color.White;
+            this.grouperSession.GroupImage = null;
+            this.grouperSession.GroupTitle = "From Session";
+            this.grouperSession.Location = new System.Drawing.Point(465, 80);
+            this.grouperSession.Name = "grouperSession";
+            this.grouperSession.Padding = new System.Windows.Forms.Padding(20);
+            this.grouperSession.PaintGroupBox = true;
+            this.grouperSession.RoundCorners = 4;
+            this.grouperSession.ShadowColor = System.Drawing.Color.DarkGray;
+            this.grouperSession.ShadowControl = false;
+            this.grouperSession.ShadowThickness = 1;
+            this.grouperSession.Size = new System.Drawing.Size(208, 64);
+            this.grouperSession.TabIndex = 44;
+            // 
+            // txtFromSession
+            // 
+            this.txtFromSession.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtFromSession.Location = new System.Drawing.Point(15, 32);
+            this.txtFromSession.Name = "txtFromSession";
+            this.txtFromSession.Size = new System.Drawing.Size(177, 20);
+            this.txtFromSession.TabIndex = 42;
+            // 
+            // grouperFrom
+            // 
+            this.grouperFrom.BackgroundColor = System.Drawing.Color.White;
+            this.grouperFrom.BackgroundGradientColor = System.Drawing.Color.White;
+            this.grouperFrom.BackgroundGradientMode = ServiceBusExplorer.Controls.Grouper.GroupBoxGradientMode.None;
+            this.grouperFrom.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.grouperFrom.BorderThickness = 1F;
+            this.grouperFrom.Controls.Add(this.txtFromSequenceNumber);
+            this.grouperFrom.CustomGroupBoxColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.grouperFrom.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
+            this.grouperFrom.ForeColor = System.Drawing.Color.White;
+            this.grouperFrom.GroupImage = null;
+            this.grouperFrom.GroupTitle = "From Sequence Number";
+            this.grouperFrom.Location = new System.Drawing.Point(465, 8);
+            this.grouperFrom.Name = "grouperFrom";
+            this.grouperFrom.Padding = new System.Windows.Forms.Padding(20);
+            this.grouperFrom.PaintGroupBox = true;
+            this.grouperFrom.RoundCorners = 4;
+            this.grouperFrom.ShadowColor = System.Drawing.Color.DarkGray;
+            this.grouperFrom.ShadowControl = false;
+            this.grouperFrom.ShadowThickness = 1;
+            this.grouperFrom.Size = new System.Drawing.Size(208, 64);
+            this.grouperFrom.TabIndex = 43;
+            // 
+            // txtFromSequenceNumber
+            // 
+            this.txtFromSequenceNumber.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtFromSequenceNumber.Location = new System.Drawing.Point(15, 32);
+            this.txtFromSequenceNumber.Name = "txtFromSequenceNumber";
+            this.txtFromSequenceNumber.Size = new System.Drawing.Size(177, 20);
+            this.txtFromSequenceNumber.TabIndex = 42;
+            this.txtFromSequenceNumber.Text = " ";
             // 
             // grouperInspector
             // 
@@ -147,7 +218,7 @@ namespace ServiceBusExplorer.Forms
             this.grouperInspector.ShadowColor = System.Drawing.Color.DarkGray;
             this.grouperInspector.ShadowControl = false;
             this.grouperInspector.ShadowThickness = 1;
-            this.grouperInspector.Size = new System.Drawing.Size(657, 72);
+            this.grouperInspector.Size = new System.Drawing.Size(432, 64);
             this.grouperInspector.TabIndex = 43;
             this.grouperInspector.CustomPaint += new System.Action<System.Windows.Forms.PaintEventArgs>(this.grouperInspector_CustomPaint);
             // 
@@ -158,7 +229,7 @@ namespace ServiceBusExplorer.Forms
             this.cboReceiverInspector.FormattingEnabled = true;
             this.cboReceiverInspector.Location = new System.Drawing.Point(16, 32);
             this.cboReceiverInspector.Name = "cboReceiverInspector";
-            this.cboReceiverInspector.Size = new System.Drawing.Size(625, 21);
+            this.cboReceiverInspector.Size = new System.Drawing.Size(400, 21);
             this.cboReceiverInspector.TabIndex = 92;
             // 
             // grouperMessages
@@ -274,45 +345,12 @@ namespace ServiceBusExplorer.Forms
             this.btnPeek.UseVisualStyleBackColor = true;
             this.btnPeek.CheckedChanged += new System.EventHandler(this.receiveMode_CheckedChanged);
             // 
-            // grouperFrom
-            // 
-            this.grouperFrom.BackgroundColor = System.Drawing.Color.White;
-            this.grouperFrom.BackgroundGradientColor = System.Drawing.Color.White;
-            this.grouperFrom.BackgroundGradientMode = ServiceBusExplorer.Controls.Grouper.GroupBoxGradientMode.None;
-            this.grouperFrom.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.grouperFrom.BorderThickness = 1F;
-            this.grouperFrom.Controls.Add(this.txtFromSequenceNumber);
-            this.grouperFrom.CustomGroupBoxColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.grouperFrom.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
-            this.grouperFrom.ForeColor = System.Drawing.Color.White;
-            this.grouperFrom.GroupImage = null;
-            this.grouperFrom.GroupTitle = "From Sequence Number";
-            this.grouperFrom.Location = new System.Drawing.Point(465, 8);
-            this.grouperFrom.Name = "grouperFrom";
-            this.grouperFrom.Padding = new System.Windows.Forms.Padding(20);
-            this.grouperFrom.PaintGroupBox = true;
-            this.grouperFrom.RoundCorners = 4;
-            this.grouperFrom.ShadowColor = System.Drawing.Color.DarkGray;
-            this.grouperFrom.ShadowControl = false;
-            this.grouperFrom.ShadowThickness = 1;
-            this.grouperFrom.Size = new System.Drawing.Size(208, 64);
-            this.grouperFrom.TabIndex = 43;
-            // 
-            // txtSequenceNumber
-            // 
-            this.txtFromSequenceNumber.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtFromSequenceNumber.Location = new System.Drawing.Point(15, 32);
-            this.txtFromSequenceNumber.Name = "txtFromSequenceNumber";
-            this.txtFromSequenceNumber.Size = new System.Drawing.Size(177, 20);
-            this.txtFromSequenceNumber.TabIndex = 42;
-            // 
             // ReceiveModeForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
-            this.ClientSize = new System.Drawing.Size(691, 217);
+            this.ClientSize = new System.Drawing.Size(690, 205);
             this.Controls.Add(this.mainPanel);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnOk);
@@ -326,13 +364,15 @@ namespace ServiceBusExplorer.Forms
             this.Text = "Enter Value";
             this.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.ReceiveModeForm_KeyPress);
             this.mainPanel.ResumeLayout(false);
+            this.grouperSession.ResumeLayout(false);
+            this.grouperSession.PerformLayout();
+            this.grouperFrom.ResumeLayout(false);
+            this.grouperFrom.PerformLayout();
             this.grouperInspector.ResumeLayout(false);
             this.grouperMessages.ResumeLayout(false);
             this.grouperMessages.PerformLayout();
             this.grouperReadMode.ResumeLayout(false);
             this.grouperReadMode.PerformLayout();
-            this.grouperFrom.ResumeLayout(false);
-            this.grouperFrom.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -353,5 +393,7 @@ namespace ServiceBusExplorer.Forms
         private System.Windows.Forms.ComboBox cboReceiverInspector;
         private Grouper grouperFrom;
         private System.Windows.Forms.TextBox txtFromSequenceNumber;
+        private Grouper grouperSession;
+        private System.Windows.Forms.TextBox txtFromSession;
     }
 }

--- a/src/ServiceBusExplorer/Forms/ReceiveModeForm.cs
+++ b/src/ServiceBusExplorer/Forms/ReceiveModeForm.cs
@@ -43,7 +43,7 @@ namespace ServiceBusExplorer.Forms
         #endregion
 
         #region Public Constructor
-        public ReceiveModeForm(string message, int count, IEnumerable<string> brokeredMessageInspectors)
+        public ReceiveModeForm(string message, int count, IEnumerable<string> brokeredMessageInspectors, bool fromSessionSelectionActive = false)
         {
             InitializeComponent();
             Text = message;
@@ -59,6 +59,8 @@ namespace ServiceBusExplorer.Forms
             {
                 cboReceiverInspector.Items.Add(messageInspectors[i]);
             }
+
+            txtFromSession.Enabled = fromSessionSelectionActive;
         }
         #endregion
 

--- a/src/ServiceBusExplorer/Forms/ReceiveModeForm.cs
+++ b/src/ServiceBusExplorer/Forms/ReceiveModeForm.cs
@@ -21,6 +21,7 @@
 
 #region Using Directives
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -73,6 +74,7 @@ namespace ServiceBusExplorer.Forms
         public bool All { get; private set; }
         public string Inspector { get; private set; }
         public long? FromSequenceNumber { get; private set; }
+        public string? FromSession { get; private set; }
         #endregion
 
         #region Event Handlers
@@ -96,6 +98,11 @@ namespace ServiceBusExplorer.Forms
                 {
                     FromSequenceNumber = fromSequenceNumber;
                 }
+            }
+
+            if (!string.IsNullOrEmpty(txtFromSession.Text))
+            {
+                FromSession = txtFromSession.Text;
             }
             Close();
         }

--- a/src/ServiceBusExplorer/ServiceBusExplorer.csproj
+++ b/src/ServiceBusExplorer/ServiceBusExplorer.csproj
@@ -47,6 +47,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <UseVSHostingProcess>true</UseVSHostingProcess>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -57,6 +58,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>NewServiceBusExplorerLogo.ico</ApplicationIcon>
@@ -75,7 +77,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\Release\</OutputPath>
@@ -86,7 +88,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>


### PR DESCRIPTION
# Reason for the PR
This PR implements the feature request #464 in a very minimalistic and non-invasive way.

# Scope / Background
Adds support for limiting retrieving messages to specific sessions only.
Currently only Queues are supported but Session aware Subscriptions should also work with minimal extra work.
For this I will create another small PR if this one is accepted.

I tried to touch as less code as possible to implement this.

In this version the user has to manually type in the Session ID in the dialog window for retrieving messages.
If requested a list of available messages sessions could be provided in the dialog aswell but then I would prefer to extract the dialog and implement one Session-aware dialog and one for all non-session-aware entities.

![image](https://user-images.githubusercontent.com/7881529/96045472-47e23600-0e72-11eb-8b18-c7efd3aa7360.png)
