### PR TITLE
Update TimeSpanControl so that if any field is filled, others are defaulted to zero

### DIFF
--- a/src/ServiceBusExplorer/Controls/NumericTextBox.cs
+++ b/src/ServiceBusExplorer/Controls/NumericTextBox.cs
@@ -82,19 +82,47 @@ namespace ServiceBusExplorer.Controls
 
         public bool IsFilled => !string.IsNullOrWhiteSpace(Text);
 
-        public bool IsValidIntegerValue => int.TryParse(Text, out _);
+        public bool IsValidIntegerValue => TryParseInt(out _);
 
-        public int IntegerValue => int.Parse(Text);
+        public int IntegerValue => TryParseInt(out var value) ? value : throw new FormatException($"Unable to parse value {Text} to integer value");
 
-        public bool IsValidDecimalValue => decimal.TryParse(Text, out _);
+        public bool IsValidDecimalValue => TryParseDecimal(out _);
 
-        public decimal DecimalValue => decimal.Parse(Text);
+        public decimal DecimalValue => TryParseDecimal(out var value) ? value : throw new FormatException($"Unable to parse value {Text} to decimal value");
 
         public bool AllowSpace { set; get; }
 
         public bool AllowDecimal { set; get; }
 
         public bool AllowNegative { set; get; }
+
+        public bool IsZeroWhenEmpty { get; set; }
+
+        #endregion
+
+        #region Private methods
+
+        private bool TryParseInt(out int value)
+        {
+            if (!IsFilled && IsZeroWhenEmpty)
+            {
+                value = 0;
+                return true;
+            }
+
+            return int.TryParse(Text, out value);
+        }
+
+        private bool TryParseDecimal(out decimal value)
+        {
+            if (!IsFilled && IsZeroWhenEmpty)
+            {
+                value = 0;
+                return true;
+            }
+
+            return decimal.TryParse(Text, out value);
+        }
 
         #endregion
     }

--- a/src/ServiceBusExplorer/Controls/TimeSpanControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/TimeSpanControl.Designer.cs
@@ -97,6 +97,7 @@ namespace ServiceBusExplorer.Controls
             this.txtMilliseconds.AllowNegative = false;
             this.txtMilliseconds.AllowSpace = false;
             this.txtMilliseconds.BackColor = System.Drawing.SystemColors.Window;
+            this.txtMilliseconds.IsZeroWhenEmpty = true;
             this.txtMilliseconds.Location = new System.Drawing.Point(223, 19);
             this.txtMilliseconds.Name = "txtMilliseconds";
             this.txtMilliseconds.Size = new System.Drawing.Size(40, 20);
@@ -108,6 +109,7 @@ namespace ServiceBusExplorer.Controls
             this.txtSeconds.AllowNegative = false;
             this.txtSeconds.AllowSpace = false;
             this.txtSeconds.BackColor = System.Drawing.SystemColors.Window;
+            this.txtSeconds.IsZeroWhenEmpty = true;
             this.txtSeconds.Location = new System.Drawing.Point(168, 19);
             this.txtSeconds.Name = "txtSeconds";
             this.txtSeconds.Size = new System.Drawing.Size(40, 20);
@@ -119,6 +121,7 @@ namespace ServiceBusExplorer.Controls
             this.txtMinutes.AllowNegative = false;
             this.txtMinutes.AllowSpace = false;
             this.txtMinutes.BackColor = System.Drawing.SystemColors.Window;
+            this.txtMinutes.IsZeroWhenEmpty = true;
             this.txtMinutes.Location = new System.Drawing.Point(113, 19);
             this.txtMinutes.Name = "txtMinutes";
             this.txtMinutes.Size = new System.Drawing.Size(40, 20);
@@ -130,6 +133,7 @@ namespace ServiceBusExplorer.Controls
             this.txtHours.AllowNegative = false;
             this.txtHours.AllowSpace = false;
             this.txtHours.BackColor = System.Drawing.SystemColors.Window;
+            this.txtHours.IsZeroWhenEmpty = true;
             this.txtHours.Location = new System.Drawing.Point(58, 19);
             this.txtHours.Name = "txtHours";
             this.txtHours.Size = new System.Drawing.Size(40, 20);
@@ -141,6 +145,7 @@ namespace ServiceBusExplorer.Controls
             this.txtDays.AllowNegative = false;
             this.txtDays.AllowSpace = false;
             this.txtDays.BackColor = System.Drawing.SystemColors.Window;
+            this.txtDays.IsZeroWhenEmpty = true;
             this.txtDays.Location = new System.Drawing.Point(3, 19);
             this.txtDays.Name = "txtDays";
             this.txtDays.Size = new System.Drawing.Size(40, 20);


### PR DESCRIPTION
This fixes #548, and should resume same behavior as in 4.1.112:
* not entering any value in any field will lead to a null value being returned by the control, and the default value for the entity will be used
* entering a value in any field will default the unfilled ones to 0