### PR TITLE
Support preview releases

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,21 +46,37 @@ jobs:
     - name: Show version
       run: echo "Building version ${{ inputs.release-version }}"
 
+    - name: Get digital version
+      id: get-digital-version
+      env:
+        ReleaseVersion: ${{ inputs.release-version }}
+      run: |
+        $numberVersion = .\GetNumberVersion -Version ${{env.ReleaseVersion}}
+        echo "Setting numberVersion to $numberVersion"
+        echo "NUMBER_VERSION=$numberVersion" >> $env:GITHUB_ENV
+
     - name: Set fileversion on all .NET Framework assemblies and assembly version on the exe
       env:
-        Version: ${{ inputs.release-version }}
+        ReleaseVersion: ${{ inputs.release-version }}
       run: |
         $sbeFileName = "$env:GITHUB_WORKSPACE\src\ServiceBusExplorer\Properties\AssemblyInfo.cs"
-        .\SetVersion -FileName $sbeFileName -PropertyName 'AssemblyVersion' -Version ${{env.Version}}
-        .\SetVersion -FileName $sbeFileName -PropertyName 'AssemblyFileVersion' -Version ${{env.Version}}      
-        .\SetVersion -FileName "$env:GITHUB_WORKSPACE\src\Common\Properties\AssemblyInfo.cs" -PropertyName 'AssemblyFileVersion' -Version ${{env.Version}}
-        .\SetVersion -FileName "$env:GITHUB_WORKSPACE\src\NotificationHubs\Properties\AssemblyInfo.cs" -PropertyName 'AssemblyFileVersion' -Version ${{env.Version}}      
+        .\SetVersion -FileName $sbeFileName -PropertyName 'AssemblyVersion' -Version ${{env.NUMBER_VERSION}}
+        .\SetVersion -FileName $sbeFileName -PropertyName 'AssemblyFileVersion' -Version ${{env.NUMBER_VERSION}}   
+        .\SetVersion -FileName $sbeFileName -PropertyName 'AssemblyInformationalVersion' -Version ${{env.ReleaseVersion}}   
+
+        $commonInfoFile = "$env:GITHUB_WORKSPACE\src\Common\Properties\AssemblyInfo.cs"
+        .\SetVersion -FileName $commonInfoFile -PropertyName 'AssemblyFileVersion' -Version ${{env.NUMBER_VERSION}}
+        .\SetVersion -FileName $commonInfoFile -PropertyName 'AssemblyInformationalVersion' -Version ${{env.ReleaseVersion}}   
+
+        $notificationHubsInfoFile = "$env:GITHUB_WORKSPACE\src\NotificationHubs\Properties\AssemblyInfo.cs"
+        .\SetVersion -FileName $notificationHubsInfoFile -PropertyName 'AssemblyFileVersion' -Version ${{env.NUMBER_VERSION}}      
+        .\SetVersion -FileName $notificationHubsInfoFile -PropertyName 'AssemblyInformationalVersion' -Version ${{env.ReleaseVersion}}   
 
     - name: Build
-      env:
-        Version: ${{ inputs.release-version }}
+      # env:
+      #   Version: ${{ inputs.release-version }}
       run: |
-        msbuild /m /property:Configuration=${{env.BUILD_CONFIGURATION}},FileVersion=${{env.Version}} ${{env.SOLUTION_FILE_PATH}}
+        msbuild /m /property:Configuration=${{env.BUILD_CONFIGURATION}},FileVersion=${{env.NUMBER_VERSION}} ${{env.SOLUTION_FILE_PATH}}
 
     - name: Run tests
       run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -86,7 +86,7 @@ jobs:
         if ($process.ExitCode -ne 0) {throw "Unit tests failed (exit code = $($process.ExitCode))" }
 
     - name: Cache build
-      uses: actions/cache@v3.0.5
+      uses: actions/cache@v3.0.11
       if: ${{ inputs.cache-build }}
       with:
         path: src/ServiceBusExplorer/bin/Release

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -62,15 +62,15 @@ jobs:
         $sbeFileName = "$env:GITHUB_WORKSPACE\src\ServiceBusExplorer\Properties\AssemblyInfo.cs"
         .\SetVersion -FileName $sbeFileName -PropertyName 'AssemblyVersion' -Version ${{env.NUMBER_VERSION}}
         .\SetVersion -FileName $sbeFileName -PropertyName 'AssemblyFileVersion' -Version ${{env.NUMBER_VERSION}}   
-        .\SetVersion -FileName $sbeFileName -PropertyName 'AssemblyInformationalVersion' -Version ${{env.ReleaseVersion}}   
+        .\SetVersion -FileName $sbeFileName -PropertyName 'AssemblyInformationalVersion' -VersionString ${{env.ReleaseVersion}}   
 
         $commonInfoFile = "$env:GITHUB_WORKSPACE\src\Common\Properties\AssemblyInfo.cs"
         .\SetVersion -FileName $commonInfoFile -PropertyName 'AssemblyFileVersion' -Version ${{env.NUMBER_VERSION}}
-        .\SetVersion -FileName $commonInfoFile -PropertyName 'AssemblyInformationalVersion' -Version ${{env.ReleaseVersion}}   
+        .\SetVersion -FileName $commonInfoFile -PropertyName 'AssemblyInformationalVersion' -VersionString ${{env.ReleaseVersion}}   
 
         $notificationHubsInfoFile = "$env:GITHUB_WORKSPACE\src\NotificationHubs\Properties\AssemblyInfo.cs"
         .\SetVersion -FileName $notificationHubsInfoFile -PropertyName 'AssemblyFileVersion' -Version ${{env.NUMBER_VERSION}}      
-        .\SetVersion -FileName $notificationHubsInfoFile -PropertyName 'AssemblyInformationalVersion' -Version ${{env.ReleaseVersion}}   
+        .\SetVersion -FileName $notificationHubsInfoFile -PropertyName 'AssemblyInformationalVersion' -VersionString ${{env.ReleaseVersion}}   
 
     - name: Build
       # env:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,8 +46,7 @@ jobs:
     - name: Show version
       run: echo "Building version ${{ inputs.release-version }}"
 
-    - name: Get digital version
-      id: get-digital-version
+    - name: Get number version
       env:
         ReleaseVersion: ${{ inputs.release-version }}
       run: |
@@ -73,8 +72,6 @@ jobs:
         .\SetVersion -FileName $notificationHubsInfoFile -PropertyName 'AssemblyInformationalVersion' -VersionString ${{env.ReleaseVersion}}   
 
     - name: Build
-      # env:
-      #   Version: ${{ inputs.release-version }}
       run: |
         msbuild /m /property:Configuration=${{env.BUILD_CONFIGURATION}},FileVersion=${{env.NUMBER_VERSION}},InformationalVersion=${{inputs.release-version}} ${{env.SOLUTION_FILE_PATH}}
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -76,7 +76,7 @@ jobs:
       # env:
       #   Version: ${{ inputs.release-version }}
       run: |
-        msbuild /m /property:Configuration=${{env.BUILD_CONFIGURATION}},FileVersion=${{env.NUMBER_VERSION}}, InformationalVersion=${{inputs.release-version}} ${{env.SOLUTION_FILE_PATH}}
+        msbuild /m /property:Configuration=${{env.BUILD_CONFIGURATION}},FileVersion=${{env.NUMBER_VERSION}},InformationalVersion=${{inputs.release-version}} ${{env.SOLUTION_FILE_PATH}}
 
     - name: Run tests
       run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -76,7 +76,7 @@ jobs:
       # env:
       #   Version: ${{ inputs.release-version }}
       run: |
-        msbuild /m /property:Configuration=${{env.BUILD_CONFIGURATION}},FileVersion=${{env.NUMBER_VERSION}} ${{env.SOLUTION_FILE_PATH}}
+        msbuild /m /property:Configuration=${{env.BUILD_CONFIGURATION}},FileVersion=${{env.NUMBER_VERSION}}, InformationalVersion=${{inputs.release-version}} ${{env.SOLUTION_FILE_PATH}}
 
     - name: Run tests
       run: |

--- a/.github/workflows/handle-tag.yml
+++ b/.github/workflows/handle-tag.yml
@@ -3,7 +3,7 @@ name: Handle tag
 on:
   push:
     tags: 
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/handle-tag.yml
+++ b/.github/workflows/handle-tag.yml
@@ -15,7 +15,7 @@ jobs:
       id: tag-commit-hash
       run: |
         hash=${{ github.sha }}
-        echo "::set-output name=tag-hash::${hash}"
+        echo "{name}=tag-hash::${hash}" >> $GITHUB_OUTPUT
         echo $hash
 
     - name: Checkout main
@@ -27,7 +27,7 @@ jobs:
       id: main-commit-hash
       run: |
         hash=$(git log -n1 --format=format:"%H")
-        echo "::set-output name=main-hash::${hash}"
+        echo "{name}=main-hash::${hash}" >> $GITHUB_OUTPUT
         echo $hash
 
     - name: Verify tag commit matches main commit - exit if they don't match

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,17 @@ jobs:
        
     - uses: actions/checkout@v3
 
+    - name: Verify release version and get just the numbers and the dots
+      id: get-number-version
+      run: |
+        [string]$numberVersion = .\GetNumberVersion -Version ${{ inputs.release-version }}
+        echo "Got version $numberVersion"
+        [bool]$prelease = $false
+        if ($numberVersion -eq ${{ inputs.release-version }}) {
+          $prelease = $True
+        }
+        echo "PRELEASE=$prerelease" >> $env:GITHUB_ENV
+
     - name: Get cached build
       id: get-cached-build
       uses: actions/cache@v3.0.5
@@ -80,7 +91,8 @@ jobs:
         Start-Sleep 1 
         gh release upload ${{ env.RELEASE_VERSION }} $env:ZipFilename $env:NupkgFilename
 
-    - name: Publish to Chocolatey
+    - name: Publish to Chocolatey if not prerelease
+      if: ${{ ! env.prerelease }}
       env:
         CHOCO_TOKEN: ${{ secrets.CHOCO_TOKEN }}
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,6 @@ jobs:
       id: get-number-version
       run: |
         [Version]$numberVersion = .\GetNumberVersion -Version ${{ inputs.release-version }}
-        echo "Got version $numberVersion"
         [bool]$prerelease = $true
         
         if ("$numberVersion" -eq "${{ inputs.release-version }}") {
@@ -36,14 +35,6 @@ jobs:
         }
         
         echo "PRERELEASE=$prerelease" >> $env:GITHUB_ENV
-
-    - name: Dump env
-      run: env | sort
-   
-    - name: Dump GitHub context
-      env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
 
     - name: Get cached build
       id: get-cached-build
@@ -102,7 +93,7 @@ jobs:
         gh release upload ${{ env.RELEASE_VERSION }} $env:ZipFilename $env:NupkgFilename
 
     - name: Publish to Chocolatey if not prerelease
-      if: ${{ ! env.PRERELEASE }}
+      if: ${{ env.PRERELEASE == 'FALSE' }}
       env:
         CHOCO_TOKEN: ${{ secrets.CHOCO_TOKEN }}
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,11 +29,13 @@ jobs:
       run: |
         [Version]$numberVersion = .\GetNumberVersion -Version ${{ inputs.release-version }}
         echo "Got version $numberVersion"
-        [bool]$prelease = $false
+        [bool]$prerelease = $true
+        
         if ("$numberVersion" -eq "${{ inputs.release-version }}") {
-          $prelease = $True
+          $prerelease = $false
         }
-        echo "PRELEASE=$prerelease" >> $env:GITHUB_ENV
+        
+        echo "PRERELEASE=$prerelease" >> $env:GITHUB_ENV
 
     - name: Get cached build
       id: get-cached-build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Get cached build
       id: get-cached-build
-      uses: actions/cache@v3.0.5
+      uses: actions/cache@v3.0.11
       with:
         path: src/ServiceBusExplorer/bin/Release
         key: cached-output-${{ github.sha }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Verify release version and get just the numbers and the dots
       id: get-number-version
       run: |
-        [string]$numberVersion = .\GetNumberVersion -Version ${{ inputs.release-version }}
+        [Version]$numberVersion = .\GetNumberVersion -Version ${{ inputs.release-version }}
         echo "Got version $numberVersion"
         [bool]$prelease = $false
         if ($numberVersion -eq ${{ inputs.release-version }}) {

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         [Version]$numberVersion = .\GetNumberVersion -Version ${{ inputs.release-version }}
         echo "Got version $numberVersion"
         [bool]$prelease = $false
-        if ($numberVersion -eq ${{ inputs.release-version }}) {
+        if ("$numberVersion" -eq "${{ inputs.release-version }}") {
           $prelease = $True
         }
         echo "PRELEASE=$prerelease" >> $env:GITHUB_ENV

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,14 @@ jobs:
         
         echo "PRERELEASE=$prerelease" >> $env:GITHUB_ENV
 
+    - name: Dump env
+      run: env | sort
+   
+    - name: Dump GitHub context
+      env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+
     - name: Get cached build
       id: get-cached-build
       uses: actions/cache@v3.0.5
@@ -94,7 +102,7 @@ jobs:
         gh release upload ${{ env.RELEASE_VERSION }} $env:ZipFilename $env:NupkgFilename
 
     - name: Publish to Chocolatey if not prerelease
-      if: ${{ ! env.prerelease }}
+      if: ${{ ! env.PRERELEASE }}
       env:
         CHOCO_TOKEN: ${{ secrets.CHOCO_TOKEN }}
       run: |

--- a/GetNumberVersion.ps1
+++ b/GetNumberVersion.ps1
@@ -1,0 +1,20 @@
+# Verify it is a proper version
+param(
+    [Parameter(Mandatory=$false)]
+	[string]
+    $Version
+)
+
+Set-StrictMode -Version 3
+
+if ($Version -match "^\d+\.\d+\.\d+$") {
+	return $Version
+}
+
+if (-not ($Version -match "^\d+\.\d+\.\d+-.{1,12}$")) {
+	throw "The version must start with three numbers separated by dots. This may be " + `
+		"followed by a '-' and a word. That word may not be longer than 12 characters. For instance, 4.3.22-beta."
+}
+
+$parts = $Version -split "-"
+return $parts[0]

--- a/GetNumberVersion.ps1
+++ b/GetNumberVersion.ps1
@@ -2,14 +2,10 @@
 param(
     [Parameter(Mandatory=$false)]
 	[string]
-    $Version = '0.0.0'
+    $Version 
 )
 
 Set-StrictMode -Version 3
-
-if ($Version -match "^\d+\.\d+\.\d+$") {
-	return $Version
-}
 
 # RegEx from https://semver.org/
 [string]$semanticRegEx = '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'

--- a/GetNumberVersion.ps1
+++ b/GetNumberVersion.ps1
@@ -2,7 +2,7 @@
 param(
     [Parameter(Mandatory=$false)]
 	[string]
-    $Version
+    $Version = '0.0.0'
 )
 
 Set-StrictMode -Version 3
@@ -11,10 +11,14 @@ if ($Version -match "^\d+\.\d+\.\d+$") {
 	return $Version
 }
 
-if (-not ($Version -match "^\d+\.\d+\.\d+-.{1,12}$")) {
-	throw "The version must start with three numbers separated by dots. This may be " + `
-		"followed by a '-' and a word. That word may not be longer than 12 characters. For instance, 4.3.22-beta."
+# RegEx from https://semver.org/
+[string]$semanticRegEx = '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+
+if (-not ($Version -match $semanticRegEx)) {
+	throw "The version must follow semantic versioning, see https://semver.org/." + `
+		" For instance 4.3.22-beta."
 }
 
-$parts = $Version -split "-"
+$parts = $Version -split {$_ -eq '-' -or $_ -eq '+'}
+
 return $parts[0]

--- a/SetVersion.ps1
+++ b/SetVersion.ps1
@@ -1,15 +1,21 @@
 param(
-    [Parameter(Mandatory)]
+	[Parameter(Mandatory)]
 	[string]
-    $FileName,
+	$FileName,
 
-    [Parameter(Mandatory)]
-    [string]
-    $PropertyName,
+	[Parameter(Mandatory)]
+	[string]
+	$PropertyName,
 
-    [Parameter(Mandatory)]
+	[Parameter(Mandatory, 
+		ParameterSetName = 'Version')]
 	[Version]
-    $Version
+	$Version,
+
+	[Parameter(Mandatory, 
+		ParameterSetName = 'VersionString')]
+	[string]
+	$VersionString
 )
 
 Set-StrictMode -Version 2
@@ -17,20 +23,22 @@ Set-StrictMode -Version 2
 $pattern = "^\[assembly: $PropertyName\(""(.*)""\)\]$"
 $found = $false
 
+if ($Version) {
+	$VersionString = $Version
+}
+
 $content = (Get-Content $fileName -Encoding UTF8) | ForEach-Object {
-	if ($_ -match $pattern) 
-	{
-		"[assembly: $PropertyName(""{0}"")]" -f $Version
-        $found = $true
+	if ($_ -match $pattern) {
+  	   	"[assembly: $PropertyName(""{0}"")]" -f $VersionString
+		$found = $true
 	} 
-	else 
-	{
+	else {
 		$_
 	}
 } 
 
 if (-not $found) {
-  $content += "[assembly: $PropertyName(""{0}"")]" -f $Version
+	$content += "[assembly: $PropertyName(""{0}"")]" -f $VersionString
 }
 
 $content | Set-Content $fileName -Encoding UTF8


### PR DESCRIPTION
Fixes #697 

Since Assembly version and file version don't allow letters this PR adds setting the Informational file version, which allows letters. Then we can have 5.3.4-beta1. 