### PR TITLE
Feature/fix export import json

### DIFF
--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -4191,7 +4191,7 @@ namespace ServiceBusExplorer.Controls
                 {
                     var bodies = brokeredMessages.Select(bm => serviceBusHelper.GetMessageText(bm,
                          MainForm.SingletonMainForm.UseAscii, out _));
-                    writer.Write(MessageSerializationHelper.Serialize(brokeredMessages, bodies));
+                    writer.Write(MessageSerializationHelper.Serialize(brokeredMessages, bodies, doNotSerializeBody: true));
                 }
             }
             catch (Exception ex)
@@ -4379,7 +4379,7 @@ namespace ServiceBusExplorer.Controls
                 {
                     var bodies = brokeredMessages.Select(bm => serviceBusHelper.GetMessageText(bm,
                          MainForm.SingletonMainForm.UseAscii, out _));
-                    writer.Write(MessageSerializationHelper.Serialize(brokeredMessages, bodies));
+                    writer.Write(MessageSerializationHelper.Serialize(brokeredMessages, bodies, doNotSerializeBody: true));
                 }
             }
             catch (Exception ex)

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -2813,7 +2813,7 @@ namespace ServiceBusExplorer.Controls
                 {
                     var bodies = brokeredMessages.Select(bm => serviceBusHelper.GetMessageText(bm,
                          MainForm.SingletonMainForm.UseAscii, out _));
-                    writer.Write(MessageSerializationHelper.Serialize(brokeredMessages, bodies));
+                    writer.Write(MessageSerializationHelper.Serialize(brokeredMessages, bodies, doNotSerializeBody: true));
                 }
             }
             catch (Exception ex)
@@ -2894,7 +2894,7 @@ namespace ServiceBusExplorer.Controls
                 {
                     var bodies = brokeredMessages.Select(bm => serviceBusHelper.GetMessageText(bm,
                          MainForm.SingletonMainForm.UseAscii, out _));
-                    writer.Write(MessageSerializationHelper.Serialize(brokeredMessages, bodies));
+                    writer.Write(MessageSerializationHelper.Serialize(brokeredMessages, bodies, doNotSerializeBody: true));
                 }
             }
             catch (Exception ex)

--- a/src/ServiceBusExplorer/Controls/TestTopicControl.cs
+++ b/src/ServiceBusExplorer/Controls/TestTopicControl.cs
@@ -820,9 +820,27 @@ namespace ServiceBusExplorer.Controls
                                         {
                                             try
                                             {
-                                                var brokeredMessageTemplate = JsonSerializerHelper.Deserialize<BrokeredMessageTemplate>(text);
-                                                template = serviceBusHelper.CreateBrokeredMessageTemplate(brokeredMessageTemplate);
-                                                messageTextList.Add(brokeredMessageTemplate.Message);
+                                                // Multiple messages
+                                                if (text.StartsWith("[", StringComparison.OrdinalIgnoreCase))
+                                                {
+                                                    var brokeredMessageTemplates = JsonSerializerHelper.Deserialize<List<BrokeredMessageTemplate>>(text);
+                                                    foreach (var item in brokeredMessageTemplates)
+                                                    {
+                                                        template = serviceBusHelper.CreateBrokeredMessageTemplate(item);
+                                                        messageTemplateList.Add(template);
+                                                        messageTextList.Add(item.Message);
+                                                    }
+
+                                                    messageCount = messageTemplateList.Count; // change the default of 1 message
+
+                                                    template = null; // clear template to avoid adding it again at the end of the method
+                                                }
+                                                else // single message
+                                                {
+                                                    var brokeredMessageTemplate = JsonSerializerHelper.Deserialize<BrokeredMessageTemplate>(text);
+                                                    template = serviceBusHelper.CreateBrokeredMessageTemplate(brokeredMessageTemplate);
+                                                    messageTextList.Add(brokeredMessageTemplate.Message);
+                                                }
                                             }
                                             catch (Exception)
                                             {


### PR DESCRIPTION
Add doNotSerializeBody on saveMessages in deadletter and transfer messages queue options like in save messages queue. This will prevent error on export message body as json;
 
Applied the same behavior on export messages from topics;

Added import multiple messages from json template file on topic control.