### PR TITLE
Set file version to 0.0.0.0 in the .NET Framework projects.

### DIFF
--- a/src/Common/Properties/AssemblyInfo.cs
+++ b/src/Common/Properties/AssemblyInfo.cs
@@ -30,4 +30,4 @@ using System.Runtime.InteropServices;
 //      Revision
 //
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]

--- a/src/NotificationHubs/Properties/AssemblyInfo.cs
+++ b/src/NotificationHubs/Properties/AssemblyInfo.cs
@@ -30,4 +30,4 @@ using System.Runtime.InteropServices;
 //      Revision
 //
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]

--- a/src/ServiceBusExplorer.Tests/Properties/AssemblyInfo.cs
+++ b/src/ServiceBusExplorer.Tests/Properties/AssemblyInfo.cs
@@ -29,4 +29,4 @@ using System.Runtime.InteropServices;
 //      Revision
 //
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]


### PR DESCRIPTION
Set file version to 0.0.0.0 in the .NET Framework projects to make it clear that it is not used.