### PR TITLE
Re-submit a single message with binary content created with Azure.Messaging.ServiceBus nuget package

### DIFF
--- a/src/ServiceBusExplorer.Tests/Helpers/ServiceBusHelperTest.cs
+++ b/src/ServiceBusExplorer.Tests/Helpers/ServiceBusHelperTest.cs
@@ -3,6 +3,8 @@
 using ServiceBusExplorer;
 using System;
 using NUnit.Framework;
+using Microsoft.ServiceBus.Messaging;
+using System.IO;
 
 #endregion
 
@@ -137,6 +139,161 @@ namespace ServiceBusExplorer.Tests.Helpers
             helper.NamespaceUri = new Uri("sb://aaa.test.com/");
 
             Assert.That(helper.GetAddressRelativeToNamespace("    "), Is.EqualTo("    "));
+        }
+
+        [Test]
+        public void GetMessageText_ProtobufMessage_WindowsAzureServiceApi_ByteArray()
+        {
+            var expectedBodyType = BodyType.ByteArray;
+
+            var helper = new ServiceBusHelper((_, _) => { });
+
+            var message = CreateProtobufTestMessage();
+            var brokeredMessage = new BrokeredMessage(message);
+            var actualMessageText = helper.GetMessageText(brokeredMessage, false, out var actualBodyType);
+
+            Assert.AreEqual(expectedBodyType, actualBodyType);
+            Assert.NotNull(actualMessageText);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(actualMessageText));
+        }
+
+        [Test]
+        public void GetMessageText_ProtobufMessage_WindowsAzureServiceApi_ReadonlyMemoryByte()
+        {
+            var expectedBodyType = BodyType.Stream;
+
+            var helper = new ServiceBusHelper((_, _) => { });
+
+            ReadOnlyMemory<byte> message = CreateProtobufTestMessage();
+            var brokeredMessage = new BrokeredMessage(message);
+            var actualMessageText = helper.GetMessageText(brokeredMessage, false, out var actualBodyType);
+
+            Assert.AreEqual(expectedBodyType, actualBodyType);
+            Assert.NotNull(actualMessageText);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(actualMessageText));
+        }
+
+        /// <summary>
+        /// AzureMessagingServiceBus only allows byte[] and BinaryData as content of the message.
+        /// This test somehow try to emulate the behavior of the new nuget package.
+        /// The exception is the same unspecified exception that occurs in test with the real service bus
+        /// Inside of the package you would do something like
+        /// Body = BinaryData.FromBytes(myByteArray)
+        ///
+        /// The actual message text in real test are like the output of <see cref="GetMessageText_ProtobufMessage_WindowsAzureServiceApi_ByteArray"/>
+        /// 
+        /// ������&
+        /// a string that a human can read
+        /// readable string"		fffff�(@
+        /// </summary>
+        [Test]
+        public void GetMessageText_ProtobufMessage_AzureMessagingServiceBus()
+        {
+            var expectedBodyType = BodyType.Stream;
+
+            var helper = new ServiceBusHelper((_, _) => { });
+
+            var message = CreateProtobufTestMessage();
+            var brokeredMessage = new BrokeredMessage(new MemoryStream(message));
+            var actualMessageText = helper.GetMessageText(brokeredMessage, false, out var actualBodyType);
+
+            Assert.AreEqual(expectedBodyType, actualBodyType);
+            Assert.NotNull(actualMessageText);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(actualMessageText));
+        }
+
+        static byte[] CreateProtobufTestMessage()
+        {
+            // Due to incompatibility with .net 462 it is not possible to generate a protobuf message inside the code.
+            return new byte[]
+            {
+                10,
+                12,
+                8,
+                154,
+                239,
+                224,
+                160,
+                6,
+                16,
+                172,
+                239,
+                162,
+                196,
+                1,
+                18,
+                38,
+                10,
+                30,
+                97,
+                32,
+                115,
+                116,
+                114,
+                105,
+                110,
+                103,
+                32,
+                116,
+                104,
+                97,
+                116,
+                32,
+                97,
+                32,
+                104,
+                117,
+                109,
+                97,
+                110,
+                32,
+                99,
+                97,
+                110,
+                32,
+                114,
+                101,
+                97,
+                100,
+                16,
+                1,
+                26,
+                2,
+                8,
+                12,
+                18,
+                30,
+                10,
+                15,
+                114,
+                101,
+                97,
+                100,
+                97,
+                98,
+                108,
+                101,
+                32,
+                115,
+                116,
+                114,
+                105,
+                110,
+                103,
+                16,
+                2,
+                34,
+                9,
+                9,
+                102,
+                102,
+                102,
+                102,
+                102,
+                230,
+                40,
+                64
+            };
         }
     }
 }

--- a/src/ServiceBusExplorer.Tests/ServiceBusExplorer.Tests.csproj
+++ b/src/ServiceBusExplorer.Tests/ServiceBusExplorer.Tests.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="6.2.2" />
   </ItemGroup>
 </Project>

--- a/src/ServiceBusExplorer.sln.DotSettings
+++ b/src/ServiceBusExplorer.sln.DotSettings
@@ -605,4 +605,5 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	
 	
 	<s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String>
-	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters /&gt;&lt;/data&gt;</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters /&gt;&lt;/data&gt;</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Protobuf/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.Designer.cs
@@ -1154,7 +1154,6 @@
             this.txtMessageText.CharWidth = 8;
             this.txtMessageText.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.txtMessageText.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
-            this.txtMessageText.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.txtMessageText.ForeColor = System.Drawing.SystemColors.ControlText;
             this.txtMessageText.IsReplaceMode = false;
             this.txtMessageText.Location = new System.Drawing.Point(16, 32);
@@ -1452,7 +1451,6 @@
             this.txtDeadletterText.CharWidth = 8;
             this.txtDeadletterText.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.txtDeadletterText.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
-            this.txtDeadletterText.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.txtDeadletterText.ForeColor = System.Drawing.SystemColors.ControlText;
             this.txtDeadletterText.IsReplaceMode = false;
             this.txtDeadletterText.Location = new System.Drawing.Point(16, 32);
@@ -1733,7 +1731,6 @@
             this.txtTransferDeadletterText.CharWidth = 8;
             this.txtTransferDeadletterText.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.txtTransferDeadletterText.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
-            this.txtTransferDeadletterText.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.txtTransferDeadletterText.ForeColor = System.Drawing.SystemColors.ControlText;
             this.txtTransferDeadletterText.IsReplaceMode = false;
             this.txtTransferDeadletterText.Location = new System.Drawing.Point(16, 32);
@@ -2096,7 +2093,7 @@
             this.saveSelectedMessagesToolStripMenuItem,
             this.saveSelectedMessagesBodyAsFileToolStripMenuItem});
             this.messagesContextMenuStrip.Name = "registrationContextMenuStrip";
-            this.messagesContextMenuStrip.Size = new System.Drawing.Size(306, 164);
+            this.messagesContextMenuStrip.Size = new System.Drawing.Size(306, 186);
             // 
             // repairAndResubmitMessageToolStripMenuItem
             // 
@@ -2110,6 +2107,7 @@
             this.resubmitMessageToolStripMenuItem.Name = "resubmitMessageToolStripMenuItem";
             this.resubmitMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.resubmitMessageToolStripMenuItem.Text = "Resubmit Selected Message";
+            this.resubmitMessageToolStripMenuItem.ToolTipText = "Resubmits the message with unchanged body.";
             this.resubmitMessageToolStripMenuItem.Click += new System.EventHandler(this.resubmitMessageToolStripMenuItem_Click);
             // 
             // resubmitSelectedMessagesInBatchModeToolStripMenuItem
@@ -2167,7 +2165,7 @@
             this.deleteSelectedMessageToolStripMenuItem,
             this.deleteSelectedMessagesToolStripMenuItem});
             this.deadletterContextMenuStrip.Name = "registrationContextMenuStrip";
-            this.deadletterContextMenuStrip.Size = new System.Drawing.Size(306, 230);
+            this.deadletterContextMenuStrip.Size = new System.Drawing.Size(306, 208);
             // 
             // repairAndResubmitDeadletterToolStripMenuItem
             // 
@@ -2181,6 +2179,7 @@
             this.resubmitDeadletterToolStripMenuItem.Name = "resubmitDeadletterToolStripMenuItem";
             this.resubmitDeadletterToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.resubmitDeadletterToolStripMenuItem.Text = "Resubmit Selected Message";
+            this.resubmitDeadletterToolStripMenuItem.ToolTipText = "Resubmits the deadletter message with unchanged body.";
             this.resubmitDeadletterToolStripMenuItem.Click += new System.EventHandler(this.resubmitDeadletterMessageToolStripMenuItem_Click);
             // 
             // resubmitSelectedDeadletterInBatchModeToolStripMenuItem

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.Designer.cs
@@ -116,6 +116,7 @@
             this.btnDeadletter = new System.Windows.Forms.Button();
             this.messagesContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.repairAndResubmitMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resubmitMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resubmitSelectedMessagesInBatchModeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.saveSelectedMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -124,6 +125,7 @@
             this.saveSelectedMessagesBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.deadletterContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.repairAndResubmitDeadletterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resubmitDeadletterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.saveSelectedDeadletteredMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -780,6 +782,7 @@
             this.txtMaxDeliveryCount.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtMaxDeliveryCount.BackColor = System.Drawing.SystemColors.Window;
+            this.txtMaxDeliveryCount.IsZeroWhenEmpty = false;
             this.txtMaxDeliveryCount.Location = new System.Drawing.Point(16, 88);
             this.txtMaxDeliveryCount.Name = "txtMaxDeliveryCount";
             this.txtMaxDeliveryCount.Size = new System.Drawing.Size(232, 20);
@@ -1151,6 +1154,7 @@
             this.txtMessageText.CharWidth = 8;
             this.txtMessageText.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.txtMessageText.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
+            this.txtMessageText.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.txtMessageText.ForeColor = System.Drawing.SystemColors.ControlText;
             this.txtMessageText.IsReplaceMode = false;
             this.txtMessageText.Location = new System.Drawing.Point(16, 32);
@@ -1448,6 +1452,7 @@
             this.txtDeadletterText.CharWidth = 8;
             this.txtDeadletterText.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.txtDeadletterText.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
+            this.txtDeadletterText.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.txtDeadletterText.ForeColor = System.Drawing.SystemColors.ControlText;
             this.txtDeadletterText.IsReplaceMode = false;
             this.txtDeadletterText.Location = new System.Drawing.Point(16, 32);
@@ -1728,6 +1733,7 @@
             this.txtTransferDeadletterText.CharWidth = 8;
             this.txtTransferDeadletterText.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.txtTransferDeadletterText.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
+            this.txtTransferDeadletterText.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.txtTransferDeadletterText.ForeColor = System.Drawing.SystemColors.ControlText;
             this.txtTransferDeadletterText.IsReplaceMode = false;
             this.txtTransferDeadletterText.Location = new System.Drawing.Point(16, 32);
@@ -2082,6 +2088,7 @@
             this.messagesContextMenuStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.messagesContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.repairAndResubmitMessageToolStripMenuItem,
+            this.resubmitMessageToolStripMenuItem,
             this.resubmitSelectedMessagesInBatchModeToolStripMenuItem,
             this.toolStripSeparator1,
             this.saveSelectedMessageToolStripMenuItem,
@@ -2089,7 +2096,7 @@
             this.saveSelectedMessagesToolStripMenuItem,
             this.saveSelectedMessagesBodyAsFileToolStripMenuItem});
             this.messagesContextMenuStrip.Name = "registrationContextMenuStrip";
-            this.messagesContextMenuStrip.Size = new System.Drawing.Size(306, 142);
+            this.messagesContextMenuStrip.Size = new System.Drawing.Size(306, 164);
             // 
             // repairAndResubmitMessageToolStripMenuItem
             // 
@@ -2097,6 +2104,13 @@
             this.repairAndResubmitMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.repairAndResubmitMessageToolStripMenuItem.Text = "Repair and Resubmit Selected Message";
             this.repairAndResubmitMessageToolStripMenuItem.Click += new System.EventHandler(this.repairAndResubmitMessageToolStripMenuItem_Click);
+            // 
+            // resubmitMessageToolStripMenuItem
+            // 
+            this.resubmitMessageToolStripMenuItem.Name = "resubmitMessageToolStripMenuItem";
+            this.resubmitMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.resubmitMessageToolStripMenuItem.Text = "Resubmit Selected Message";
+            this.resubmitMessageToolStripMenuItem.Click += new System.EventHandler(this.resubmitMessageToolStripMenuItem_Click);
             // 
             // resubmitSelectedMessagesInBatchModeToolStripMenuItem
             // 
@@ -2143,6 +2157,7 @@
             this.deadletterContextMenuStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.deadletterContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.repairAndResubmitDeadletterToolStripMenuItem,
+            this.resubmitDeadletterToolStripMenuItem,
             this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem,
             this.toolStripSeparator2,
             this.saveSelectedDeadletteredMessageToolStripMenuItem,
@@ -2152,7 +2167,7 @@
             this.deleteSelectedMessageToolStripMenuItem,
             this.deleteSelectedMessagesToolStripMenuItem});
             this.deadletterContextMenuStrip.Name = "registrationContextMenuStrip";
-            this.deadletterContextMenuStrip.Size = new System.Drawing.Size(306, 186);
+            this.deadletterContextMenuStrip.Size = new System.Drawing.Size(306, 230);
             // 
             // repairAndResubmitDeadletterToolStripMenuItem
             // 
@@ -2160,6 +2175,13 @@
             this.repairAndResubmitDeadletterToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.repairAndResubmitDeadletterToolStripMenuItem.Text = "Repair And Resubmit Selected Message";
             this.repairAndResubmitDeadletterToolStripMenuItem.Click += new System.EventHandler(this.repairAndResubmitDeadletterMessageToolStripMenuItem_Click);
+            // 
+            // resubmitDeadletterToolStripMenuItem
+            // 
+            this.resubmitDeadletterToolStripMenuItem.Name = "resubmitDeadletterToolStripMenuItem";
+            this.resubmitDeadletterToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.resubmitDeadletterToolStripMenuItem.Text = "Resubmit Selected Message";
+            this.resubmitDeadletterToolStripMenuItem.Click += new System.EventHandler(this.resubmitDeadletterMessageToolStripMenuItem_Click);
             // 
             // resubmitSelectedDeadletterInBatchModeToolStripMenuItem
             // 
@@ -2548,5 +2570,7 @@
         private System.Windows.Forms.PropertyGrid messageCustomPropertyGrid;
         private System.Windows.Forms.PropertyGrid deadletterCustomPropertyGrid;
         private System.Windows.Forms.PropertyGrid transferDeadletterCustomPropertyGrid;
+        private System.Windows.Forms.ToolStripMenuItem resubmitDeadletterToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem resubmitMessageToolStripMenuItem;
     }
 }

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -3306,25 +3306,15 @@ namespace ServiceBusExplorer.Controls
 
         private void resubmitMessageToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            try
-            {
-                if (messagesDataGridView.SelectedRows.Count <= 0)
-                {
-                    return;
-                }
-                using (var form = new MessageForm(queueDescription, messagesDataGridView.SelectedRows.Cast<DataGridViewRow>()
-                           .Select(r => (BrokeredMessage)r.DataBoundItem), serviceBusHelper, writeToLog))
-                {
-                    form.ShowDialog();
-                }
-            }
-            catch (Exception ex)
-            {
-                HandleException(ex);
-            }
+            ResubmitSelectedMessages();
         }
 
         private void resubmitSelectedMessagesInBatchModeToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            ResubmitSelectedMessages();
+        }
+
+        private void ResubmitSelectedMessages()
         {
             try
             {
@@ -3332,8 +3322,9 @@ namespace ServiceBusExplorer.Controls
                 {
                     return;
                 }
+
                 using (var form = new MessageForm(queueDescription, messagesDataGridView.SelectedRows.Cast<DataGridViewRow>()
-                    .Select(r => (BrokeredMessage)r.DataBoundItem), serviceBusHelper, writeToLog))
+                           .Select(r => (BrokeredMessage)r.DataBoundItem), serviceBusHelper, writeToLog))
                 {
                     form.ShowDialog();
                 }
@@ -3464,35 +3455,16 @@ namespace ServiceBusExplorer.Controls
 
         private async void resubmitDeadletterMessageToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            try
-            {
-                if (deadletterDataGridView.SelectedRows.Count <= 0)
-                {
-                    return;
-                }
-                using (var form = new MessageForm(queueDescription, deadletterDataGridView.SelectedRows.Cast<DataGridViewRow>()
-                           .Select(r => (BrokeredMessage)r.DataBoundItem), serviceBusHelper, writeToLog))
-                {
-                    form.ShowDialog();
-                    if (form.RemovedSequenceNumbers != null && form.RemovedSequenceNumbers.Any())
-                    {
-                        RemoveDeadletterDataGridRows(form.RemovedSequenceNumbers);
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                HandleException(ex);
-            }
-
-            // Rather than getting the updated entities from the forms we refresh all queues and topics to keep things 
-            // simple.
-            await MainForm.SingletonMainForm.RefreshQueues();
-            await MainForm.SingletonMainForm.RefreshTopics();
+            await ResubmitSelectedDeadletterMessages();
         }
 
         private async void resubmitSelectedDeadletterMessagesInBatchModeToolStripMenuItem_Click(object sender,
             EventArgs e)
+        {
+            await ResubmitSelectedDeadletterMessages();
+        }
+
+        async Task ResubmitSelectedDeadletterMessages()
         {
             try
             {
@@ -3500,8 +3472,9 @@ namespace ServiceBusExplorer.Controls
                 {
                     return;
                 }
+
                 using (var form = new MessageForm(queueDescription, deadletterDataGridView.SelectedRows.Cast<DataGridViewRow>()
-                    .Select(r => (BrokeredMessage)r.DataBoundItem), serviceBusHelper, writeToLog))
+                           .Select(r => (BrokeredMessage)r.DataBoundItem), serviceBusHelper, writeToLog))
                 {
                     form.ShowDialog();
                     if (form.RemovedSequenceNumbers != null && form.RemovedSequenceNumbers.Any())

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -3426,6 +3426,7 @@ namespace ServiceBusExplorer.Controls
             var multipleSelectedRows = deadletterDataGridView.SelectedRows.Count > 1;
 
             repairAndResubmitDeadletterToolStripMenuItem.Visible = !multipleSelectedRows;
+            resubmitDeadletterToolStripMenuItem.Visible = !multipleSelectedRows;
             saveSelectedDeadletteredMessageToolStripMenuItem.Visible = !multipleSelectedRows;
             saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem.Visible = !multipleSelectedRows;
             deleteSelectedMessageToolStripMenuItem.Visible = !multipleSelectedRows;

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.resx
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.resx
@@ -124,7 +124,7 @@
   <data name="pictFindMessages.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAIAAABvFaqvAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        EQAACxEBf2RfkQAAAAd0SU1FB90LGg8kOha4XJIAAAMOSURBVDhPrdHrS1NxGMDx/ohehVnWi4gKur4I
+        DAAACwwBP0AiyAAAAAd0SU1FB90LGg8kOha4XJIAAAMOSURBVDhPrdHrS1NxGMDx/ohehVnWi4gKur4I
         e5ck0cSiTMWE0HI6dWq7oGLTOfO2edyW052zzc3LtKl43TlnNzRteEvNzbMp5aUsE+dlXpIi0l9HCLcO
         QwWFL+fV83w4PL9jsN52mCoNhHFo1vF17bAQmQKzt/fNHAFEhuhtPqAaM1GgG77GQS+ltQfxjQzYKmkZ
         rjUTKtxOmfSOClUaxp6VWQMSUZqQeCqfCxLMBGZN3Ejvv5vXVdQ4vIf1H0Qqj4Rvz7O6Mxs2s3QgUQno
@@ -161,7 +161,7 @@
   <data name="pictFindDeadletter.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAIAAABvFaqvAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        EQAACxEBf2RfkQAAAAd0SU1FB90LGg8kOha4XJIAAAMOSURBVDhPrdHrS1NxGMDx/ohehVnWi4gKur4I
+        DAAACwwBP0AiyAAAAAd0SU1FB90LGg8kOha4XJIAAAMOSURBVDhPrdHrS1NxGMDx/ohehVnWi4gKur4I
         e5ck0cSiTMWE0HI6dWq7oGLTOfO2edyW052zzc3LtKl43TlnNzRteEvNzbMp5aUsE+dlXpIi0l9HCLcO
         QwWFL+fV83w4PL9jsN52mCoNhHFo1vF17bAQmQKzt/fNHAFEhuhtPqAaM1GgG77GQS+ltQfxjQzYKmkZ
         rjUTKtxOmfSOClUaxp6VWQMSUZqQeCqfCxLMBGZN3Ejvv5vXVdQ4vIf1H0Qqj4Rvz7O6Mxs2s3QgUQno
@@ -198,7 +198,7 @@
   <data name="pictureBox1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAIAAABvFaqvAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        EQAACxEBf2RfkQAAAAd0SU1FB90LGg8kOha4XJIAAAMOSURBVDhPrdHrS1NxGMDx/ohehVnWi4gKur4I
+        DAAACwwBP0AiyAAAAAd0SU1FB90LGg8kOha4XJIAAAMOSURBVDhPrdHrS1NxGMDx/ohehVnWi4gKur4I
         e5ck0cSiTMWE0HI6dWq7oGLTOfO2edyW052zzc3LtKl43TlnNzRteEvNzbMp5aUsE+dlXpIi0l9HCLcO
         QwWFL+fV83w4PL9jsN52mCoNhHFo1vF17bAQmQKzt/fNHAFEhuhtPqAaM1GgG77GQS+ltQfxjQzYKmkZ
         rjUTKtxOmfSOClUaxp6VWQMSUZqQeCqfCxLMBGZN3Ejvv5vXVdQ4vIf1H0Qqj4Rvz7O6Mxs2s3QgUQno
@@ -260,6 +260,6 @@
     <value>390, 57</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>47</value>
+    <value>116</value>
   </metadata>
 </root>

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.Designer.cs
@@ -1384,7 +1384,6 @@
             this.txtDeadletterText.CharWidth = 8;
             this.txtDeadletterText.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.txtDeadletterText.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
-            this.txtDeadletterText.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.txtDeadletterText.ForeColor = System.Drawing.SystemColors.ControlText;
             this.txtDeadletterText.IsReplaceMode = false;
             this.txtDeadletterText.Location = new System.Drawing.Point(16, 32);
@@ -1709,6 +1708,7 @@
             this.resubmitDeadletterToolStripMenuItem.Name = "resubmitDeadletterToolStripMenuItem";
             this.resubmitDeadletterToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.resubmitDeadletterToolStripMenuItem.Text = "Resubmit Selected Message";
+            this.resubmitDeadletterToolStripMenuItem.ToolTipText = "Resubmits the deadletter message with unchanged body.";
             this.resubmitDeadletterToolStripMenuItem.Click += new System.EventHandler(this.resubmitDeadletterMessageToolStripMenuItem_Click);
             // 
             // resubmitSelectedDeadletterInBatchModeToolStripMenuItem
@@ -1776,6 +1776,7 @@
             this.resubmitMessageToolStripMenuItem.Name = "resubmitMessageToolStripMenuItem";
             this.resubmitMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.resubmitMessageToolStripMenuItem.Text = "Resubmit Selected Message";
+            this.resubmitMessageToolStripMenuItem.ToolTipText = "Resubmits the message with unchanged body.";
             this.resubmitMessageToolStripMenuItem.Click += new System.EventHandler(this.resubmitMessageToolStripMenuItem_Click);
             // 
             // resubmitSelectedMessagesInBatchModeToolStripMenuItem

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.Designer.cs
@@ -106,6 +106,7 @@
             this.saveFileDialog = new System.Windows.Forms.SaveFileDialog();
             this.deadletterContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.repairAndResubmitDeadletterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resubmitDeadletterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.saveSelectedDeadletteredMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -114,6 +115,7 @@
             this.deleteSelectedMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.messagesContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.repairAndResubmitMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resubmitMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resubmitSelectedMessagesInBatchModeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.saveSelectedMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -817,6 +819,7 @@
             this.txtMaxDeliveryCount.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.txtMaxDeliveryCount.BackColor = System.Drawing.SystemColors.Window;
+            this.txtMaxDeliveryCount.IsZeroWhenEmpty = false;
             this.txtMaxDeliveryCount.Location = new System.Drawing.Point(16, 44);
             this.txtMaxDeliveryCount.Name = "txtMaxDeliveryCount";
             this.txtMaxDeliveryCount.Size = new System.Drawing.Size(232, 20);
@@ -1080,7 +1083,7 @@
         '\"',
         '\'',
         '\''};
-            this.txtMessageText.AutoScrollMinSize = new System.Drawing.Size(27, 14);
+            this.txtMessageText.AutoScrollMinSize = new System.Drawing.Size(2, 14);
             this.txtMessageText.BackBrush = null;
             this.txtMessageText.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.txtMessageText.CharHeight = 14;
@@ -1374,7 +1377,7 @@
         '\"',
         '\'',
         '\''};
-            this.txtDeadletterText.AutoScrollMinSize = new System.Drawing.Size(27, 14);
+            this.txtDeadletterText.AutoScrollMinSize = new System.Drawing.Size(2, 14);
             this.txtDeadletterText.BackBrush = null;
             this.txtDeadletterText.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.txtDeadletterText.CharHeight = 14;
@@ -1684,6 +1687,7 @@
             this.deadletterContextMenuStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.deadletterContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.repairAndResubmitDeadletterToolStripMenuItem,
+            this.resubmitDeadletterToolStripMenuItem,
             this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem,
             this.toolStripSeparator2,
             this.saveSelectedDeadletteredMessageToolStripMenuItem,
@@ -1691,7 +1695,7 @@
             this.deleteSelectedMessageToolStripMenuItem,
             this.deleteSelectedMessagesToolStripMenuItem});
             this.deadletterContextMenuStrip.Name = "registrationContextMenuStrip";
-            this.deadletterContextMenuStrip.Size = new System.Drawing.Size(306, 142);
+            this.deadletterContextMenuStrip.Size = new System.Drawing.Size(306, 186);
             // 
             // repairAndResubmitDeadletterToolStripMenuItem
             // 
@@ -1699,6 +1703,13 @@
             this.repairAndResubmitDeadletterToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.repairAndResubmitDeadletterToolStripMenuItem.Text = "Repair And Resubmit Selected Message";
             this.repairAndResubmitDeadletterToolStripMenuItem.Click += new System.EventHandler(this.repairAndResubmitDeadletterMessageToolStripMenuItem_Click);
+            // 
+            // resubmitDeadletterToolStripMenuItem
+            // 
+            this.resubmitDeadletterToolStripMenuItem.Name = "resubmitDeadletterToolStripMenuItem";
+            this.resubmitDeadletterToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.resubmitDeadletterToolStripMenuItem.Text = "Resubmit Selected Message";
+            this.resubmitDeadletterToolStripMenuItem.Click += new System.EventHandler(this.resubmitDeadletterMessageToolStripMenuItem_Click);
             // 
             // resubmitSelectedDeadletterInBatchModeToolStripMenuItem
             // 
@@ -1745,12 +1756,13 @@
             this.messagesContextMenuStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.messagesContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.repairAndResubmitMessageToolStripMenuItem,
+            this.resubmitMessageToolStripMenuItem,
             this.resubmitSelectedMessagesInBatchModeToolStripMenuItem,
             this.toolStripSeparator1,
             this.saveSelectedMessageToolStripMenuItem,
             this.saveSelectedMessagesToolStripMenuItem});
             this.messagesContextMenuStrip.Name = "registrationContextMenuStrip";
-            this.messagesContextMenuStrip.Size = new System.Drawing.Size(306, 98);
+            this.messagesContextMenuStrip.Size = new System.Drawing.Size(306, 120);
             // 
             // repairAndResubmitMessageToolStripMenuItem
             // 
@@ -1758,6 +1770,13 @@
             this.repairAndResubmitMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.repairAndResubmitMessageToolStripMenuItem.Text = "Repair And Resubmit Selected Message";
             this.repairAndResubmitMessageToolStripMenuItem.Click += new System.EventHandler(this.repairAndResubmitMessageToolStripMenuItem_Click);
+            // 
+            // resubmitMessageToolStripMenuItem
+            // 
+            this.resubmitMessageToolStripMenuItem.Name = "resubmitMessageToolStripMenuItem";
+            this.resubmitMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.resubmitMessageToolStripMenuItem.Text = "Resubmit Selected Message";
+            this.resubmitMessageToolStripMenuItem.Click += new System.EventHandler(this.resubmitMessageToolStripMenuItem_Click);
             // 
             // resubmitSelectedMessagesInBatchModeToolStripMenuItem
             // 
@@ -2004,5 +2023,7 @@
         private TimeSpanControl tsLockDuration;
         private System.Windows.Forms.PropertyGrid messageCustomPropertyGrid;
         private System.Windows.Forms.PropertyGrid deadletterCustomPropertyGrid;
+        private System.Windows.Forms.ToolStripMenuItem resubmitDeadletterToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem resubmitMessageToolStripMenuItem;
     }
 }

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -2273,25 +2273,15 @@ namespace ServiceBusExplorer.Controls
 
         private void resubmitMessageToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            try
-            {
-                if (messagesDataGridView.SelectedRows.Count <= 0)
-                {
-                    return;
-                }
-                using (var form = new MessageForm(subscriptionWrapper, messagesDataGridView.SelectedRows.Cast<DataGridViewRow>()
-                           .Select(r => (BrokeredMessage)r.DataBoundItem), serviceBusHelper, writeToLog))
-                {
-                    form.ShowDialog();
-                }
-            }
-            catch (Exception ex)
-            {
-                HandleException(ex);
-            }
+            ResubmitSelectedMessages();
         }
 
         private void resubmitSelectedMessagesInBatchModeToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            ResubmitSelectedMessages();
+        }
+
+        private void ResubmitSelectedMessages()
         {
             try
             {
@@ -2299,8 +2289,9 @@ namespace ServiceBusExplorer.Controls
                 {
                     return;
                 }
+
                 using (var form = new MessageForm(subscriptionWrapper, messagesDataGridView.SelectedRows.Cast<DataGridViewRow>()
-                                .Select(r => (BrokeredMessage)r.DataBoundItem), serviceBusHelper, writeToLog))
+                           .Select(r => (BrokeredMessage)r.DataBoundItem), serviceBusHelper, writeToLog))
                 {
                     form.ShowDialog();
                 }
@@ -2411,34 +2402,15 @@ namespace ServiceBusExplorer.Controls
 
         private async void resubmitDeadletterMessageToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            try
-            {
-                if (deadletterDataGridView.SelectedRows.Count <= 0)
-                {
-                    return;
-                }
-                using (var form = new MessageForm(subscriptionWrapper, deadletterDataGridView.SelectedRows.Cast<DataGridViewRow>()
-                                .Select(r => (BrokeredMessage)r.DataBoundItem), serviceBusHelper, writeToLog))
-                {
-                    form.ShowDialog();
-                    if (form.RemovedSequenceNumbers != null && form.RemovedSequenceNumbers.Any())
-                    {
-                        RemoveDeadletterDataGridRows(form.RemovedSequenceNumbers);
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                HandleException(ex);
-            }
-
-            // Rather than getting the updated entities from the forms we refresh all queues and topics to keep things 
-            // simple.
-            await MainForm.SingletonMainForm.RefreshQueues();
-            await MainForm.SingletonMainForm.RefreshTopics();
+            await ResubmitSelectedDeadletterMessages();
         }
 
         private async void resubmitSelectedDeadletterMessagesInBatchModeToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            await ResubmitSelectedDeadletterMessages();
+        }
+
+        private async Task ResubmitSelectedDeadletterMessages()
         {
             try
             {
@@ -2446,8 +2418,9 @@ namespace ServiceBusExplorer.Controls
                 {
                     return;
                 }
+
                 using (var form = new MessageForm(subscriptionWrapper, deadletterDataGridView.SelectedRows.Cast<DataGridViewRow>()
-                                .Select(r => (BrokeredMessage)r.DataBoundItem), serviceBusHelper, writeToLog))
+                           .Select(r => (BrokeredMessage)r.DataBoundItem), serviceBusHelper, writeToLog))
                 {
                     form.ShowDialog();
                     if (form.RemovedSequenceNumbers != null && form.RemovedSequenceNumbers.Any())

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.resx
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.resx
@@ -124,7 +124,7 @@
   <data name="pictFindMessages.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAIAAABvFaqvAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        DQAACw0B7QfALAAAAAd0SU1FB90LGg8kOha4XJIAAAMOSURBVDhPrdHrS1NxGMDx/ohehVnWi4gKur4I
+        DAAACwwBP0AiyAAAAAd0SU1FB90LGg8kOha4XJIAAAMOSURBVDhPrdHrS1NxGMDx/ohehVnWi4gKur4I
         e5ck0cSiTMWE0HI6dWq7oGLTOfO2edyW052zzc3LtKl43TlnNzRteEvNzbMp5aUsE+dlXpIi0l9HCLcO
         QwWFL+fV83w4PL9jsN52mCoNhHFo1vF17bAQmQKzt/fNHAFEhuhtPqAaM1GgG77GQS+ltQfxjQzYKmkZ
         rjUTKtxOmfSOClUaxp6VWQMSUZqQeCqfCxLMBGZN3Ejvv5vXVdQ4vIf1H0Qqj4Rvz7O6Mxs2s3QgUQno
@@ -161,7 +161,7 @@
   <data name="pictFindDeadletter.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAIAAABvFaqvAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        DQAACw0B7QfALAAAAAd0SU1FB90LGg8kOha4XJIAAAMOSURBVDhPrdHrS1NxGMDx/ohehVnWi4gKur4I
+        DAAACwwBP0AiyAAAAAd0SU1FB90LGg8kOha4XJIAAAMOSURBVDhPrdHrS1NxGMDx/ohehVnWi4gKur4I
         e5ck0cSiTMWE0HI6dWq7oGLTOfO2edyW052zzc3LtKl43TlnNzRteEvNzbMp5aUsE+dlXpIi0l9HCLcO
         QwWFL+fV83w4PL9jsN52mCoNhHFo1vF17bAQmQKzt/fNHAFEhuhtPqAaM1GgG77GQS+ltQfxjQzYKmkZ
         rjUTKtxOmfSOClUaxp6VWQMSUZqQeCqfCxLMBGZN3Ejvv5vXVdQ4vIf1H0Qqj4Rvz7O6Mxs2s3QgUQno

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.resx
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.resx
@@ -124,7 +124,7 @@
   <data name="pictFindMessages.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAIAAABvFaqvAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        EQAACxEBf2RfkQAAAAd0SU1FB90LGg8kOha4XJIAAAMOSURBVDhPrdHrS1NxGMDx/ohehVnWi4gKur4I
+        DQAACw0B7QfALAAAAAd0SU1FB90LGg8kOha4XJIAAAMOSURBVDhPrdHrS1NxGMDx/ohehVnWi4gKur4I
         e5ck0cSiTMWE0HI6dWq7oGLTOfO2edyW052zzc3LtKl43TlnNzRteEvNzbMp5aUsE+dlXpIi0l9HCLcO
         QwWFL+fV83w4PL9jsN52mCoNhHFo1vF17bAQmQKzt/fNHAFEhuhtPqAaM1GgG77GQS+ltQfxjQzYKmkZ
         rjUTKtxOmfSOClUaxp6VWQMSUZqQeCqfCxLMBGZN3Ejvv5vXVdQ4vIf1H0Qqj4Rvz7O6Mxs2s3QgUQno
@@ -161,7 +161,7 @@
   <data name="pictFindDeadletter.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAIAAABvFaqvAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        EQAACxEBf2RfkQAAAAd0SU1FB90LGg8kOha4XJIAAAMOSURBVDhPrdHrS1NxGMDx/ohehVnWi4gKur4I
+        DQAACw0B7QfALAAAAAd0SU1FB90LGg8kOha4XJIAAAMOSURBVDhPrdHrS1NxGMDx/ohehVnWi4gKur4I
         e5ck0cSiTMWE0HI6dWq7oGLTOfO2edyW052zzc3LtKl43TlnNzRteEvNzbMp5aUsE+dlXpIi0l9HCLcO
         QwWFL+fV83w4PL9jsN52mCoNhHFo1vF17bAQmQKzt/fNHAFEhuhtPqAaM1GgG77GQS+ltQfxjQzYKmkZ
         rjUTKtxOmfSOClUaxp6VWQMSUZqQeCqfCxLMBGZN3Ejvv5vXVdQ4vIf1H0Qqj4Rvz7O6Mxs2s3QgUQno

--- a/src/ServiceBusExplorer/Controls/ListenerControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/ListenerControl.Designer.cs
@@ -905,7 +905,6 @@
             this.txtMessageText.CharWidth = 8;
             this.txtMessageText.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.txtMessageText.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
-            this.txtMessageText.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.txtMessageText.ForeColor = System.Drawing.SystemColors.ControlText;
             this.txtMessageText.IsReplaceMode = false;
             this.txtMessageText.Location = new System.Drawing.Point(16, 32);
@@ -1040,6 +1039,7 @@
             this.resubmitMessageToolStripMenuItem.Name = "resubmitMessageToolStripMenuItem";
             this.resubmitMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.resubmitMessageToolStripMenuItem.Text = "Resubmit Selected Message";
+            this.resubmitMessageToolStripMenuItem.ToolTipText = "Resubmits the message with unchanged body.";
             this.resubmitMessageToolStripMenuItem.Click += new System.EventHandler(this.resubmitMessageToolStripMenuItem_Click);
             // 
             // resubmitSelectedMessagesInBatchModeToolStripMenuItem

--- a/src/ServiceBusExplorer/Controls/ListenerControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/ListenerControl.Designer.cs
@@ -78,6 +78,7 @@
             this.messageCustomPropertyGrid = new System.Windows.Forms.PropertyGrid();
             this.messagesContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.repairAndResubmitMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resubmitMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resubmitSelectedMessagesInBatchModeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.saveSelectedMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -273,6 +274,7 @@
             this.txtMessageSizePerSecond.AllowDecimal = false;
             this.txtMessageSizePerSecond.AllowNegative = false;
             this.txtMessageSizePerSecond.AllowSpace = false;
+            this.txtMessageSizePerSecond.IsZeroWhenEmpty = false;
             this.txtMessageSizePerSecond.Location = new System.Drawing.Point(160, 88);
             this.txtMessageSizePerSecond.Name = "txtMessageSizePerSecond";
             this.txtMessageSizePerSecond.Size = new System.Drawing.Size(88, 20);
@@ -293,6 +295,7 @@
             this.txtAverageDuration.AllowDecimal = false;
             this.txtAverageDuration.AllowNegative = false;
             this.txtAverageDuration.AllowSpace = false;
+            this.txtAverageDuration.IsZeroWhenEmpty = false;
             this.txtAverageDuration.Location = new System.Drawing.Point(16, 88);
             this.txtAverageDuration.Name = "txtAverageDuration";
             this.txtAverageDuration.Size = new System.Drawing.Size(80, 20);
@@ -303,6 +306,7 @@
             this.txtMessagesTotal.AllowDecimal = false;
             this.txtMessagesTotal.AllowNegative = false;
             this.txtMessagesTotal.AllowSpace = false;
+            this.txtMessagesTotal.IsZeroWhenEmpty = false;
             this.txtMessagesTotal.Location = new System.Drawing.Point(16, 48);
             this.txtMessagesTotal.Name = "txtMessagesTotal";
             this.txtMessagesTotal.Size = new System.Drawing.Size(128, 20);
@@ -323,6 +327,7 @@
             this.txtMessagesPerSecond.AllowDecimal = false;
             this.txtMessagesPerSecond.AllowNegative = false;
             this.txtMessagesPerSecond.AllowSpace = false;
+            this.txtMessagesPerSecond.IsZeroWhenEmpty = false;
             this.txtMessagesPerSecond.Location = new System.Drawing.Point(160, 48);
             this.txtMessagesPerSecond.Name = "txtMessagesPerSecond";
             this.txtMessagesPerSecond.Size = new System.Drawing.Size(88, 20);
@@ -530,6 +535,7 @@
             this.txtMessageWaitTimeout.AllowDecimal = false;
             this.txtMessageWaitTimeout.AllowNegative = false;
             this.txtMessageWaitTimeout.AllowSpace = false;
+            this.txtMessageWaitTimeout.IsZeroWhenEmpty = false;
             this.txtMessageWaitTimeout.Location = new System.Drawing.Point(632, 48);
             this.txtMessageWaitTimeout.Name = "txtMessageWaitTimeout";
             this.txtMessageWaitTimeout.Size = new System.Drawing.Size(96, 20);
@@ -551,6 +557,7 @@
             this.txtAutoRenewTimeout.AllowDecimal = false;
             this.txtAutoRenewTimeout.AllowNegative = false;
             this.txtAutoRenewTimeout.AllowSpace = false;
+            this.txtAutoRenewTimeout.IsZeroWhenEmpty = false;
             this.txtAutoRenewTimeout.Location = new System.Drawing.Point(496, 48);
             this.txtAutoRenewTimeout.Name = "txtAutoRenewTimeout";
             this.txtAutoRenewTimeout.Size = new System.Drawing.Size(96, 20);
@@ -572,6 +579,7 @@
             this.txtPrefetchCount.AllowDecimal = false;
             this.txtPrefetchCount.AllowNegative = false;
             this.txtPrefetchCount.AllowSpace = false;
+            this.txtPrefetchCount.IsZeroWhenEmpty = false;
             this.txtPrefetchCount.Location = new System.Drawing.Point(256, 48);
             this.txtPrefetchCount.Name = "txtPrefetchCount";
             this.txtPrefetchCount.Size = new System.Drawing.Size(96, 20);
@@ -686,6 +694,7 @@
             this.txtRefreshInformation.AllowDecimal = false;
             this.txtRefreshInformation.AllowNegative = false;
             this.txtRefreshInformation.AllowSpace = false;
+            this.txtRefreshInformation.IsZeroWhenEmpty = false;
             this.txtRefreshInformation.Location = new System.Drawing.Point(136, 48);
             this.txtRefreshInformation.Name = "txtRefreshInformation";
             this.txtRefreshInformation.Size = new System.Drawing.Size(96, 20);
@@ -708,6 +717,7 @@
             this.txtMaxConcurrentCalls.AllowDecimal = false;
             this.txtMaxConcurrentCalls.AllowNegative = false;
             this.txtMaxConcurrentCalls.AllowSpace = false;
+            this.txtMaxConcurrentCalls.IsZeroWhenEmpty = false;
             this.txtMaxConcurrentCalls.Location = new System.Drawing.Point(16, 48);
             this.txtMaxConcurrentCalls.Name = "txtMaxConcurrentCalls";
             this.txtMaxConcurrentCalls.Size = new System.Drawing.Size(96, 20);
@@ -1010,12 +1020,13 @@
             // 
             this.messagesContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.repairAndResubmitMessageToolStripMenuItem,
+            this.resubmitMessageToolStripMenuItem,
             this.resubmitSelectedMessagesInBatchModeToolStripMenuItem,
             this.toolStripSeparator1,
             this.saveSelectedMessageToolStripMenuItem,
             this.saveSelectedMessagesToolStripMenuItem});
             this.messagesContextMenuStrip.Name = "registrationContextMenuStrip";
-            this.messagesContextMenuStrip.Size = new System.Drawing.Size(306, 98);
+            this.messagesContextMenuStrip.Size = new System.Drawing.Size(306, 142);
             // 
             // repairAndResubmitMessageToolStripMenuItem
             // 
@@ -1023,6 +1034,13 @@
             this.repairAndResubmitMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.repairAndResubmitMessageToolStripMenuItem.Text = "Repair and Resubmit Selected Message";
             this.repairAndResubmitMessageToolStripMenuItem.Click += new System.EventHandler(this.repairAndResubmitMessageToolStripMenuItem_Click);
+            // 
+            // resubmitMessageToolStripMenuItem
+            // 
+            this.resubmitMessageToolStripMenuItem.Name = "resubmitMessageToolStripMenuItem";
+            this.resubmitMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.resubmitMessageToolStripMenuItem.Text = "Resubmit Selected Message";
+            this.resubmitMessageToolStripMenuItem.Click += new System.EventHandler(this.resubmitMessageToolStripMenuItem_Click);
             // 
             // resubmitSelectedMessagesInBatchModeToolStripMenuItem
             // 
@@ -1226,5 +1244,6 @@
         private FastColoredTextBoxNS.FastColoredTextBox txtMessageText;
         private Grouper grouperMessageCustomProperties;
         private System.Windows.Forms.PropertyGrid messageCustomPropertyGrid;
+        private System.Windows.Forms.ToolStripMenuItem resubmitMessageToolStripMenuItem;
     }
 }

--- a/src/ServiceBusExplorer/Controls/ListenerControl.cs
+++ b/src/ServiceBusExplorer/Controls/ListenerControl.cs
@@ -724,69 +724,15 @@ namespace ServiceBusExplorer.Controls
 
         private async void resubmitMessageToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            try
-            {
-                if (messagesDataGridView.SelectedRows.Count <= 0)
-                {
-                    return;
-                }
-                string entityPath;
-                using (var form = new SelectEntityForm(SelectEntityDialogTitle, SelectEntityGrouperTitle, SelectEntityLabelText))
-                {
-                    if (form.ShowDialog() != DialogResult.OK)
-                    {
-                        return;
-                    }
-                    if (string.IsNullOrWhiteSpace(form.Path))
-                    {
-                        return;
-                    }
-                    entityPath = form.Path;
-                }
-                var sent = 0;
-                var messageSender = await serviceBusHelper.MessagingFactory.CreateMessageSenderAsync(entityPath);
-                var messages = messagesDataGridView.SelectedRows.Cast<DataGridViewRow>().Select(r =>
-                {
-                    var message = r.DataBoundItem as BrokeredMessage;
-                    serviceBusHelper.GetMessageText(message, MainForm.SingletonMainForm.UseAscii, out var bodyType);
-                    if (bodyType == BodyType.Wcf)
-                    {
-                        var wcfUri = serviceBusHelper.IsCloudNamespace ?
-                                         new Uri(serviceBusHelper.NamespaceUri, messageSender.Path) :
-                                         new UriBuilder
-                                         {
-                                             Host = serviceBusHelper.NamespaceUri.Host,
-                                             Path = $"{serviceBusHelper.NamespaceUri.AbsolutePath}/{messageSender.Path}",
-                                             Scheme = "sb"
-                                         }.Uri;
-                        return serviceBusHelper.CreateMessageForWcfReceiver(message,
-                                                                            0,
-                                                                            false,
-                                                                            false,
-                                                                            wcfUri);
-                    }
-                    return serviceBusHelper.CreateMessageForApiReceiver(message,
-                                                                        0,
-                                                                        false,
-                                                                        false,
-                                                                        bodyType,
-                                                                        null);
-                });
-                IEnumerable<BrokeredMessage> brokeredMessages = messages as IList<BrokeredMessage> ?? messages.ToList();
-                if (brokeredMessages.Any())
-                {
-                    sent = brokeredMessages.Count();
-                    await messageSender.SendBatchAsync(brokeredMessages);
-                }
-                writeToLog(string.Format(MessageSentMessage, sent, entityPath));
-            }
-            catch (Exception ex)
-            {
-                HandleException(ex);
-            }
+            await ResubmitSelectedMessages();
         }
 
         private async void resubmitSelectedMessagesInBatchModeToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            await ResubmitSelectedMessages();
+        }
+
+        private async Task ResubmitSelectedMessages()
         {
             try
             {
@@ -794,6 +740,7 @@ namespace ServiceBusExplorer.Controls
                 {
                     return;
                 }
+
                 string entityPath;
                 using (var form = new SelectEntityForm(SelectEntityDialogTitle, SelectEntityGrouperTitle, SelectEntityLabelText))
                 {
@@ -801,12 +748,15 @@ namespace ServiceBusExplorer.Controls
                     {
                         return;
                     }
+
                     if (string.IsNullOrWhiteSpace(form.Path))
                     {
                         return;
                     }
+
                     entityPath = form.Path;
                 }
+
                 var sent = 0;
                 var messageSender = await serviceBusHelper.MessagingFactory.CreateMessageSenderAsync(entityPath);
                 var messages = messagesDataGridView.SelectedRows.Cast<DataGridViewRow>().Select(r =>
@@ -815,26 +765,27 @@ namespace ServiceBusExplorer.Controls
                     serviceBusHelper.GetMessageText(message, MainForm.SingletonMainForm.UseAscii, out var bodyType);
                     if (bodyType == BodyType.Wcf)
                     {
-                        var wcfUri = serviceBusHelper.IsCloudNamespace ?
-                                         new Uri(serviceBusHelper.NamespaceUri, messageSender.Path) :
-                                         new UriBuilder
-                                         {
-                                             Host = serviceBusHelper.NamespaceUri.Host,
-                                             Path = $"{serviceBusHelper.NamespaceUri.AbsolutePath}/{messageSender.Path}",
-                                             Scheme = "sb"
-                                         }.Uri;
+                        var wcfUri = serviceBusHelper.IsCloudNamespace
+                            ? new Uri(serviceBusHelper.NamespaceUri, messageSender.Path)
+                            : new UriBuilder
+                            {
+                                Host = serviceBusHelper.NamespaceUri.Host,
+                                Path = $"{serviceBusHelper.NamespaceUri.AbsolutePath}/{messageSender.Path}",
+                                Scheme = "sb"
+                            }.Uri;
                         return serviceBusHelper.CreateMessageForWcfReceiver(message,
-                                                                            0,
-                                                                            false,
-                                                                            false,
-                                                                            wcfUri);
+                            0,
+                            false,
+                            false,
+                            wcfUri);
                     }
+
                     return serviceBusHelper.CreateMessageForApiReceiver(message,
-                                                                        0,
-                                                                        false,
-                                                                        false,
-                                                                        bodyType,
-                                                                        null);
+                        0,
+                        false,
+                        false,
+                        bodyType,
+                        null);
                 });
                 IEnumerable<BrokeredMessage> brokeredMessages = messages as IList<BrokeredMessage> ?? messages.ToList();
                 if (brokeredMessages.Any())
@@ -842,6 +793,7 @@ namespace ServiceBusExplorer.Controls
                     sent = brokeredMessages.Count();
                     await messageSender.SendBatchAsync(brokeredMessages);
                 }
+
                 writeToLog(string.Format(MessageSentMessage, sent, entityPath));
             }
             catch (Exception ex)

--- a/src/ServiceBusExplorer/Controls/ListenerControl.resx
+++ b/src/ServiceBusExplorer/Controls/ListenerControl.resx
@@ -124,7 +124,7 @@
   <data name="pictFindMessages.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAIAAABvFaqvAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        EQAACxEBf2RfkQAAAAd0SU1FB90LGg8kOha4XJIAAAMOSURBVDhPrdHrS1NxGMDx/ohehVnWi4gKur4I
+        DwAACw8BkvkDpQAAAAd0SU1FB90LGg8kOha4XJIAAAMOSURBVDhPrdHrS1NxGMDx/ohehVnWi4gKur4I
         e5ck0cSiTMWE0HI6dWq7oGLTOfO2edyW052zzc3LtKl43TlnNzRteEvNzbMp5aUsE+dlXpIi0l9HCLcO
         QwWFL+fV83w4PL9jsN52mCoNhHFo1vF17bAQmQKzt/fNHAFEhuhtPqAaM1GgG77GQS+ltQfxjQzYKmkZ
         rjUTKtxOmfSOClUaxp6VWQMSUZqQeCqfCxLMBGZN3Ejvv5vXVdQ4vIf1H0Qqj4Rvz7O6Mxs2s3QgUQno

--- a/src/ServiceBusExplorer/Controls/ListenerControl.resx
+++ b/src/ServiceBusExplorer/Controls/ListenerControl.resx
@@ -124,7 +124,7 @@
   <data name="pictFindMessages.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAIAAABvFaqvAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        DwAACw8BkvkDpQAAAAd0SU1FB90LGg8kOha4XJIAAAMOSURBVDhPrdHrS1NxGMDx/ohehVnWi4gKur4I
+        DgAACw4BQL7hQQAAAAd0SU1FB90LGg8kOha4XJIAAAMOSURBVDhPrdHrS1NxGMDx/ohehVnWi4gKur4I
         e5ck0cSiTMWE0HI6dWq7oGLTOfO2edyW052zzc3LtKl43TlnNzRteEvNzbMp5aUsE+dlXpIi0l9HCLcO
         QwWFL+fV83w4PL9jsN52mCoNhHFo1vF17bAQmQKzt/fNHAFEhuhtPqAaM1GgG77GQS+ltQfxjQzYKmkZ
         rjUTKtxOmfSOClUaxp6VWQMSUZqQeCqfCxLMBGZN3Ejvv5vXVdQ4vIf1H0Qqj4Rvz7O6Mxs2s3QgUQno


### PR DESCRIPTION
I found out that the issue discussed in #712 only occurs when Azure.Messaging.ServiceBus is used.
I added UnitTest to show that the issue does not occur if you use Windows.AzureService.
I failed to reproduce exactly the error. I added a test that somehow emulates the error behavior. I do have not enough knowledge of what was changed between the two APIs. Also, the current Protobuf Nuget Package does not support 4.6.2 so i had to add the Protobuf message as a byte array :(

I ended up adding an additional menu item to resubmit a single message without changing the content.
I reused the code from the resubmit of multiple messages.
But that is just a workaround.

I manually tested re-submitting in Azure ServiceBus Queue and Topic and in both cases DLQ-Messages.
I was not able to manually test Azure Event Grid because I have no test environment.

Finally, I updated NUnit3TestAdapter to the newest version to locally run tests.