### PR TITLE
Adding installation of vs-project extension to solve NUnit issue

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,8 +24,10 @@ jobs:
     env:
       NUnitVersion: '3.15.2'
     steps:        
-    - name: Install NUnit Console Runner 
-      run: Install-Package NUnit.ConsoleRunner -Force -RequiredVersion $env:NUnitVersion
+    - name: Install NUnit Console Runner and VS project extension
+      run: | 
+        Install-Package NUnit.ConsoleRunner -Force -RequiredVersion $env:NUnitVersion
+        Install-Package NUnit.Extension.VSProjectLoader -Force -RequiredVersion '3.9.0'
 
     - name: Git configuration
       run: git config --global core.autocrlf false


### PR DESCRIPTION
The NuGet package NUnit.ConsoleRunner does not contain the extensions that are included in the MSI package NUnit.Console. There is a great comment about this at https://github.com/nunit/docs/issues/311#issuecomment-494573236. 

One of the solutions for this is to install the NuGet package NUnit.Extension.VSProjectLoader. It is not a .NET tool package though so I am sticking with Install-Package.