### PR TITLE
Fix the ability to connect using an EntityPath connection string

### DIFF
--- a/src/Common/Helpers/ServiceBusHelper.cs
+++ b/src/Common/Helpers/ServiceBusHelper.cs
@@ -422,6 +422,19 @@ namespace ServiceBusExplorer
             }
         }
 
+        public string ConnectionStringWithoutEntityPath
+        {
+            get
+            { 
+                var builder = new ServiceBusConnectionStringBuilder(connectionString)
+                {
+                    EntityPath = string.Empty
+                };
+
+                return builder.ToString();
+            }
+        }
+
         /// <summary>
         /// Gets or sets the connection string.
         /// </summary>
@@ -677,7 +690,7 @@ namespace ServiceBusExplorer
             MessagingFactory factory;
             if (!string.IsNullOrEmpty(ConnectionString))
             {
-                factory = MessagingFactory.CreateFromConnectionString(ConnectionString);
+                factory = MessagingFactory.CreateFromConnectionString(ConnectionStringWithoutEntityPath);
             }
             else
             {
@@ -732,18 +745,7 @@ namespace ServiceBusExplorer
                 // such as queues, topics, subscriptions, and rules, in your service namespace. 
                 // You must provide service namespace address and access credentials in order 
                 // to manage your service namespace.
-                if (serviceBusNamespace.EntityPath != string.Empty)
-                {
-                    var csBuilder = new ServiceBusConnectionStringBuilder(connectionString)
-                    {
-                        EntityPath = string.Empty
-                    };
-                    namespaceManager = Microsoft.ServiceBus.NamespaceManager.CreateFromConnectionString(connectionString = csBuilder.ToString());
-                }
-                else
-                {
-                    namespaceManager = Microsoft.ServiceBus.NamespaceManager.CreateFromConnectionString(connectionString);
-                }
+                namespaceManager = Microsoft.ServiceBus.NamespaceManager.CreateFromConnectionString(ConnectionStringWithoutEntityPath);
 
                 // Set retry count
                 if (namespaceManager.Settings.RetryPolicy is Microsoft.ServiceBus.RetryExponential defaultServiceBusRetryExponential)
@@ -779,7 +781,7 @@ namespace ServiceBusExplorer
 
                 // As the name suggests, the MessagingFactory class is a Factory class that allows to create
                 // instances of the QueueClient, TopicClient and SubscriptionClient classes.
-                MessagingFactory = MessagingFactory.CreateFromConnectionString(connectionString);
+                MessagingFactory = MessagingFactory.CreateFromConnectionString(ConnectionStringWithoutEntityPath);
                 WriteToLogIf(traceEnabled, MessageFactorySuccessfullyCreated);
                 return true;
             });
@@ -5306,18 +5308,6 @@ namespace ServiceBusExplorer
                 receiverList.Add(messageReceiver);
                 ReceiveNextMessage(messageCount, 0, messageReceiver, encoder, complete, receiveTimeout);
             }
-        }
-
-        public string GetHostWithoutNamespace()
-        {
-            if (namespaceUri == null ||
-                string.IsNullOrWhiteSpace(namespaceUri.Host))
-            {
-                return null;
-            }
-            var host = namespaceUri.Host;
-            var index = host.IndexOf('.');
-            return host.Substring(index);
         }
 
         public string GetAddressRelativeToNamespace(string address)

--- a/src/EventHubs/EventHubs.csproj
+++ b/src/EventHubs/EventHubs.csproj
@@ -10,7 +10,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.7.0" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.7.3" />
   </ItemGroup>
 
 

--- a/src/ServiceBus/Helpers/ServiceBusHelper2.cs
+++ b/src/ServiceBus/Helpers/ServiceBusHelper2.cs
@@ -32,6 +32,18 @@ namespace ServiceBusExplorer.ServiceBus.Helpers
         public string ConnectionString { get; set; }
         public ServiceBusTransportType TransportType { get; set; }
 
+        public bool ConnectionStringContainsEntityPath()
+        {
+            var connectionStringProperties = ServiceBusConnectionStringProperties.Parse(ConnectionString);
+            
+            if (connectionStringProperties?.EntityPath != null)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         public async Task<bool> IsPremiumNamespace()
         {
             var administrationClient = new ServiceBusAdministrationClient(ConnectionString);

--- a/src/ServiceBus/ServiceBus.csproj
+++ b/src/ServiceBus/ServiceBus.csproj
@@ -8,7 +8,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.8.1" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
   </ItemGroup>
 
 

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -299,7 +299,12 @@ namespace ServiceBusExplorer.Controls
             this.serviceBusHelper2 = serviceBusHelper.GetServiceBusHelper2();
             this.path = path;
             this.queueDescription = queueDescription;
+
+            if (!serviceBusHelper2.ConnectionStringContainsEntityPath())
+            {
             this.premiumNamespace = serviceBusHelper2.IsPremiumNamespace().GetAwaiter().GetResult();
+            }
+
             this.duplicateQueue = duplicateQueue;
 
             InitializeComponent();

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -302,7 +302,7 @@ namespace ServiceBusExplorer.Controls
 
             if (!serviceBusHelper2.ConnectionStringContainsEntityPath())
             {
-            this.premiumNamespace = serviceBusHelper2.IsPremiumNamespace().GetAwaiter().GetResult();
+                this.premiumNamespace = serviceBusHelper2.IsPremiumNamespace().GetAwaiter().GetResult();
             }
 
             this.duplicateQueue = duplicateQueue;

--- a/src/ServiceBusExplorer/Controls/HandleTopicControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleTopicControl.cs
@@ -154,7 +154,12 @@ namespace ServiceBusExplorer.Controls
             this.writeToLog = writeToLog;
             this.serviceBusHelper = serviceBusHelper;
             this.serviceBusHelper2 = serviceBusHelper.GetServiceBusHelper2();
+            
+            if (!serviceBusHelper2.ConnectionStringContainsEntityPath())
+            {
             this.premiumNamespace = serviceBusHelper2.IsPremiumNamespace().GetAwaiter().GetResult();
+            }
+            
             this.topicDescription = topicDescription;
             this.path = path;
 

--- a/src/ServiceBusExplorer/Controls/HandleTopicControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleTopicControl.cs
@@ -157,7 +157,7 @@ namespace ServiceBusExplorer.Controls
             
             if (!serviceBusHelper2.ConnectionStringContainsEntityPath())
             {
-            this.premiumNamespace = serviceBusHelper2.IsPremiumNamespace().GetAwaiter().GetResult();
+                this.premiumNamespace = serviceBusHelper2.IsPremiumNamespace().GetAwaiter().GetResult();
             }
             
             this.topicDescription = topicDescription;


### PR DESCRIPTION
Fixes #611

The EntityPath was previously removed from the connection string, since the Track 0 SDK cannot handle it. However, Track 2 SDK requires it. This PR preserves the original string.

The ConnectionStringContainsEntityPath method could have been put inside the IsPremiumNamespace method but having it outside makes it clearer that this is sort of a hack. To get a good solution I'd prefer to have an enum for the SKU, where one of the enum members should be "unknown" since it looks like we won't be able to get the SKU when using a connection string containing an EntityPath. In that case some parts of the GUI should be hidden.

But let's start with this and make sure it works.

