### PR TITLE
DictionaryPropertyDescriptor bug (issue #581)

### DIFF
--- a/src/ServiceBusExplorer/UIHelpers/DictionaryPropertyDescriptor.cs
+++ b/src/ServiceBusExplorer/UIHelpers/DictionaryPropertyDescriptor.cs
@@ -19,7 +19,7 @@ namespace ServiceBusExplorer.UIHelpers
             IsReadOnly = isReadOnly;
         }
 
-        public override Type PropertyType => _dictionary[_key].GetType();
+        public override Type PropertyType => _dictionary[_key]?.GetType();
 
         public override void SetValue(object component, object value)
         {


### PR DESCRIPTION
Fixes #581 

When the dictionary behind a ´DictionaryPropertyDescriptor´  contains a key for which the value is "null", the PropertyType property fails with a ´NullReferenException´.  By changing ´_dictionary[_key].GetType()´ to ´_dictionary[_key]?.GetType()´ (notice the question mark) we bypass this problem.  The ´PropertyGrid´ is capable of dealing with a null type (the row gets disabled).  This allows us to view messages which otherwise remained hidden.