### PR TITLE
If the message file does not exist, make the messageText an empty string (instead of null)

### DIFF
--- a/src/Common/Helpers/MessageAndPropertiesHelper.cs
+++ b/src/Common/Helpers/MessageAndPropertiesHelper.cs
@@ -254,7 +254,7 @@ namespace ServiceBusExplorer.Helpers
             {
                 if (!File.Exists(messageFilePath))
                 {
-                    return null;
+                    return string.Empty;
                 }
 
                 using (var reader = new StreamReader(messageFilePath))
@@ -272,7 +272,7 @@ namespace ServiceBusExplorer.Helpers
             catch (Exception)
             {
             }
-            return null;
+            return string.Empty;
         }
 
         private static void WriteFile(string path, string content)


### PR DESCRIPTION
Currently the settings cannot be saved on a fresh install of 5.0.10 because of the NullReferenceException thrown on line 670 of `OptionForm` for `ConfigurationParameters.MessageParameter`.
```System.NullReferenceException
  HResult=0x80004003
  Message=Object reference not set to an instance of an object.
  Source=ServiceBusExplorer
  StackTrace:
   at ServiceBusExplorer.Forms.OptionForm.SaveSetting[T](TwoFilesConfiguration configuration, MainSettings savedSettings, String setting, T runningValue) in C:\Users\AWITKOWS\source\repos\ServiceBusExplorer\src\ServiceBusExplorer\Forms\OptionForm.cs:line 670
   at ServiceBusExplorer.Forms.OptionForm.SaveSettings(ConfigFileUse configFileUse) in C:\Users\AWITKOWS\source\repos\ServiceBusExplorer\src\ServiceBusExplorer\Forms\OptionForm.cs:line 622
   at ServiceBusExplorer.Forms.OptionForm.btnSave_Click(Object sender, EventArgs e) in C:\Users\AWITKOWS\source\repos\ServiceBusExplorer\src\ServiceBusExplorer\Forms\OptionForm.cs:line 176
   at System.Windows.Forms.Control.OnClick(EventArgs e)
   at System.Windows.Forms.Button.OnClick(EventArgs e)
   at System.Windows.Forms.Button.OnMouseUp(MouseEventArgs mevent)
   at System.Windows.Forms.Control.WmMouseUp(Message& m, MouseButtons button, Int32 clicks)
   at System.Windows.Forms.Control.WndProc(Message& m)
   at System.Windows.Forms.ButtonBase.WndProc(Message& m)
   at System.Windows.Forms.Button.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)
```

`savedSettings.GetValue("message")` returns null because `MainSettings.MessageText` is null.