### PR TITLE
Support inconsistent schemes that have no impacts on actual behavior

### DIFF
--- a/src/Common/Helpers/ServiceBusHelper.cs
+++ b/src/Common/Helpers/ServiceBusHelper.cs
@@ -5324,7 +5324,11 @@ namespace ServiceBusExplorer
         {
             if (Uri.IsWellFormedUriString(address, UriKind.Absolute))
             {
-                var uri = new Uri(address, UriKind.Absolute);
+                var uri = new UriBuilder(new Uri(address, UriKind.Absolute))
+                {
+                    Scheme = NamespaceUri.Scheme,
+                    Port = NamespaceUri.Port
+                }.Uri;
                 if (NamespaceUri.IsBaseOf(uri))
                 {
                     var uriRelativeToNamespace = NamespaceUri.MakeRelativeUri(uri);

--- a/src/ServiceBusExplorer.Tests/Helpers/ServiceBusHelperTest.cs
+++ b/src/ServiceBusExplorer.Tests/Helpers/ServiceBusHelperTest.cs
@@ -30,6 +30,35 @@ namespace ServiceBusExplorer.Tests.Helpers
         }
 
         [Test]
+        public void GetAddressRelativeToNamespace_AbsoluteUriUnderNamespace_Different_Scheme_ReturnsRelativePath()
+        {
+            var helper = new ServiceBusHelper((m, a) => { });
+            helper.NamespaceUri = new Uri("sb://aaa.test.com/");
+
+            Assert.That(helper.GetAddressRelativeToNamespace("http://aaa.test.com/some/path/segments/name"), Is.EqualTo("some/path/segments/name"));
+        }
+
+        [Test]
+        public void GetAddressRelativeToNamespace_AbsoluteUriUnderNamespace_Different_Scheme_Port_Specified_ReturnsRelativePath()
+        {
+            var helper = new ServiceBusHelper((m, a) => { });
+            helper.NamespaceUri = new Uri("sb://aaa.test.com:80/");
+
+            Assert.That(helper.GetAddressRelativeToNamespace("http://aaa.test.com:80/some/path/segments/name"), Is.EqualTo("some/path/segments/name"));
+        }
+
+        [TestCase(":80", ":81")]
+        [TestCase(":80", "")]
+        [TestCase("", ":80")]
+        public void GetAddressRelativeToNamespace_AbsoluteUriUnderNamespace_Different_Scheme_Different_Port_ReturnsLastSegment(string namespacePort, string port)
+        {
+            var helper = new ServiceBusHelper((m, a) => { });
+            helper.NamespaceUri = new Uri($"sb://aaa.test.com{namespacePort}/");
+
+            Assert.That(helper.GetAddressRelativeToNamespace($"http://aaa.test.com{port}/some/path/segments/name"), Is.EqualTo("some/path/segments/name"));
+        }
+
+        [Test]
         public void GetAddressRelativeToNamespace_AbsoluteUriNotUnderNamespace_ReturnsLastSegment()
         {
             var helper = new ServiceBusHelper((m, a) => { });


### PR DESCRIPTION
Currently, relative urls for subscriptions forwards for example, are checked by ensuring the uri of the namespace is a base of the subscription url, before getting the relative path.
When the url is not absolute, or the condition above is false, the code fallbacks to a simple and imperfect string parsing code.

Recently, it has been put to my knowledge that some tooling where using different schemes for the urls (in this case, MassTransit uses `http://` rather than `sb://`).
This has no impact on the actual behavior of the service bus.

As such, I propose this PR to ensure the scheme is ignored when doing this matching, by copying the scheme of the namespace to the compared uri.
For technical purposes, I had to copy the port from the namespace also to prevent a default port to be added the the built url when there was none.