### PR TITLE
fix alt-ctrl-del interpreted as delete

### DIFF
--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -1904,6 +1904,11 @@ namespace ServiceBusExplorer.Forms
 
         private void serviceBusTreeView_KeyDown(object sender, KeyEventArgs keyEventArgs)
         {
+            if (keyEventArgs.Modifiers == (Keys.Alt | Keys.Control) && keyEventArgs.KeyCode == Keys.Delete) // ignore three-finger salute
+            {
+                return;
+            }
+
             switch (keyEventArgs.KeyCode)
             {
                 case Keys.Delete: // purge entity


### PR DESCRIPTION
I have accidentally deleted queues and topics by locking computers / bringing up the task manager with the application open.
(alt-ctrl-del and then enter)

This change will save my job. :)

I know you can use ctrl-l to lock a windows machine but - "old dogs can't learn new tricks" and this habit is hard for me to break.