### PR TITLE
Add source configuration to choco push command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,4 +97,4 @@ jobs:
       env:
         CHOCO_TOKEN: ${{ secrets.CHOCO_TOKEN }}
       run: |
-        choco push $env:NupkgFilename -k="$env:CHOCO_TOKEN"
+        choco push $env:NupkgFilename -k="$env:CHOCO_TOKEN" --source=https://push.chocolatey.org/

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ $RECYCLE.BIN/
 
 # The new Debug Profile file
 /src/ServiceBusExplorer/Properties/launchSettings.json
+
+# VS code settings
+.vscode/settings.json


### PR DESCRIPTION
GitHub Actions was unable to upload the package to chocolatey. The error message is: 

> "Default push source configuration is not set. Please pass a source to push to, such as --source=https://push.chocolatey.org/"

Adding --source=https://push.chocolatey.org/ should put the package in the community feed, where it is located today.

As to the reason this happened my guess is the VM used for the build is using a newer version of choco that requires this parameter. 