### PR TITLE
Prevent tab to switch after receiving messages

### DIFF
--- a/src/ServiceBusExplorer/Forms/MainForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.Designer.cs
@@ -616,7 +616,7 @@ namespace ServiceBusExplorer.Forms
             this.serviceBusTreeView.TabIndex = 13;
             this.serviceBusTreeView.BeforeExpand += new System.Windows.Forms.TreeViewCancelEventHandler(this.serviceBusTreeView_BeforeExpand);
             this.serviceBusTreeView.NodeMouseClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.serviceBusTreeView_NodeMouseClick);
-            this.serviceBusTreeView.KeyUp += new System.Windows.Forms.KeyEventHandler(this.serviceBusTreeView_KeyUp);
+            this.serviceBusTreeView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.serviceBusTreeView_KeyDown);
             // 
             // panelMain
             // 

--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -2273,7 +2273,7 @@ namespace ServiceBusExplorer.Forms
             }
         }
 
-        private void serviceBusTreeView_KeyUp(object sender, KeyEventArgs keyEventArgs)
+        private void serviceBusTreeView_KeyDown(object sender, KeyEventArgs keyEventArgs)
         {
             switch (keyEventArgs.KeyCode)
             {
@@ -4622,6 +4622,7 @@ namespace ServiceBusExplorer.Forms
                                     SubscriptionRetrievedFormat, subscription.Name, topic.Path),
                                 false);
                             treeNodesToLazyLoad.Add(subscriptionNode);
+                            ApplyColor(subscriptionNode, true);
                         }
                     }
                 }
@@ -4654,6 +4655,7 @@ namespace ServiceBusExplorer.Forms
                                     topic.Path), false);
                         }
                     }
+                    ApplyColor(subscriptionNode, true);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Prior to this PR, when you used the Receive messages features and you used the `Enter` key to close the modal form allowing to provide details (mode, number of messages), quite frequently, immediately after receiving messages, the right tab switched back to the queue/subscription details.
Apart from the annoyance, when using Receive mode, it meant messages were lost without a way to get them anymore.

This was due to the fact that events are sent in the following order:
* `KeyDown`
* `KeyPress`
* `Keyup`

As the `KeyPress` was consumed to close the modal form, the `KeyUp` was sent to the parent window, which is often in this case the tree view, in turn resulting in its `KeyUp` event to fire.

Switching to `KeyDown` for the tree view easily solves this, and makes the behavior consistent with the error list view.