### PR TITLE
Modify BulkPurge to handle Topic with no Subscriptions

### DIFF
--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -6714,7 +6714,7 @@ namespace ServiceBusExplorer.Forms
                 }
 
                 List<SubscriptionWrapper> subscriptions = new List<SubscriptionWrapper>();
-                Func<TreeNode, IEnumerable<SubscriptionWrapper>> subscriptionsExtractor = tn => tn.FirstNode.Nodes.Cast<TreeNode>().Select(n => n.Tag as SubscriptionWrapper);
+                Func<TreeNode, IEnumerable<SubscriptionWrapper>> subscriptionsExtractor = tn => tn.FirstNode?.Nodes.Cast<TreeNode>().Select(n => n.Tag as SubscriptionWrapper) ?? Enumerable.Empty<SubscriptionWrapper>();
 
                 List<QueueDescription> queues = new List<QueueDescription>();
 


### PR DESCRIPTION
Fix for Issue [702](https://github.com/paolosalvatori/ServiceBusExplorer/issues/702).

Modify subscriptionsExtractor  anonymous function so that it handles the case where tn.FirstNode is null by returning an empty Enumerable.