### PR TITLE
Exported JSON cannot be imported

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ assembly_info:
 environment:
   choco_token:
     secure: 68Fr+kbT0ilhb84AyU/kKVWJw74urnreRDCpZ2L89v0cJeuEGcOchKGIFsy4Hp+V
+  IGNORE_NORMALISATION_GIT_HEAD_MOVE: 1 # GitVersion issue workaround
 
 
 #---------------------------------#

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -87,7 +87,7 @@ artifacts:
 notifications:
   - provider: GitHubPullRequest
     auth_token:
-      secure: SDw1gs4noXA0eUpBoBcbT2XNYwf0Bg7gHR/TpP2Y/gQS/QYST7toE0oRzoKV/2U6 # encrypted token from GitHub
+      secure: a/WGT6eXKEH9TdksK6aUV+XCQeoRGYxlVvzuVPjOWy1zgza8eCqaeh+Sirc06C2h # encrypted token from GitHub
     template: "{{#passed}}:white_check_mark:{{/passed}}{{#failed}}:x:{{/failed}} [Build {{&projectName}} {{buildVersion}} {{status}}]({{buildUrl}}) (commit {{commitUrl}} by @{{&commitAuthorUsername}})"
 
 #---------------------------------#
@@ -97,7 +97,7 @@ notifications:
 deploy:
   - provider: GitHub
     auth_token:
-      secure: SDw1gs4noXA0eUpBoBcbT2XNYwf0Bg7gHR/TpP2Y/gQS/QYST7toE0oRzoKV/2U6 # encrypted token from GitHub
+      secure: a/WGT6eXKEH9TdksK6aUV+XCQeoRGYxlVvzuVPjOWy1zgza8eCqaeh+Sirc06C2h # encrypted token from GitHub
     artifact: /.*\.*/           # upload all NuGet packages to release assets
     description: ServiceBus Explorer build %APPVEYOR_BUILD_VERSION%.
     draft: false

--- a/src/Common/Helpers/BrokeredMessageTemplate.cs
+++ b/src/Common/Helpers/BrokeredMessageTemplate.cs
@@ -139,7 +139,7 @@ namespace ServiceBusExplorer.Helpers
         /// Gets or sets the message of the BrokeredMessage object.
         /// </summary>
         [XmlIgnore]
-        [JsonProperty(PropertyName = "message", Order = 13)]
+        [JsonProperty(PropertyName = "body", Order = 13)]
         public string Message 
         {
             get
@@ -155,7 +155,7 @@ namespace ServiceBusExplorer.Helpers
         /// <summary>
         /// Gets or sets the message of the BrokeredMessage object.
         /// </summary>
-        [XmlElement(ElementName = "message", Type = typeof(XmlCDataSection), Namespace = "http://schemas.microsoft.com/servicebusexplorer")]
+        [XmlElement(ElementName = "body", Type = typeof(XmlCDataSection), Namespace = "http://schemas.microsoft.com/servicebusexplorer")]
         public XmlCDataSection CData 
         {
             get

--- a/src/Common/Helpers/MessagePropertyInfo.cs
+++ b/src/Common/Helpers/MessagePropertyInfo.cs
@@ -76,7 +76,7 @@ namespace ServiceBusExplorer.Helpers
 
         // TODO: figure out what to do with the Type property
         [XmlElement(ElementName = "type", Namespace = "http://schemas.microsoft.com/servicebusexplorer")]
-        [JsonProperty(PropertyName = "type", Order = 2, Required = /*Required.Always*/ Required.Default)]
+        [JsonProperty(PropertyName = "type", Order = 2, Required = Required.Default)]
         public string Type { get; set; }
 
         [XmlIgnore]

--- a/src/Common/Helpers/MessagePropertyInfo.cs
+++ b/src/Common/Helpers/MessagePropertyInfo.cs
@@ -74,8 +74,9 @@ namespace ServiceBusExplorer.Helpers
         [JsonProperty(PropertyName = "key", Order = 1, Required = Required.Always)]
         public string Key { get; set; }
 
+        // TODO: figure out what to do with the Type property
         [XmlElement(ElementName = "type", Namespace = "http://schemas.microsoft.com/servicebusexplorer")]
-        [JsonProperty(PropertyName = "type", Order = 2, Required = Required.Always)]
+        [JsonProperty(PropertyName = "type", Order = 2, Required = /*Required.Always*/ Required.Default)]
         public string Type { get; set; }
 
         [XmlIgnore]

--- a/src/Common/Helpers/MessageSerializationHelper.cs
+++ b/src/Common/Helpers/MessageSerializationHelper.cs
@@ -93,7 +93,17 @@ namespace ServiceBusExplorer.Helpers
                     try
                     {
                         var value = keyValuePair.Value.GetValue(entityEnumerable[i], null);
-                        entityDictionary[camelCase] = value;
+
+                        if (camelCase == "properties")
+                        {
+                            // TODO: do not hard-code everything to strings, discover the type and use it
+                            entityDictionary[camelCase] = ((Dictionary<string, object>)value)
+                                .Select(x => new MessagePropertyInfo(x.Key, "String", x.Value)).ToArray();
+                        }
+                        else
+                        {
+                            entityDictionary[camelCase] = value;
+                        }
                     }
                     // ReSharper disable once EmptyGeneralCatchClause
                     catch (Exception)

--- a/src/Common/Helpers/MessageSerializationHelper.cs
+++ b/src/Common/Helpers/MessageSerializationHelper.cs
@@ -150,7 +150,17 @@ namespace ServiceBusExplorer.Helpers
                 try
                 {
                     var value = keyValuePair.Value.GetValue(entity, null);
-                    entityDictionary[camelCase] = value;
+
+                    if (camelCase == "properties")
+                    {
+                        // TODO: do not hard-code everything to strings, discover the type and use it
+                        entityDictionary[camelCase] = ((Dictionary<string, object>)value)
+                            .Select(x => new MessagePropertyInfo(x.Key, "String", x.Value)).ToArray();
+                    }
+                    else
+                    {
+                        entityDictionary[camelCase] = value;
+                    }
                 }
                     // ReSharper disable once EmptyGeneralCatchClause
                 catch (Exception)

--- a/src/Common/Helpers/MessageSerializationHelper.cs
+++ b/src/Common/Helpers/MessageSerializationHelper.cs
@@ -127,7 +127,13 @@ namespace ServiceBusExplorer.Helpers
                     {
                         // TODO: do not hard-code everything to strings, discover the type and use it
                         entityDictionary[camelCase] = ((Dictionary<string, object>)value)
-                            .Select(x => new MessagePropertyInfo(x.Key, "String", x.Value)).ToArray();
+                            .Select(x =>
+                            {
+                                var typeName = x.Value.GetType().ToString().Replace("System.", "");
+
+                                return new MessagePropertyInfo(x.Key, typeName, x.Value);
+                            })
+                            .ToArray();
                     }
                     else
                     {

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -4003,7 +4003,7 @@ namespace ServiceBusExplorer.Controls
                 {
                     var bodies = brokeredMessages.Select(bm => serviceBusHelper.GetMessageText(bm,
                          MainForm.SingletonMainForm.UseAscii, out _));
-                    writer.Write(MessageSerializationHelper.Serialize(brokeredMessages, bodies));
+                    writer.Write(MessageSerializationHelper.Serialize(brokeredMessages, bodies, doNotSerializeBody: true));
                 }
             }
             catch (Exception ex)

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -2773,7 +2773,7 @@ namespace ServiceBusExplorer.Controls
                 }
                 using (var writer = new StreamWriter(saveFileDialog.FileName))
                 {
-                    writer.Write(MessageSerializationHelper.Serialize(bindingList[currentMessageRowIndex], txtMessageText.Text));
+                    writer.Write(MessageSerializationHelper.Serialize(bindingList[currentMessageRowIndex], txtMessageText.Text, doNotSerializeBody: true));
                 }
             }
             catch (Exception ex)

--- a/src/ServiceBusExplorer/Controls/TestQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/TestQueueControl.cs
@@ -833,13 +833,31 @@ namespace ServiceBusExplorer.Controls
                                                                                                           bindingSource.Cast<MessagePropertyInfo>());
                                                 messageTextList.Add(text);
                                             }
-                                            else if (radioButtonJsonTemplate.Checked)
+                                            else if (radioButtonJsonTemplate.Checked) // JSON
                                             {
                                                 try
                                                 {
-                                                    var brokeredMessageTemplate = JsonSerializerHelper.Deserialize<BrokeredMessageTemplate>(text);
-                                                    template = serviceBusHelper.CreateBrokeredMessageTemplate(brokeredMessageTemplate);
-                                                    messageTextList.Add(brokeredMessageTemplate.Message);
+                                                    // Multiple messages
+                                                    if (text.StartsWith("[", StringComparison.OrdinalIgnoreCase))
+                                                    {
+                                                        var brokeredMessageTemplates = JsonSerializerHelper.Deserialize<List<BrokeredMessageTemplate>>(text);
+                                                        foreach (var item in brokeredMessageTemplates)
+                                                        {
+                                                            template = serviceBusHelper.CreateBrokeredMessageTemplate(item);
+                                                            messageTemplateList.Add(template);
+                                                            messageTextList.Add(item.Message);
+                                                        }
+
+                                                        messageCount = messageTemplateList.Count; // change the default of 1 message
+
+                                                        template = null; // clear template to avoid adding it again at the end of the method
+                                                    }
+                                                    else // single message
+                                                    {
+                                                        var brokeredMessageTemplate = JsonSerializerHelper.Deserialize<BrokeredMessageTemplate>(text);
+                                                        template = serviceBusHelper.CreateBrokeredMessageTemplate(brokeredMessageTemplate);
+                                                        messageTextList.Add(brokeredMessageTemplate.Message);
+                                                    }
                                                 }
                                                 catch (Exception)
                                                 {

--- a/src/ServiceBusExplorer/Forms/MessageForm.cs
+++ b/src/ServiceBusExplorer/Forms/MessageForm.cs
@@ -656,7 +656,7 @@ namespace ServiceBusExplorer.Forms
             }
             using (var writer = new StreamWriter(saveFileDialog.FileName))
             {
-                writer.Write(MessageSerializationHelper.Serialize(brokeredMessage, txtMessageText.Text));
+                writer.Write(MessageSerializationHelper.Serialize(brokeredMessage, txtMessageText.Text, doNotSerializeBody: true));
             }
         }
 

--- a/src/ServiceBusExplorer/ServiceBusExplorer.csproj
+++ b/src/ServiceBusExplorer/ServiceBusExplorer.csproj
@@ -545,7 +545,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="GitVersion.CommandLine" Version="5.6.1" />
+    <PackageReference Include="GitVersion.CommandLine" Version="5.9.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="GitVersionTask" Version="5.5.1" />
     <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="1.0.9" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />


### PR DESCRIPTION
Fixes #586

**Replaces #617, #623** (~~GitVersion issued due to the branch name~~, source of the branch?)

This PR is an **attempt** to fix the export/import of JSON messages.

There's a whole slew of broken things with the current code base 😞

- Serialization
  - ❌ Incorrectly stored body - the body is stored as an object rather than raw JSON. To work properly, the body has to be saved as an escaped JSON string.
  - ❌ Incorrectly stored properties/headers - headers are stored as an object where it should be an array of key/value objects
- Deserialization
  - ❌ Incorrectly deserialized body - deserialized property is called `content` rather than `body`
  - ✖️ Incorrect merging of deserialized properties/headers and custom provide via app properties/headers - properties provided via app are lost. Don't think it matters since a restored message can be tweaked via modifying the serialized text.

To make it worse, there are multiple paths of invocation and reuse for XML & JSON.
Frankly, I don't know if it's worth spending time fixing it; fixing one thing will break something else.

I'm going to **attempt** fix JSON as this is the most common message serialization type used. No guarantees it won't break XML or other formats the application claims to support.

- [x] Fix body serialization
- [x] Fix body deserialization
- [x] Fix property serialization 
- [x] Works with a single exported message (queue)
- [x] Works with multiple exported messages (queue)
- [x] Works with DLQ-ed single message (queue)
- [x] Works with DLQ-ed multiple messages (queue)
- [x] Works with a single exported message (topic/subscription)
- [x] Works with multiple exported messages (topic/subscription)
- [x] Works with DLQ-ed single message (topic/subscription)
- [x] Works with DLQ-ed multiple messages (topic/subscription)
- [x] Investigate what "Template" stands for - _no longer relevant_
- Serialization/deserializaton from to/files other than JSON is not working --> Raised as https://github.com/paolosalvatori/ServiceBusExplorer/issues/619
- [x] Save application properties types and do not hardcode to `String`

## Changes in action

### Preserving types

https://user-images.githubusercontent.com/1309622/158310081-586550e7-970b-4b13-b172-a92f02f5ff6e.mp4

### Single message export/import

https://user-images.githubusercontent.com/1309622/158314129-82c0d2b7-4bc3-471a-8455-5f094b4f48e3.mp4

### Multiple messages export/import

https://user-images.githubusercontent.com/1309622/158316558-23f6f0e7-d186-4a21-8918-2a4558563eed.mp4
