### PR TITLE
Message filter - simple string contains

### DIFF
--- a/src/Common/Helpers/CustomMessageSessionAsyncHandler.cs
+++ b/src/Common/Helpers/CustomMessageSessionAsyncHandler.cs
@@ -88,6 +88,10 @@ namespace ServiceBusExplorer.Helpers
                 if (configuration.MessageInspector != null)
                 {
                     message = configuration.MessageInspector.AfterReceiveMessage(message);
+                    if (message == null)
+                    {
+                        return;
+                    }
                 }
                 if (configuration.Logging)
                 {

--- a/src/Common/Helpers/FilteredBrokeredMessageInspector.cs
+++ b/src/Common/Helpers/FilteredBrokeredMessageInspector.cs
@@ -1,0 +1,49 @@
+﻿
+#region Using Directives
+using Microsoft.ServiceBus.Messaging;
+using ServiceBusExplorer.Helpers;
+#endregion
+
+namespace ServiceBusExplorer.Common.Helpers
+{
+    public class FilteredBrokeredMessageInspector : IBrokeredMessageInspector
+    {
+        #region Private instance fields
+        private readonly string _filter;
+        private IBrokeredMessageInspector _messageInspector;
+        #endregion
+
+        public FilteredBrokeredMessageInspector(string filter, IBrokeredMessageInspector messageInspector)
+        {
+            _filter = filter;
+            _messageInspector = messageInspector;
+        }
+
+        public BrokeredMessage BeforeSendMessage(BrokeredMessage message)
+        {
+            return _messageInspector == null ? message : _messageInspector.BeforeSendMessage(message);
+        }
+
+        public BrokeredMessage AfterReceiveMessage(BrokeredMessage message)
+        {
+            // TODO: Should we be before/after the other message inspector?
+            _messageInspector?.AfterReceiveMessage(message);
+
+            return Filter(message);
+        }
+
+        private BrokeredMessage Filter(BrokeredMessage message)
+        {
+            var contents = message.GetMessageText();
+
+            if (contents == null || contents == BrokeredMessageExtensions.UnableToReadMessageBody)
+            {
+                // Fail the filter if we can't read
+                return null;
+            }
+
+            // Better filter mechanism e.g. regex etc - switch?
+            return contents.Contains(_filter) ? message : null;
+        }
+    }
+}

--- a/src/Common/Helpers/ServiceBusHelper.cs
+++ b/src/Common/Helpers/ServiceBusHelper.cs
@@ -4239,7 +4239,7 @@ namespace ServiceBusExplorer
                             messageList = messageEnumerable as IList<BrokeredMessage> ?? messageEnumerable.ToList();
                             if (messageInspector != null)
                             {
-                                messageList = messageList.Select(b => messageInspector.AfterReceiveMessage(b)).ToList();
+                                messageList = messageList.Select(messageInspector.AfterReceiveMessage).Where(x => x != null).ToList();
                             }
                             isCompleted = messageEnumerable == null || !messageList.Any();
                             if (isCompleted)

--- a/src/ServiceBusExplorer.sln.DotSettings
+++ b/src/ServiceBusExplorer.sln.DotSettings
@@ -589,6 +589,7 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=NAMESPACE_005FALIAS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EdotCover_002EIde_002ECore_002EFilterManagement_002EModel_002ESolutionFilterSettingsManagerMigrateSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>

--- a/src/ServiceBusExplorer/Controls/ListenerControl.cs
+++ b/src/ServiceBusExplorer/Controls/ListenerControl.cs
@@ -1182,6 +1182,10 @@ namespace ServiceBusExplorer.Controls
                 if (receiverBrokeredMessageInspector != null)
                 {
                     message = receiverBrokeredMessageInspector.AfterReceiveMessage(message);
+                    if (message == null)
+                    {
+                        return;
+                    }
                 }
                 if (logging)
                 {

--- a/src/ServiceBusExplorer/FormExtensions.cs
+++ b/src/ServiceBusExplorer/FormExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+using ServiceBusExplorer.Common.Helpers;
+using ServiceBusExplorer.Forms;
+using ServiceBusExplorer.Helpers;
+
+namespace ServiceBusExplorer
+{
+    internal static class FormExtensions
+    {
+        public static IBrokeredMessageInspector ToBrokeredMessageInspector(this ReceiveModeForm receiveModeForm, ServiceBusHelper serviceBusHelper)
+        {
+
+            var messageInspector = !string.IsNullOrEmpty(receiveModeForm.Inspector) &&
+                                   serviceBusHelper.BrokeredMessageInspectors.ContainsKey(
+                                       receiveModeForm.Inspector)
+                ? Activator.CreateInstance(serviceBusHelper.BrokeredMessageInspectors[receiveModeForm.Inspector])
+                    as IBrokeredMessageInspector
+                : null;
+
+            if (!string.IsNullOrEmpty(receiveModeForm.Filter))
+            {
+                // Wrap the current inspector in a filter
+                messageInspector = new FilteredBrokeredMessageInspector(receiveModeForm.Filter, messageInspector);
+            }
+
+            return messageInspector;
+        }
+    }
+}

--- a/src/ServiceBusExplorer/Forms/ReceiveModeForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/ReceiveModeForm.Designer.cs
@@ -70,12 +70,15 @@ namespace ServiceBusExplorer.Forms
             this.grouperReadMode = new ServiceBusExplorer.Controls.Grouper();
             this.btnReceive = new System.Windows.Forms.RadioButton();
             this.btnPeek = new System.Windows.Forms.RadioButton();
+            this.grouperFilter = new ServiceBusExplorer.Controls.Grouper();
+            this.txtFilter = new System.Windows.Forms.TextBox();
             this.mainPanel.SuspendLayout();
             this.grouperSession.SuspendLayout();
             this.grouperFrom.SuspendLayout();
             this.grouperInspector.SuspendLayout();
             this.grouperMessages.SuspendLayout();
             this.grouperReadMode.SuspendLayout();
+            this.grouperFilter.SuspendLayout();
             this.SuspendLayout();
             // 
             // btnOk
@@ -86,7 +89,7 @@ namespace ServiceBusExplorer.Forms
             this.btnOk.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnOk.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnOk.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnOk.Location = new System.Drawing.Point(522, 169);
+            this.btnOk.Location = new System.Drawing.Point(524, 240);
             this.btnOk.Name = "btnOk";
             this.btnOk.Size = new System.Drawing.Size(72, 24);
             this.btnOk.TabIndex = 1;
@@ -104,7 +107,7 @@ namespace ServiceBusExplorer.Forms
             this.btnCancel.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCancel.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnCancel.Location = new System.Drawing.Point(602, 169);
+            this.btnCancel.Location = new System.Drawing.Point(602, 240);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(72, 24);
             this.btnCancel.TabIndex = 2;
@@ -119,6 +122,7 @@ namespace ServiceBusExplorer.Forms
             this.mainPanel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.mainPanel.BackColor = System.Drawing.SystemColors.Window;
+            this.mainPanel.Controls.Add(this.grouperFilter);
             this.mainPanel.Controls.Add(this.grouperSession);
             this.mainPanel.Controls.Add(this.grouperFrom);
             this.mainPanel.Controls.Add(this.grouperInspector);
@@ -126,7 +130,7 @@ namespace ServiceBusExplorer.Forms
             this.mainPanel.Controls.Add(this.grouperReadMode);
             this.mainPanel.Location = new System.Drawing.Point(0, 0);
             this.mainPanel.Name = "mainPanel";
-            this.mainPanel.Size = new System.Drawing.Size(690, 155);
+            this.mainPanel.Size = new System.Drawing.Size(690, 228);
             this.mainPanel.TabIndex = 0;
             this.mainPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.mainPanel_Paint);
             // 
@@ -143,7 +147,7 @@ namespace ServiceBusExplorer.Forms
             this.grouperSession.ForeColor = System.Drawing.Color.White;
             this.grouperSession.GroupImage = null;
             this.grouperSession.GroupTitle = "From Session";
-            this.grouperSession.Location = new System.Drawing.Point(465, 80);
+            this.grouperSession.Location = new System.Drawing.Point(465, 148);
             this.grouperSession.Name = "grouperSession";
             this.grouperSession.Padding = new System.Windows.Forms.Padding(20);
             this.grouperSession.PaintGroupBox = true;
@@ -189,8 +193,12 @@ namespace ServiceBusExplorer.Forms
             // 
             // txtFromSequenceNumber
             // 
+            this.txtFromSequenceNumber.AllowDecimal = false;
+            this.txtFromSequenceNumber.AllowNegative = false;
+            this.txtFromSequenceNumber.AllowSpace = false;
             this.txtFromSequenceNumber.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtFromSequenceNumber.IsZeroWhenEmpty = false;
             this.txtFromSequenceNumber.Location = new System.Drawing.Point(15, 32);
             this.txtFromSequenceNumber.Name = "txtFromSequenceNumber";
             this.txtFromSequenceNumber.Size = new System.Drawing.Size(177, 20);
@@ -210,7 +218,7 @@ namespace ServiceBusExplorer.Forms
             this.grouperInspector.ForeColor = System.Drawing.Color.White;
             this.grouperInspector.GroupImage = null;
             this.grouperInspector.GroupTitle = "Message Inspector";
-            this.grouperInspector.Location = new System.Drawing.Point(16, 80);
+            this.grouperInspector.Location = new System.Drawing.Point(16, 148);
             this.grouperInspector.Name = "grouperInspector";
             this.grouperInspector.Padding = new System.Windows.Forms.Padding(20);
             this.grouperInspector.PaintGroupBox = true;
@@ -260,8 +268,12 @@ namespace ServiceBusExplorer.Forms
             // 
             // txtMessageCount
             // 
+            this.txtMessageCount.AllowDecimal = false;
+            this.txtMessageCount.AllowNegative = false;
+            this.txtMessageCount.AllowSpace = false;
             this.txtMessageCount.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtMessageCount.IsZeroWhenEmpty = false;
             this.txtMessageCount.Location = new System.Drawing.Point(112, 32);
             this.txtMessageCount.Name = "txtMessageCount";
             this.txtMessageCount.Size = new System.Drawing.Size(80, 20);
@@ -344,12 +356,45 @@ namespace ServiceBusExplorer.Forms
             this.btnPeek.UseVisualStyleBackColor = true;
             this.btnPeek.CheckedChanged += new System.EventHandler(this.receiveMode_CheckedChanged);
             // 
+            // grouperFilter
+            // 
+            this.grouperFilter.BackgroundColor = System.Drawing.Color.White;
+            this.grouperFilter.BackgroundGradientColor = System.Drawing.Color.White;
+            this.grouperFilter.BackgroundGradientMode = ServiceBusExplorer.Controls.Grouper.GroupBoxGradientMode.None;
+            this.grouperFilter.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.grouperFilter.BorderThickness = 1F;
+            this.grouperFilter.Controls.Add(this.txtFilter);
+            this.grouperFilter.CustomGroupBoxColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.grouperFilter.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F);
+            this.grouperFilter.ForeColor = System.Drawing.Color.White;
+            this.grouperFilter.GroupImage = null;
+            this.grouperFilter.GroupTitle = "Message Filter";
+            this.grouperFilter.Location = new System.Drawing.Point(16, 78);
+            this.grouperFilter.Name = "grouperFilter";
+            this.grouperFilter.Padding = new System.Windows.Forms.Padding(20);
+            this.grouperFilter.PaintGroupBox = true;
+            this.grouperFilter.RoundCorners = 4;
+            this.grouperFilter.ShadowColor = System.Drawing.Color.DarkGray;
+            this.grouperFilter.ShadowControl = false;
+            this.grouperFilter.ShadowThickness = 1;
+            this.grouperFilter.Size = new System.Drawing.Size(432, 64);
+            this.grouperFilter.TabIndex = 45;
+            // 
+            // txtFilter
+            // 
+            this.txtFilter.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtFilter.Location = new System.Drawing.Point(15, 32);
+            this.txtFilter.Name = "txtFilter";
+            this.txtFilter.Size = new System.Drawing.Size(401, 20);
+            this.txtFilter.TabIndex = 42;
+            // 
             // ReceiveModeForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
-            this.ClientSize = new System.Drawing.Size(690, 205);
+            this.ClientSize = new System.Drawing.Size(690, 276);
             this.Controls.Add(this.mainPanel);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnOk);
@@ -372,6 +417,8 @@ namespace ServiceBusExplorer.Forms
             this.grouperMessages.PerformLayout();
             this.grouperReadMode.ResumeLayout(false);
             this.grouperReadMode.PerformLayout();
+            this.grouperFilter.ResumeLayout(false);
+            this.grouperFilter.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -394,5 +441,7 @@ namespace ServiceBusExplorer.Forms
         private ServiceBusExplorer.Controls.NumericTextBox txtFromSequenceNumber;
         private Grouper grouperSession;
         private System.Windows.Forms.TextBox txtFromSession;
+        private Grouper grouperFilter;
+        private System.Windows.Forms.TextBox txtFilter;
     }
 }

--- a/src/ServiceBusExplorer/Forms/ReceiveModeForm.cs
+++ b/src/ServiceBusExplorer/Forms/ReceiveModeForm.cs
@@ -77,6 +77,7 @@ namespace ServiceBusExplorer.Forms
         public string? Inspector { get; private set; }
         public long? FromSequenceNumber { get; private set; }
         public string? FromSession { get; private set; }
+        public string? Filter { get; private set; }
         #endregion
 
         #region Event Handlers
@@ -100,6 +101,11 @@ namespace ServiceBusExplorer.Forms
                 {
                     FromSequenceNumber = fromSequenceNumber;
                 }
+            }
+
+            if (!string.IsNullOrEmpty(txtFilter.Text))
+            {
+                Filter = txtFilter.Text;
             }
 
             if (!string.IsNullOrEmpty(txtFromSession.Text))


### PR DESCRIPTION
Not ready to be merged yet, but gives you an idea of approach...

1. Works on Queues/DLQ
1. Simple string.Contains on message content
    1. Option for regex?
    1. Should we apply before/after specified IBrokeredMessageInspector, option?
    1. Want to know how many accepted/rejected 
1. Refactored LogBrokeredMessageInspector to extract common code
1. Refactored IBrokerMessageInspector into a factory extension method to extract common code
1. Also apply to delete or presume we are already filtered?