### PR TITLE
Correctly reflect queue maximum size based on namespace SKU

### DIFF
--- a/src/ServiceBus/Helpers/ServiceBusHelper2.cs
+++ b/src/ServiceBus/Helpers/ServiceBusHelper2.cs
@@ -19,16 +19,14 @@
 //=======================================================================================
 #endregion
 
+using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
 
 // ReSharper disable CheckNamespace
 namespace ServiceBusExplorer.ServiceBus.Helpers
 // ReSharper restore CheckNamespace
 {
-    using System.Threading.Tasks;
-    using Azure;
-    using Azure.Messaging.ServiceBus.Administration;
-
     public class ServiceBusHelper2
     {
         public string ConnectionString { get; set; }

--- a/src/ServiceBus/Helpers/ServiceBusHelper2.cs
+++ b/src/ServiceBus/Helpers/ServiceBusHelper2.cs
@@ -19,17 +19,27 @@
 //=======================================================================================
 #endregion
 
-#region Using Directives
 using Azure.Messaging.ServiceBus;
-#endregion
 
 // ReSharper disable CheckNamespace
 namespace ServiceBusExplorer.ServiceBus.Helpers
 // ReSharper restore CheckNamespace
 {
+    using System.Threading.Tasks;
+    using Azure;
+    using Azure.Messaging.ServiceBus.Administration;
+
     public class ServiceBusHelper2
     {
         public string ConnectionString { get; set; }
         public ServiceBusTransportType TransportType { get; set; }
+
+        public async Task<bool> IsPremiumNamespace()
+        {
+            var administrationClient = new ServiceBusAdministrationClient(ConnectionString);
+            NamespaceProperties namespaceProperties = await administrationClient.GetNamespacePropertiesAsync().ConfigureAwait(false);
+
+            return namespaceProperties.MessagingSku == MessagingSku.Premium;
+        }
     }
 }

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -234,6 +234,7 @@ namespace ServiceBusExplorer.Controls
 
         private QueueDescription queueDescription = default!;
         private readonly ServiceBusHelper serviceBusHelper = default!;
+        private readonly ServiceBusHelper2 serviceBusHelper2 = default!;
         private readonly WriteToLogDelegate writeToLog = default!;
         private readonly string path = default!;
         private readonly List<TabPage> hiddenPages = new List<TabPage>();
@@ -280,6 +281,7 @@ namespace ServiceBusExplorer.Controls
         {
             this.writeToLog = writeToLog;
             this.serviceBusHelper = serviceBusHelper;
+            this.serviceBusHelper2 = serviceBusHelper.GetServiceBusHelper2();
             this.path = path;
             this.queueDescription = queueDescription;
 
@@ -525,7 +527,9 @@ namespace ServiceBusExplorer.Controls
 
         private void InitializeControls()
         {
-            trackBarMaxQueueSize.Maximum = serviceBusHelper.IsCloudNamespace ? 5 : 11;
+            var maxSize = serviceBusHelper.IsCloudNamespace ? 5 : 11;
+            maxSize = serviceBusHelper2.IsPremiumNamespace().GetAwaiter().GetResult() ? 80 : maxSize;
+            trackBarMaxQueueSize.Maximum = maxSize;
 
             // Splitter controls
             messagesSplitContainer.SplitterWidth = 16;

--- a/src/ServiceBusExplorer/Controls/HandleTopicControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleTopicControl.cs
@@ -27,9 +27,8 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Globalization;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Threading;
 using System.Windows.Forms;
+using ServiceBusExplorer.ServiceBus.Helpers;
 using ServiceBusExplorer.Forms;
 using ServiceBusExplorer.Helpers;
 using ServiceBusExplorer.UIHelpers;
@@ -40,8 +39,6 @@ using Microsoft.ServiceBus.Messaging;
 
 namespace ServiceBusExplorer.Controls
 {
-    using ServiceBus.Helpers;
-
     public partial class HandleTopicControl : UserControl
     {
         #region Private Constants

--- a/src/ServiceBusExplorer/Controls/HandleTopicControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleTopicControl.cs
@@ -40,6 +40,8 @@ using Microsoft.ServiceBus.Messaging;
 
 namespace ServiceBusExplorer.Controls
 {
+    using ServiceBus.Helpers;
+
     public partial class HandleTopicControl : UserControl
     {
         #region Private Constants
@@ -126,6 +128,7 @@ namespace ServiceBusExplorer.Controls
         private readonly List<TabPage> hiddenPages = new List<TabPage>();
         private TopicDescription topicDescription;
         private readonly ServiceBusHelper serviceBusHelper;
+        private readonly ServiceBusHelper2 serviceBusHelper2 = default!;
         private readonly WriteToLogDelegate writeToLog;
         private readonly string path;
         #endregion
@@ -141,6 +144,7 @@ namespace ServiceBusExplorer.Controls
         {
             this.writeToLog = writeToLog;
             this.serviceBusHelper = serviceBusHelper;
+            this.serviceBusHelper2 = serviceBusHelper.GetServiceBusHelper2();
             this.topicDescription = topicDescription;
             this.path = path;
 
@@ -173,7 +177,9 @@ namespace ServiceBusExplorer.Controls
         #region Private Methods
         private void InitializeControls()
         {
-            trackBarMaxTopicSize.Maximum = serviceBusHelper.IsCloudNamespace ? 5 : 11;
+            var maxSize = serviceBusHelper.IsCloudNamespace ? 5 : 11;
+            maxSize = serviceBusHelper2.IsPremiumNamespace().GetAwaiter().GetResult() ? 80 : maxSize;
+            trackBarMaxTopicSize.Maximum = maxSize;
 
             // IsAnonymousAccessible
             if (serviceBusHelper.IsCloudNamespace)


### PR DESCRIPTION
Fixes #499 

The maximum queue length controller (slider) to reflect the maximum queue size available for the used namespace SKU.

![image](https://user-images.githubusercontent.com/1309622/103858494-a8e66800-5075-11eb-845c-4088d6acd424.png)
