### PR TITLE
Keep more issues from getting closed

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,13 @@ daysUntilClose: 7
 exemptLabels:
   - pinned
   - security
+  - bug
+  - Feature
+  - Discussion
+  - enhancement
+  - question
+  - blocked
+  - suggestion
 # Label to use when marking an issue as stale
 staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Currently an issue is closed after 60 days by the bot. We want to keep issues that have been labeled as bug, feature and some other labels to be permanent.