### PR TITLE
Allow empty and null messages 

### DIFF
--- a/src/Common/Helpers/BrokeredMessageExtensions.cs
+++ b/src/Common/Helpers/BrokeredMessageExtensions.cs
@@ -53,20 +53,20 @@ namespace ServiceBusExplorer.Helpers
 
         public static BrokeredMessage Clone(this BrokeredMessage message, Stream stream, bool omitAllProperties)
         {
-            if (stream == null)
-            {
-                return null;
-            }
-            if (stream.CanSeek)
+            if (stream != null && stream.CanSeek)
             {
                 stream.Seek(0, SeekOrigin.Begin);
             }
+
             var clone = message.Clone();
+
             if (omitAllProperties)
             {
                 clone.Properties.Clear();
             }
+
             BodyStreamPropertyInfo.SetValue(clone, stream);
+
             return clone;
         }
 

--- a/src/ServiceBusExplorer/Controls/TestQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/TestQueueControl.cs
@@ -437,11 +437,6 @@ namespace ServiceBusExplorer.Controls
         {
             try
             {
-                if (messageTabControl.SelectedIndex == MessageTabPage && string.IsNullOrWhiteSpace(txtMessageText.Text))
-                {
-                    writeToLog(MessageCannotBeNull);
-                    return false;
-                }
                 if (string.IsNullOrWhiteSpace(txtReceiveTimeout.Text) ||
                     !int.TryParse(txtReceiveTimeout.Text, out var temp) ||
                     temp < 0)

--- a/src/ServiceBusExplorer/Controls/TestQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/TestQueueControl.cs
@@ -77,7 +77,6 @@ namespace ServiceBusExplorer.Controls
         //***************************
         // Messages
         //***************************
-        private const string MessageCannotBeNull = "The Message field cannot be null.";
         private const string ReceiveTimeoutCannotBeNull = "The receive timeout field cannot be null and must be a non negative integer number.";
         private const string SessionTimeoutCannotBeNull = "The session timeout field cannot be null and must be a non negative integer number.";
         private const string PrefetchCountCannotBeNull = "The prefetch count field cannot be null and must be an integer number.";

--- a/src/ServiceBusExplorer/Controls/TestTopicControl.cs
+++ b/src/ServiceBusExplorer/Controls/TestTopicControl.cs
@@ -76,7 +76,6 @@ namespace ServiceBusExplorer.Controls
         //***************************
         // Messages
         //***************************
-        private const string MessageCannotBeNull = "The Message field cannot be null.";
         private const string ReceiveTimeoutCannotBeNull = "The receive timeout field cannot be null and must a non negative integer number.";
         private const string SessionTimeoutCannotBeNull = "The session timeout field cannot be null and must be a non negative integer number.";
         private const string PrefetchCountCannotBeNull = "The prefetch count field cannot be null and must be an integer number.";
@@ -440,11 +439,6 @@ namespace ServiceBusExplorer.Controls
         {
             try
             {
-                if (messageTabControl.SelectedIndex == MessageTabPage && string.IsNullOrWhiteSpace(txtMessageText.Text))
-                {
-                    writeToLog(MessageCannotBeNull);
-                    return false;
-                }
                 if (string.IsNullOrWhiteSpace(txtReceiveTimeout.Text) ||
                     !int.TryParse(txtReceiveTimeout.Text, out var temp) ||
                     temp < 0)


### PR DESCRIPTION
This will allow sending messages with empty bodies to queues and topics. It also allows resubmitting messages with bodies == null to queues and topics. 

Fixes #547 

