### PR TITLE
Make empty TimeSpanControl indicate usage of default value

### DIFF
--- a/src/ServiceBusExplorer/Controls/HandleNotificationHubControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleNotificationHubControl.cs
@@ -2060,14 +2060,17 @@ namespace ServiceBusExplorer.Controls
                                                                         mpnsCredentialCertificateKey);
                     }
 
-                    if (tsRegistrationTimeToLive.TimeSpanValue.HasValue)
+                    if (tsRegistrationTimeToLive.IsFilled)
                     {
-                        description.RegistrationTtl = tsRegistrationTimeToLive.TimeSpanValue.Value;
-                    }
-                    else
-                    {
-                        writeToLog(tsRegistrationTimeToLive.GetErrorMessage(RegistrationTimeToLive));
-                        return;
+                        if (tsRegistrationTimeToLive.TimeSpanValue.HasValue)
+                        {
+                            description.RegistrationTtl = tsRegistrationTimeToLive.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsRegistrationTimeToLive.GetErrorMessage(RegistrationTimeToLive));
+                            return;
+                        }
                     }
                     
                     var bindingList = authorizationRulesBindingSource.DataSource as BindingList<NotificationHubAuthorizationRuleWrapper>;
@@ -2162,14 +2165,17 @@ namespace ServiceBusExplorer.Controls
             {
                 try
                 {
-                    if (tsRegistrationTimeToLive.TimeSpanValue.HasValue)
+                    if (tsRegistrationTimeToLive.IsFilled)
                     {
-                        notificationHubDescription.RegistrationTtl = tsRegistrationTimeToLive.TimeSpanValue.Value;
-                    }
-                    else
-                    {
-                        writeToLog(tsRegistrationTimeToLive.GetErrorMessage(RegistrationTimeToLive));
-                        return;
+                        if (tsRegistrationTimeToLive.TimeSpanValue.HasValue)
+                        {
+                            notificationHubDescription.RegistrationTtl = tsRegistrationTimeToLive.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsRegistrationTimeToLive.GetErrorMessage(RegistrationTimeToLive));
+                            return;
+                        }
                     }
 
                     notificationHubDescription.WnsCredential = !string.IsNullOrWhiteSpace(txtPackageSid.Text) &&

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -2045,44 +2045,56 @@ namespace ServiceBusExplorer.Controls
                         }
                     }
 
-                    if (tsDefaultMessageTimeToLive.TimeSpanValue.HasValue)
+                    if (tsDefaultMessageTimeToLive.IsFilled)
                     {
-                        description.DefaultMessageTimeToLive = tsDefaultMessageTimeToLive.TimeSpanValue.Value;
-                    }
-                    else
-                    {
-                        writeToLog(tsDefaultMessageTimeToLive.GetErrorMessage(DefaultMessageTimeToLive));
-                        return;
-                    }
-
-                    if (tsDuplicateDetectionHistoryTimeWindow.TimeSpanValue.HasValue)
-                    {
-                        description.DuplicateDetectionHistoryTimeWindow = tsDuplicateDetectionHistoryTimeWindow.TimeSpanValue.Value;
-                    }
-                    else
-                    {
-                        writeToLog(tsDuplicateDetectionHistoryTimeWindow.GetErrorMessage(DuplicateDetectionHistoryTimeWindow));
-                        return;
+                        if (tsDefaultMessageTimeToLive.TimeSpanValue.HasValue)
+                        {
+                            description.DefaultMessageTimeToLive = tsDefaultMessageTimeToLive.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsDefaultMessageTimeToLive.GetErrorMessage(DefaultMessageTimeToLive));
+                            return;
+                        }
                     }
 
-                    if (tsAutoDeleteOnIdle.TimeSpanValue.HasValue)
+                    if (tsDuplicateDetectionHistoryTimeWindow.IsFilled)
                     {
-                        description.AutoDeleteOnIdle = tsAutoDeleteOnIdle.TimeSpanValue.Value;
-                    }
-                    else
-                    {
-                        writeToLog(tsAutoDeleteOnIdle.GetErrorMessage(AutoDeleteOnIdle));
-                        return;
+                        if (tsDuplicateDetectionHistoryTimeWindow.TimeSpanValue.HasValue)
+                        {
+                            description.DuplicateDetectionHistoryTimeWindow = tsDuplicateDetectionHistoryTimeWindow.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsDuplicateDetectionHistoryTimeWindow.GetErrorMessage(DuplicateDetectionHistoryTimeWindow));
+                            return;
+                        }
                     }
 
-                    if (tsLockDuration.TimeSpanValue.HasValue)
+                    if (tsAutoDeleteOnIdle.IsFilled)
                     {
-                        description.LockDuration = tsLockDuration.TimeSpanValue.Value;
+                        if (tsAutoDeleteOnIdle.TimeSpanValue.HasValue)
+                        {
+                            description.AutoDeleteOnIdle = tsAutoDeleteOnIdle.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsAutoDeleteOnIdle.GetErrorMessage(AutoDeleteOnIdle));
+                            return;
+                        }
                     }
-                    else
+
+                    if (tsLockDuration.IsFilled)
                     {
-                        writeToLog(tsLockDuration.GetErrorMessage(LockDuration));
-                        return;
+                        if (tsLockDuration.TimeSpanValue.HasValue)
+                        {
+                            description.LockDuration = tsLockDuration.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsLockDuration.GetErrorMessage(LockDuration));
+                            return;
+                        }
                     }
                     
                     description.EnableBatchedOperations = checkedListBox.GetItemChecked(EnableBatchedOperationsIndex);
@@ -2253,46 +2265,58 @@ namespace ServiceBusExplorer.Controls
                         }
                     }
 
-                    if (tsDefaultMessageTimeToLive.TimeSpanValue.HasValue)
+                    if (tsDefaultMessageTimeToLive.IsFilled)
                     {
-                        queueDescription.DefaultMessageTimeToLive = tsDefaultMessageTimeToLive.TimeSpanValue.Value;
-                    }
-                    else
-                    {
-                        writeToLog(tsDefaultMessageTimeToLive.GetErrorMessage(DefaultMessageTimeToLive));
-                        return;
-                    }
-
-                    if (tsDuplicateDetectionHistoryTimeWindow.TimeSpanValue.HasValue)
-                    {
-                        queueDescription.DuplicateDetectionHistoryTimeWindow = tsDuplicateDetectionHistoryTimeWindow.TimeSpanValue.Value;
-                    }
-                    else
-                    {
-                        writeToLog(tsDuplicateDetectionHistoryTimeWindow.GetErrorMessage(DuplicateDetectionHistoryTimeWindow));
-                        return;
+                        if (tsDefaultMessageTimeToLive.TimeSpanValue.HasValue)
+                        {
+                            queueDescription.DefaultMessageTimeToLive = tsDefaultMessageTimeToLive.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsDefaultMessageTimeToLive.GetErrorMessage(DefaultMessageTimeToLive));
+                            return;
+                        }
                     }
 
-                    if (tsAutoDeleteOnIdle.TimeSpanValue.HasValue)
+                    if (tsDuplicateDetectionHistoryTimeWindow.IsFilled)
                     {
-                        queueDescription.AutoDeleteOnIdle = tsAutoDeleteOnIdle.TimeSpanValue.Value;
-                    }
-                    else
-                    {
-                        writeToLog(tsAutoDeleteOnIdle.GetErrorMessage(AutoDeleteOnIdle));
-                        return;
-                    }
-
-                    if (tsLockDuration.TimeSpanValue.HasValue)
-                    {
-                        queueDescription.LockDuration = tsLockDuration.TimeSpanValue.Value;
-                    }
-                    else
-                    {
-                        writeToLog(tsLockDuration.GetErrorMessage(LockDuration));
-                        return;
+                        if (tsDuplicateDetectionHistoryTimeWindow.TimeSpanValue.HasValue)
+                        {
+                            queueDescription.DuplicateDetectionHistoryTimeWindow = tsDuplicateDetectionHistoryTimeWindow.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsDuplicateDetectionHistoryTimeWindow.GetErrorMessage(DuplicateDetectionHistoryTimeWindow));
+                            return;
+                        }
                     }
 
+                    if (tsAutoDeleteOnIdle.IsFilled)
+                    {
+                        if (tsAutoDeleteOnIdle.TimeSpanValue.HasValue)
+                        {
+                            queueDescription.AutoDeleteOnIdle = tsAutoDeleteOnIdle.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsAutoDeleteOnIdle.GetErrorMessage(AutoDeleteOnIdle));
+                            return;
+                        }
+                    }
+
+                    if (tsLockDuration.IsFilled)
+                    {
+                        if (tsLockDuration.TimeSpanValue.HasValue)
+                        {
+                            queueDescription.LockDuration = tsLockDuration.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsLockDuration.GetErrorMessage(LockDuration));
+                            return;
+                        }
+                    }
+                    
                     queueDescription.EnableBatchedOperations =
                         checkedListBox.GetItemChecked(EnableBatchedOperationsIndex);
                     queueDescription.EnableExpress = checkedListBox.GetItemChecked(EnableExpressIndex);

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -1366,34 +1366,43 @@ namespace ServiceBusExplorer.Controls
                         }
                     }
 
-                    if (tsDefaultMessageTimeToLive.TimeSpanValue.HasValue)
+                    if (tsDefaultMessageTimeToLive.IsFilled)
                     {
-                        subscriptionDescription.DefaultMessageTimeToLive = tsDefaultMessageTimeToLive.TimeSpanValue.Value;
-                    }
-                    else
-                    {
-                        writeToLog(tsDefaultMessageTimeToLive.GetErrorMessage(DefaultMessageTimeToLive));
-                        return;
-                    }
-
-                    if (tsLockDuration.TimeSpanValue.HasValue)
-                    {
-                        subscriptionDescription.LockDuration = tsLockDuration.TimeSpanValue.Value;
-                    }
-                    else
-                    {
-                        writeToLog(tsLockDuration.GetErrorMessage(LockDuration));
-                        return;
+                        if (tsDefaultMessageTimeToLive.TimeSpanValue.HasValue)
+                        {
+                            subscriptionDescription.DefaultMessageTimeToLive = tsDefaultMessageTimeToLive.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsDefaultMessageTimeToLive.GetErrorMessage(DefaultMessageTimeToLive));
+                            return;
+                        }
                     }
 
-                    if (tsAutoDeleteOnIdle.TimeSpanValue.HasValue)
+                    if (tsLockDuration.IsFilled)
                     {
-                        subscriptionDescription.AutoDeleteOnIdle = tsAutoDeleteOnIdle.TimeSpanValue.Value;
+                        if (tsLockDuration.TimeSpanValue.HasValue)
+                        {
+                            subscriptionDescription.LockDuration = tsLockDuration.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsLockDuration.GetErrorMessage(LockDuration));
+                            return;
+                        }
                     }
-                    else
+
+                    if (tsAutoDeleteOnIdle.IsFilled)
                     {
-                        writeToLog(tsAutoDeleteOnIdle.GetErrorMessage(AutoDeleteOnIdle));
-                        return;
+                        if (tsAutoDeleteOnIdle.TimeSpanValue.HasValue)
+                        {
+                            subscriptionDescription.AutoDeleteOnIdle = tsAutoDeleteOnIdle.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsAutoDeleteOnIdle.GetErrorMessage(AutoDeleteOnIdle));
+                            return;
+                        }
                     }
                     
                     subscriptionDescription.EnableBatchedOperations = checkedListBox.GetItemChecked(EnableBatchedOperationsIndex);
@@ -1485,34 +1494,43 @@ namespace ServiceBusExplorer.Controls
                         }
                     }
 
-                    if (tsDefaultMessageTimeToLive.TimeSpanValue.HasValue)
+                    if (tsDefaultMessageTimeToLive.IsFilled)
                     {
-                        subscriptionWrapper.SubscriptionDescription.DefaultMessageTimeToLive = tsDefaultMessageTimeToLive.TimeSpanValue.Value;
-                    }
-                    else
-                    {
-                        writeToLog(tsDefaultMessageTimeToLive.GetErrorMessage(DefaultMessageTimeToLive));
-                        return;
-                    }
-
-                    if (tsLockDuration.TimeSpanValue.HasValue)
-                    {
-                        subscriptionWrapper.SubscriptionDescription.LockDuration = tsLockDuration.TimeSpanValue.Value;
-                    }
-                    else
-                    {
-                        writeToLog(tsLockDuration.GetErrorMessage(LockDuration));
-                        return;
+                        if (tsDefaultMessageTimeToLive.TimeSpanValue.HasValue)
+                        {
+                            subscriptionWrapper.SubscriptionDescription.DefaultMessageTimeToLive = tsDefaultMessageTimeToLive.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsDefaultMessageTimeToLive.GetErrorMessage(DefaultMessageTimeToLive));
+                            return;
+                        }
                     }
 
-                    if (tsAutoDeleteOnIdle.TimeSpanValue.HasValue)
+                    if (tsLockDuration.IsFilled)
                     {
-                        subscriptionWrapper.SubscriptionDescription.AutoDeleteOnIdle = tsAutoDeleteOnIdle.TimeSpanValue.Value;
+                        if (tsLockDuration.TimeSpanValue.HasValue)
+                        {
+                            subscriptionWrapper.SubscriptionDescription.LockDuration = tsLockDuration.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsLockDuration.GetErrorMessage(LockDuration));
+                            return;
+                        }
                     }
-                    else
+
+                    if (tsAutoDeleteOnIdle.IsFilled)
                     {
-                        writeToLog(tsAutoDeleteOnIdle.GetErrorMessage(AutoDeleteOnIdle));
-                        return;
+                        if (tsAutoDeleteOnIdle.TimeSpanValue.HasValue)
+                        {
+                            subscriptionWrapper.SubscriptionDescription.AutoDeleteOnIdle = tsAutoDeleteOnIdle.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsAutoDeleteOnIdle.GetErrorMessage(AutoDeleteOnIdle));
+                            return;
+                        }
                     }
                     
                     subscriptionWrapper.SubscriptionDescription.EnableBatchedOperations = checkedListBox.GetItemChecked(EnableBatchedOperationsIndex);

--- a/src/ServiceBusExplorer/Controls/HandleTopicControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleTopicControl.cs
@@ -470,34 +470,43 @@ namespace ServiceBusExplorer.Controls
                             UserMetadata = txtUserMetadata.Text
                         };
 
-                    if (tsDefaultMessageTimeToLive.TimeSpanValue.HasValue)
+                    if (tsDefaultMessageTimeToLive.IsFilled)
                     {
-                        description.DefaultMessageTimeToLive = tsDefaultMessageTimeToLive.TimeSpanValue.Value;
-                    }
-                    else
-                    {
-                        writeToLog(tsDefaultMessageTimeToLive.GetErrorMessage(DefaultMessageTimeToLive));
-                        return;
-                    }
-
-                    if (tsDuplicateDetectionHistoryTimeWindow.TimeSpanValue.HasValue)
-                    {
-                        description.DuplicateDetectionHistoryTimeWindow = tsDuplicateDetectionHistoryTimeWindow.TimeSpanValue.Value;
-                    }
-                    else
-                    {
-                        writeToLog(tsDuplicateDetectionHistoryTimeWindow.GetErrorMessage(DuplicateDetectionHistoryTimeWindow));
-                        return;
+                        if (tsDefaultMessageTimeToLive.TimeSpanValue.HasValue)
+                        {
+                            description.DefaultMessageTimeToLive = tsDefaultMessageTimeToLive.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsDefaultMessageTimeToLive.GetErrorMessage(DefaultMessageTimeToLive));
+                            return;
+                        }
                     }
 
-                    if (tsAutoDeleteOnIdle.TimeSpanValue.HasValue)
+                    if (tsDuplicateDetectionHistoryTimeWindow.IsFilled)
                     {
-                        description.AutoDeleteOnIdle = tsAutoDeleteOnIdle.TimeSpanValue.Value;
+                        if (tsDuplicateDetectionHistoryTimeWindow.TimeSpanValue.HasValue)
+                        {
+                            description.DuplicateDetectionHistoryTimeWindow = tsDuplicateDetectionHistoryTimeWindow.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsDuplicateDetectionHistoryTimeWindow.GetErrorMessage(DuplicateDetectionHistoryTimeWindow));
+                            return;
+                        }
                     }
-                    else
+
+                    if (tsAutoDeleteOnIdle.IsFilled)
                     {
-                        writeToLog(tsAutoDeleteOnIdle.GetErrorMessage(AutoDeleteOnIdle));
-                        return;
+                        if (tsAutoDeleteOnIdle.TimeSpanValue.HasValue)
+                        {
+                            description.AutoDeleteOnIdle = tsAutoDeleteOnIdle.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsAutoDeleteOnIdle.GetErrorMessage(AutoDeleteOnIdle));
+                            return;
+                        }
                     }
                     
                     description.EnableBatchedOperations = checkedListBox.GetItemChecked(EnableBatchedOperationsIndex);
@@ -609,36 +618,45 @@ namespace ServiceBusExplorer.Controls
                 {
                     topicDescription.UserMetadata = txtUserMetadata.Text;
 
-                    if (tsDefaultMessageTimeToLive.TimeSpanValue.HasValue)
+                    if (tsDefaultMessageTimeToLive.IsFilled)
                     {
-                        topicDescription.DefaultMessageTimeToLive = tsDefaultMessageTimeToLive.TimeSpanValue.Value;
-                    }
-                    else
-                    {
-                        writeToLog(tsDefaultMessageTimeToLive.GetErrorMessage(DefaultMessageTimeToLive));
-                        return;
-                    }
-
-                    if (tsDuplicateDetectionHistoryTimeWindow.TimeSpanValue.HasValue)
-                    {
-                        topicDescription.DuplicateDetectionHistoryTimeWindow = tsDuplicateDetectionHistoryTimeWindow.TimeSpanValue.Value;
-                    }
-                    else
-                    {
-                        writeToLog(tsDuplicateDetectionHistoryTimeWindow.GetErrorMessage(DuplicateDetectionHistoryTimeWindow));
-                        return;
+                        if (tsDefaultMessageTimeToLive.TimeSpanValue.HasValue)
+                        {
+                            topicDescription.DefaultMessageTimeToLive = tsDefaultMessageTimeToLive.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsDefaultMessageTimeToLive.GetErrorMessage(DefaultMessageTimeToLive));
+                            return;
+                        }
                     }
 
-                    if (tsAutoDeleteOnIdle.TimeSpanValue.HasValue)
+                    if (tsDuplicateDetectionHistoryTimeWindow.IsFilled)
                     {
-                        topicDescription.AutoDeleteOnIdle = tsAutoDeleteOnIdle.TimeSpanValue.Value;
-                    }
-                    else
-                    {
-                        writeToLog(tsAutoDeleteOnIdle.GetErrorMessage(AutoDeleteOnIdle));
-                        return;
+                        if (tsDuplicateDetectionHistoryTimeWindow.TimeSpanValue.HasValue)
+                        {
+                            topicDescription.DuplicateDetectionHistoryTimeWindow = tsDuplicateDetectionHistoryTimeWindow.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsDuplicateDetectionHistoryTimeWindow.GetErrorMessage(DuplicateDetectionHistoryTimeWindow));
+                            return;
+                        }
                     }
 
+                    if (tsAutoDeleteOnIdle.IsFilled)
+                    {
+                        if (tsAutoDeleteOnIdle.TimeSpanValue.HasValue)
+                        {
+                            topicDescription.AutoDeleteOnIdle = tsAutoDeleteOnIdle.TimeSpanValue.Value;
+                        }
+                        else
+                        {
+                            writeToLog(tsAutoDeleteOnIdle.GetErrorMessage(AutoDeleteOnIdle));
+                            return;
+                        }
+                    }
+                    
                     topicDescription.EnableBatchedOperations = checkedListBox.GetItemChecked(EnableBatchedOperationsIndex);
                     topicDescription.EnableExpress = checkedListBox.GetItemChecked(EnableExpressIndex);
                     topicDescription.EnableFilteringMessagesBeforePublishing = checkedListBox.GetItemChecked(EnableFilteringMessagesBeforePublishingIndex);

--- a/src/ServiceBusExplorer/Controls/NumericTextBox.cs
+++ b/src/ServiceBusExplorer/Controls/NumericTextBox.cs
@@ -80,6 +80,8 @@ namespace ServiceBusExplorer.Controls
 
         #region Public Properties
 
+        public bool IsFilled => !string.IsNullOrWhiteSpace(Text);
+
         public bool IsValidIntegerValue => int.TryParse(Text, out _);
 
         public int IntegerValue => int.Parse(Text);

--- a/src/ServiceBusExplorer/Controls/TimeSpanControl.cs
+++ b/src/ServiceBusExplorer/Controls/TimeSpanControl.cs
@@ -20,6 +20,8 @@
             InitializeComponent();
         }
 
+        public bool IsFilled => txtDays.IsFilled || txtHours.IsFilled || txtMinutes.IsFilled || txtSeconds.IsFilled || txtMilliseconds.IsFilled;
+
         public bool IsValidValue => txtDays.IsValidIntegerValue && txtHours.IsValidIntegerValue && txtMinutes.IsValidIntegerValue && txtSeconds.IsValidIntegerValue && txtMilliseconds.IsValidIntegerValue;
 
         public string GetErrorMessage(string fieldName)
@@ -58,7 +60,7 @@
         {
             get
             {
-                if (!IsValidValue)
+                if (!IsFilled || !IsValidValue)
                 {
                     return null;
                 }


### PR DESCRIPTION
Following #493 , I introduced a regression pointed in #501 as users were forced to enter values in the `TimeSpanControl`.

This PR reintroduces the previous behavior which is to ensure that if all fields are empty or whitespace, then the default value for the property is to be used.

Sorry for this regression!