### PR TITLE
Fix build

### DIFF
--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -435,7 +435,7 @@ namespace ServiceBusExplorer.Controls
             }
             else
             {
-                ConfigureCreatedUserInterface();
+                ConfigureCreateUserInterface();
             }
         }
 

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -435,7 +435,7 @@ namespace ServiceBusExplorer.Controls
             }
             else
             {
-                ConfigureReadUserInterface();
+                ConfigureCreatedUserInterface();
             }
         }
 

--- a/src/ServiceBusExplorer/ServiceBusExplorer.csproj
+++ b/src/ServiceBusExplorer/ServiceBusExplorer.csproj
@@ -30,6 +30,8 @@
     <Description>The Service Bus Explorer allows users to connect to a Service Bus namespace and administer messaging entities in an easy manner. The tool provides advanced features like import/export functionality or the ability to test topic, queues, subscriptions, relay services, notification hubs and events hubs.</Description>
     <Copyright>Copyright 2017 Paolo Salvatori</Copyright>
     <OutputPath>bin\$(Configuration)\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <Authors>Paolo Salvatori</Authors>
     <PackageIconUrl></PackageIconUrl>
     <PackageId>servicebusexplorer</PackageId>
@@ -525,7 +527,7 @@
       <PackagePath></PackagePath>
     </None>
     <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
+      <Generator>PublicSettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
     <Compile Update="Properties\Resources.Designer.cs">


### PR DESCRIPTION
Removes the folder with the NET Framework version that was added when the C# project was switched to SDK style.
Fixes #629 

Also adds the line that was added in #628 but got merged to the wrong branch.