### PR TITLE
Fix null ref creating new subscription

### DIFF
--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -435,7 +435,7 @@ namespace ServiceBusExplorer.Controls
             }
             else
             {
-                ConfigureReadUserInterface();
+                ConfigureCreateUserInterface();
             }
         }
 


### PR DESCRIPTION
Fixes null reference exception when creating a new subscription, introduced by commit 09aa1eb5d1b1606935a08dc03f0f071e5508018c .