### PR TITLE
Abstracting EventHubs EventData

### DIFF
--- a/src/Common/Abstractions/EventDataMessage.cs
+++ b/src/Common/Abstractions/EventDataMessage.cs
@@ -1,0 +1,50 @@
+﻿namespace ServiceBusExplorer.Abstractions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using Microsoft.Azure.Amqp;
+    using Microsoft.ServiceBus.Messaging;
+
+    public class EventDataMessage : IDisposable
+    {
+        readonly EventData eventData;
+        Stream stream;
+
+        public EventDataMessage(EventData eventData)
+        {
+            this.eventData = eventData;
+            stream = eventData.GetBodyStream();
+            Properties = eventData.Properties;
+            PartitionKey = eventData.PartitionKey;
+            SequenceNumber = eventData.SequenceNumber;
+            Offset = eventData.Offset;
+            SerializedSizeInBytes = eventData.SerializedSizeInBytes;
+            EnqueuedTimeUtc = eventData.EnqueuedTimeUtc;
+            SystemProperties = eventData.SystemProperties;
+        }
+
+        public string PartitionKey { get; private set; }
+        public long SequenceNumber { get; private set; }
+        public long SerializedSizeInBytes { get; private set; }
+        public string Offset { get; private set; }
+        public DateTime EnqueuedTimeUtc { get; private set; }
+        public IDictionary<string, object> Properties { get; private set; }
+        public IDictionary<string, object> SystemProperties { get; private set; }
+
+        public Stream GetBodyStream()
+        {
+            var memoryStream = new MemoryStream();
+
+            stream.CopyTo(memoryStream);
+            stream.Seek(0L, SeekOrigin.Begin);
+
+            return memoryStream;
+        }
+
+        public void Dispose()
+        {
+            eventData.Dispose();
+        }
+    }
+}

--- a/src/Common/Helpers/ServiceBusHelper.cs
+++ b/src/Common/Helpers/ServiceBusHelper.cs
@@ -1,20 +1,20 @@
 ﻿#region Copyright
 //=======================================================================================
-// Microsoft Azure Customer Advisory Team 
+// Microsoft Azure Customer Advisory Team
 //
 // This sample is supplemental to the technical guidance published on my personal
-// blog at http://blogs.msdn.com/b/paolos/. 
-// 
+// blog at http://blogs.msdn.com/b/paolos/.
+//
 // Author: Paolo Salvatori
 //=======================================================================================
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// 
-// LICENSED UNDER THE APACHE LICENSE, VERSION 2.0 (THE "LICENSE"); YOU MAY NOT USE THESE 
-// FILES EXCEPT IN COMPLIANCE WITH THE LICENSE. YOU MAY OBTAIN A COPY OF THE LICENSE AT 
+//
+// LICENSED UNDER THE APACHE LICENSE, VERSION 2.0 (THE "LICENSE"); YOU MAY NOT USE THESE
+// FILES EXCEPT IN COMPLIANCE WITH THE LICENSE. YOU MAY OBTAIN A COPY OF THE LICENSE AT
 // http://www.apache.org/licenses/LICENSE-2.0
-// UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, SOFTWARE DISTRIBUTED UNDER THE 
-// LICENSE IS DISTRIBUTED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
-// KIND, EITHER EXPRESS OR IMPLIED. SEE THE LICENSE FOR THE SPECIFIC LANGUAGE GOVERNING 
+// UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, SOFTWARE DISTRIBUTED UNDER THE
+// LICENSE IS DISTRIBUTED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED. SEE THE LICENSE FOR THE SPECIFIC LANGUAGE GOVERNING
 // PERMISSIONS AND LIMITATIONS UNDER THE LICENSE.
 //=======================================================================================
 #endregion
@@ -54,6 +54,7 @@ namespace ServiceBusExplorer
 {
     using System.IO.Compression;
     using System.Web.UI.WebControls;
+    using Abstractions;
     using ServiceBusConnectionStringBuilder = Microsoft.ServiceBus.ServiceBusConnectionStringBuilder;
 
     public enum BodyType
@@ -425,7 +426,7 @@ namespace ServiceBusExplorer
         public string ConnectionStringWithoutEntityPath
         {
             get
-            { 
+            {
                 var builder = new ServiceBusConnectionStringBuilder(connectionString)
                 {
                     EntityPath = string.Empty
@@ -700,7 +701,7 @@ namespace ServiceBusExplorer
                     TokenProvider = tokenProvider,
                     OperationTimeout = TimeSpan.FromMinutes(5)
                 };
-                // In the first release of the service bus, the only available transport protocol is sb 
+                // In the first release of the service bus, the only available transport protocol is sb
                 if (scheme == DefaultScheme)
                 {
                     messagingFactorySettings.NetMessagingTransportSettings = new NetMessagingTransportSettings();
@@ -734,16 +735,16 @@ namespace ServiceBusExplorer
                 throw new Exception($"Could not contact host in connection string: { serviceBusNamespace.ConnectionString }.");
             }
 
-            Func<bool> func = (() =>
+            var func = (() =>
             {
                 connectionString = serviceBusNamespace.ConnectionString;
                 currentSharedAccessKey = serviceBusNamespace.SharedAccessKey;
                 currentSharedAccessKeyName = serviceBusNamespace.SharedAccessKeyName;
                 currentTransportType = serviceBusNamespace.TransportType;
 
-                // The NamespaceManager class can be used for managing entities, 
-                // such as queues, topics, subscriptions, and rules, in your service namespace. 
-                // You must provide service namespace address and access credentials in order 
+                // The NamespaceManager class can be used for managing entities,
+                // such as queues, topics, subscriptions, and rules, in your service namespace.
+                // You must provide service namespace address and access credentials in order
                 // to manage your service namespace.
                 namespaceManager = Microsoft.ServiceBus.NamespaceManager.CreateFromConnectionString(ConnectionStringWithoutEntityPath);
 
@@ -809,7 +810,7 @@ namespace ServiceBusExplorer
         /// <summary>
         /// Retrieves an enumerable collection of all relays in the service bus namespace.
         /// </summary>
-        /// <returns>Returns an IEnumerable<RelayDescription/> collection of all relays in the service namespace. 
+        /// <returns>Returns an IEnumerable<RelayDescription/> collection of all relays in the service namespace.
         ///          Returns an empty collection if no relay exists in this service namespace.</returns>
         public IEnumerable<RelayDescription> GetRelays(int timeoutInSeconds)
         {
@@ -955,7 +956,7 @@ namespace ServiceBusExplorer
         /// <summary>
         /// Retrieves an enumerable collection of all event hubs in the service bus namespace.
         /// </summary>
-        /// <returns>Returns an IEnumerable<EventHubDescription/> collection of all event hubs in the service namespace. 
+        /// <returns>Returns an IEnumerable<EventHubDescription/> collection of all event hubs in the service namespace.
         ///          Returns an empty collection if no event hub exists in this service namespace.</returns>
         public Task<IEnumerable<EventHubDescription>> GetEventHubs(int timeoutInSeconds)
         {
@@ -1228,7 +1229,7 @@ namespace ServiceBusExplorer
         /// Retrieves the collection of consumer groups of the event hub passed as a parameter.
         /// </summary>
         /// <param name="eventHubPath">The path of a event hub.</param>
-        /// <param name="name">The name of a consumer group.</param> 
+        /// <param name="name">The name of a consumer group.</param>
         /// <returns>Returns an IEnumerable<SubscriptionDescription/> collection of consumer groups attached to the event hub passed as a parameter.</returns>
         public ConsumerGroupDescription GetConsumerGroup(string eventHubPath, string name)
         {
@@ -1419,7 +1420,7 @@ namespace ServiceBusExplorer
         /// <summary>
         /// Retrieves an enumerable collection of all notification hubs in the service bus namespace.
         /// </summary>
-        /// <returns>Returns an IEnumerable<NotificationHubDescription/> collection of all notification hubs in the service namespace. 
+        /// <returns>Returns an IEnumerable<NotificationHubDescription/> collection of all notification hubs in the service namespace.
         ///          Returns an empty collection if no notification hub exists in this service namespace.</returns>
         public IEnumerable<AzureNotificationHubs.NotificationHubDescription> GetNotificationHubs(int timeoutInSeconds)
         {
@@ -1554,8 +1555,8 @@ namespace ServiceBusExplorer
         /// <summary>
         /// Retrieves an enumerable collection of all queues in the service bus namespace.
         /// </summary>
-        /// <param name="filter">OData filter.</param> 
-        /// <returns>Returns an IEnumerable<QueueDescription/> collection of all queues in the service namespace. 
+        /// <param name="filter">OData filter.</param>
+        /// <returns>Returns an IEnumerable<QueueDescription/> collection of all queues in the service namespace.
         ///          Returns an empty collection if no queue exists in this service namespace.</returns>
         public IEnumerable<QueueDescription> GetQueues(string filter, int timeoutInSeconds)
         {
@@ -1648,8 +1649,8 @@ namespace ServiceBusExplorer
         /// <summary>
         /// Retrieves an enumerable collection of all message sessions for the queue passed as argument.
         /// </summary>
-        /// <param name="path">The queue for which to search message sessions.</param> 
-        /// <param name="dateTime">The time the session was last updated.</param> 
+        /// <param name="path">The queue for which to search message sessions.</param>
+        /// <param name="dateTime">The time the session was last updated.</param>
         /// <returns>Returns an IEnumerable<QueueDescription/> collection of message sessions.</returns>
         public IEnumerable<MessageSession> GetMessageSessions(string path, DateTime? dateTime)
         {
@@ -1669,8 +1670,8 @@ namespace ServiceBusExplorer
         /// <summary>
         /// Retrieves an enumerable collection of all message sessions for the queue passed as argument.
         /// </summary>
-        /// <param name="queue">The queue for which to search message sessions.</param> 
-        /// <param name="dateTime">The time the session was last updated.</param> 
+        /// <param name="queue">The queue for which to search message sessions.</param>
+        /// <param name="dateTime">The time the session was last updated.</param>
         /// <returns>Returns an IEnumerable<QueueDescription/> collection of message sessions.</returns>
         public IEnumerable<MessageSession> GetMessageSessions(QueueDescription queue, DateTime? dateTime)
         {
@@ -1708,8 +1709,8 @@ namespace ServiceBusExplorer
         /// <summary>
         /// Retrieves an enumerable collection of all topics in the service bus namespace.
         /// </summary>
-        /// <param name="filter">OData filter.</param> 
-        /// <returns>Returns an IEnumerable<TopicDescription/> collection of all topics in the service namespace. 
+        /// <param name="filter">OData filter.</param>
+        /// <returns>Returns an IEnumerable<TopicDescription/> collection of all topics in the service namespace.
         ///          Returns an empty collection if no topic exists in this service namespace.</returns>
         public IEnumerable<TopicDescription> GetTopics(string filter, int timeoutInSeconds)
         {
@@ -1848,8 +1849,8 @@ namespace ServiceBusExplorer
         /// <summary>
         /// Retrieves an enumerable collection of all message sessions for the subscription passed as argument.
         /// </summary>
-        /// <param name="subscription">The subscription for which to search message sessions.</param> 
-        /// <param name="dateTime">The time the session was last updated.</param> 
+        /// <param name="subscription">The subscription for which to search message sessions.</param>
+        /// <param name="dateTime">The time the session was last updated.</param>
         /// <returns>Returns an IEnumerable<QueueDescription/> collection of message sessions.</returns>
         public IEnumerable<MessageSession> GetMessageSessions(SubscriptionDescription subscription, DateTime? dateTime)
         {
@@ -2515,7 +2516,7 @@ namespace ServiceBusExplorer
                                                                                                            subscriptionDescription.Name),
                                                                                                            writeToLog);
             RetryHelper.RetryAction(() => subscriptionClient.AddRule(ruleDescription), writeToLog);
-            Func<IEnumerable<RuleDescription>> func = (() => namespaceManager.GetRules(subscriptionDescription.TopicPath, subscriptionDescription.Name));
+            var func = (() => namespaceManager.GetRules(subscriptionDescription.TopicPath, subscriptionDescription.Name));
             var rules = RetryHelper.RetryFunc(func, writeToLog);
             var rule = rules.FirstOrDefault(r => r.Name == ruleDescription.Name);
             WriteToLogIf(traceEnabled, string.Format(CultureInfo.CurrentCulture, RuleCreated, ruleDescription.Name, subscriptionDescription.Name));
@@ -5057,7 +5058,7 @@ namespace ServiceBusExplorer
         /// <param name="bodyType">BodyType</param>
         /// <param name="doNotSerializeBody"></param>
         /// <returns>The content of the EventData.</returns>
-        public string GetMessageText(EventData eventDataToRead, out BodyType bodyType, bool doNotSerializeBody = false)
+        public string GetMessageText(EventDataMessage eventDataToRead, out BodyType bodyType, bool doNotSerializeBody = false)
         {
             string eventDataText = null;
             bodyType = BodyType.Stream;

--- a/src/ServiceBus/Helpers/ServiceBusPurger.cs
+++ b/src/ServiceBus/Helpers/ServiceBusPurger.cs
@@ -1,20 +1,20 @@
 ﻿#region Copyright
 //=======================================================================================
-// Microsoft Azure Customer Advisory Team 
+// Microsoft Azure Customer Advisory Team
 //
 // This sample is supplemental to the technical guidance published on my personal
-// blog at http://blogs.msdn.com/b/paolos/. 
-// 
+// blog at http://blogs.msdn.com/b/paolos/.
+//
 // Author: Paolo Salvatori
 //=======================================================================================
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// 
-// LICENSED UNDER THE APACHE LICENSE, VERSION 2.0 (THE "LICENSE"); YOU MAY NOT USE THESE 
-// FILES EXCEPT IN COMPLIANCE WITH THE LICENSE. YOU MAY OBTAIN A COPY OF THE LICENSE AT 
+//
+// LICENSED UNDER THE APACHE LICENSE, VERSION 2.0 (THE "LICENSE"); YOU MAY NOT USE THESE
+// FILES EXCEPT IN COMPLIANCE WITH THE LICENSE. YOU MAY OBTAIN A COPY OF THE LICENSE AT
 // http://www.apache.org/licenses/LICENSE-2.0
-// UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, SOFTWARE DISTRIBUTED UNDER THE 
-// LICENSE IS DISTRIBUTED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
-// KIND, EITHER EXPRESS OR IMPLIED. SEE THE LICENSE FOR THE SPECIFIC LANGUAGE GOVERNING 
+// UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, SOFTWARE DISTRIBUTED UNDER THE
+// LICENSE IS DISTRIBUTED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED. SEE THE LICENSE FOR THE SPECIFIC LANGUAGE GOVERNING
 // PERMISSIONS AND LIMITATIONS UNDER THE LICENSE.
 //=======================================================================================
 #endregion
@@ -100,7 +100,6 @@ namespace ServiceBusExplorer.ServiceBus.Helpers
         {
             long totalMessagesPurged = 0;
             var consecutiveSessionTimeOuts = 0;
-            ServiceBusSessionReceiver sessionReceiver = null;
             long messagesToPurgeCount = await GetMessageCount(entity, deadLetterQueueData: false)
                 .ConfigureAwait(false);
 
@@ -117,9 +116,9 @@ namespace ServiceBusExplorer.ServiceBus.Helpers
 
                 while (consecutiveSessionTimeOuts < enoughZeroReceives && totalMessagesPurged < messagesToPurgeCount)
                 {
-                    sessionReceiver = await CreateServiceBusSessionReceiver(entity,
-                        client,
-                        purgeDeadLetterQueueInstead: false)
+                    var sessionReceiver = await CreateServiceBusSessionReceiver(entity,
+                            client,
+                            purgeDeadLetterQueueInstead: false)
                         .ConfigureAwait(false);
 
                     var consecutiveZeroBatchReceives = 0;
@@ -236,7 +235,7 @@ namespace ServiceBusExplorer.ServiceBus.Helpers
                                 await receiver.CloseAsync().ConfigureAwait(false);
                             }
                         }
-                    });  // End of lambda 
+                    });  // End of lambda
                 }
 
                 await Task.WhenAll(tasks).ConfigureAwait(false);

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -235,7 +235,6 @@ namespace ServiceBusExplorer.Controls
 
         private QueueDescription queueDescription = default!;
         private readonly ServiceBusHelper serviceBusHelper = default!;
-        private readonly ServiceBusHelper2 serviceBusHelper2 = default!;
         private readonly WriteToLogDelegate writeToLog = default!;
         private readonly string path = default!;
         private readonly List<TabPage> hiddenPages = new List<TabPage>();
@@ -297,9 +296,9 @@ namespace ServiceBusExplorer.Controls
         {
             this.writeToLog = writeToLog;
             this.serviceBusHelper = serviceBusHelper;
-            this.serviceBusHelper2 = serviceBusHelper.GetServiceBusHelper2();
             this.path = path;
             this.queueDescription = queueDescription;
+            var serviceBusHelper2 = serviceBusHelper.GetServiceBusHelper2();
 
             if (!serviceBusHelper2.ConnectionStringContainsEntityPath())
             {

--- a/src/ServiceBusExplorer/Controls/HandleTopicControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleTopicControl.cs
@@ -125,7 +125,6 @@ namespace ServiceBusExplorer.Controls
         private readonly List<TabPage> hiddenPages = new List<TabPage>();
         private TopicDescription topicDescription;
         private readonly ServiceBusHelper serviceBusHelper;
-        private readonly ServiceBusHelper2 serviceBusHelper2 = default!;
         private readonly WriteToLogDelegate writeToLog;
         private readonly bool premiumNamespace;
         private readonly string path;
@@ -153,7 +152,7 @@ namespace ServiceBusExplorer.Controls
         {
             this.writeToLog = writeToLog;
             this.serviceBusHelper = serviceBusHelper;
-            this.serviceBusHelper2 = serviceBusHelper.GetServiceBusHelper2();
+            var serviceBusHelper2 = serviceBusHelper.GetServiceBusHelper2();
             
             if (!serviceBusHelper2.ConnectionStringContainsEntityPath())
             {

--- a/src/ServiceBusExplorer/Controls/PartitionListenerControl.cs
+++ b/src/ServiceBusExplorer/Controls/PartitionListenerControl.cs
@@ -644,11 +644,30 @@ namespace ServiceBusExplorer.Controls
             currentEventData = bindingList[e.RowIndex];
             eventDataPropertyGrid.SelectedObject = currentEventData;
 
-            LanguageDetector.SetFormattedMessage(serviceBusHelper, currentEventData.Clone(), txtMessageText);
+            try
+            {
+                //var eventData = currentEventData.Clone();
+                LanguageDetector.SetFormattedMessage(serviceBusHelper, currentEventData, txtMessageText);
+            }
+            catch (Exception exception)
+            {
+                HandleException(exception);
+            }
 
-            var listViewItems = currentEventData.Properties.Select(p => new ListViewItem(new[] { p.Key, (p.Value ?? string.Empty).ToString() })).ToArray();
-            eventDataPropertyListView.Items.Clear();
-            eventDataPropertyListView.Items.AddRange(listViewItems);
+            try
+            {
+                var type = typeof(EventData);
+                var fieldInfo = type.GetField("properties", BindingFlags.Instance | BindingFlags.NonPublic);
+                var value = fieldInfo.GetValue(currentEventData);
+
+                var listViewItems = currentEventData.Properties.Select(p => new ListViewItem(new[] { p.Key, (p.Value ?? string.Empty).ToString() })).ToArray();
+                eventDataPropertyListView.Items.Clear();
+                eventDataPropertyListView.Items.AddRange(listViewItems);
+            }
+            catch (Exception exception)
+            {
+                HandleException(exception);
+            }
         }
 
         private void tabPageMessages_Resize(object sender, EventArgs e)

--- a/src/ServiceBusExplorer/Controls/PartitionListenerControl.cs
+++ b/src/ServiceBusExplorer/Controls/PartitionListenerControl.cs
@@ -658,11 +658,6 @@ namespace ServiceBusExplorer.Controls
 
             try
             {
-                // Investigation: Properties throws OOTB. Can access the member field but it has no values.
-                // var type = typeof(EventData);
-                // var fieldInfo = type.GetField("properties", BindingFlags.Instance | BindingFlags.NonPublic);
-                // var value = fieldInfo.GetValue(currentEventData);
-
                 var listViewItems = currentEventData.Properties.Select(p => new ListViewItem(new[] { p.Key, (p.Value ?? string.Empty).ToString() })).ToArray();
                 eventDataPropertyListView.Items.Clear();
                 eventDataPropertyListView.Items.AddRange(listViewItems);
@@ -1523,7 +1518,7 @@ EventProcessorCheckpointHelper.GetLease(ns, eventHub, consumerGroup.GroupName, p
                 {
                     return;
                 }
-                var bindingList = eventDataBindingSource.DataSource as BindingList<EventData>;
+                var bindingList = eventDataBindingSource.DataSource as BindingList<EventDataMessage>;
                 if (bindingList == null)
                 {
                     return;

--- a/src/ServiceBusExplorer/Controls/PartitionListenerControl.cs
+++ b/src/ServiceBusExplorer/Controls/PartitionListenerControl.cs
@@ -1,20 +1,20 @@
 ﻿#region Copyright
 //=======================================================================================
-// Microsoft Azure Customer Advisory Team 
+// Microsoft Azure Customer Advisory Team
 //
 // This sample is supplemental to the technical guidance published on my personal
-// blog at http://blogs.msdn.com/b/paolos/. 
-// 
+// blog at http://blogs.msdn.com/b/paolos/.
+//
 // Author: Paolo Salvatori
 //=======================================================================================
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// 
-// LICENSED UNDER THE APACHE LICENSE, VERSION 2.0 (THE "LICENSE"); YOU MAY NOT USE THESE 
-// FILES EXCEPT IN COMPLIANCE WITH THE LICENSE. YOU MAY OBTAIN A COPY OF THE LICENSE AT 
+//
+// LICENSED UNDER THE APACHE LICENSE, VERSION 2.0 (THE "LICENSE"); YOU MAY NOT USE THESE
+// FILES EXCEPT IN COMPLIANCE WITH THE LICENSE. YOU MAY OBTAIN A COPY OF THE LICENSE AT
 // http://www.apache.org/licenses/LICENSE-2.0
-// UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, SOFTWARE DISTRIBUTED UNDER THE 
-// LICENSE IS DISTRIBUTED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
-// KIND, EITHER EXPRESS OR IMPLIED. SEE THE LICENSE FOR THE SPECIFIC LANGUAGE GOVERNING 
+// UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, SOFTWARE DISTRIBUTED UNDER THE
+// LICENSE IS DISTRIBUTED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED. SEE THE LICENSE FOR THE SPECIFIC LANGUAGE GOVERNING
 // PERMISSIONS AND LIMITATIONS UNDER THE LICENSE.
 //=======================================================================================
 #endregion
@@ -315,12 +315,12 @@ namespace ServiceBusExplorer.Controls
             eventDataDataGridView.DefaultCellStyle.SelectionBackColor = Color.FromArgb(92, 125, 150);
             eventDataDataGridView.DefaultCellStyle.SelectionForeColor = SystemColors.Window;
 
-            // Set RowHeadersDefaultCellStyle.SelectionBackColor so that its default 
+            // Set RowHeadersDefaultCellStyle.SelectionBackColor so that its default
             // value won't override DataGridView.DefaultCellStyle.SelectionBackColor.
             eventDataDataGridView.RowHeadersDefaultCellStyle.SelectionBackColor = Color.FromArgb(153, 180, 209);
 
-            // Set the background color for all rows and for alternating rows.  
-            // The value for alternating rows overrides the value for all rows. 
+            // Set the background color for all rows and for alternating rows.
+            // The value for alternating rows overrides the value for all rows.
             eventDataDataGridView.RowsDefaultCellStyle.BackColor = SystemColors.Window;
             eventDataDataGridView.RowsDefaultCellStyle.ForeColor = SystemColors.ControlText;
             //eventDataDataGridView.AlternatingRowsDefaultCellStyle.BackColor = Color.White;
@@ -656,9 +656,10 @@ namespace ServiceBusExplorer.Controls
 
             try
             {
-                var type = typeof(EventData);
-                var fieldInfo = type.GetField("properties", BindingFlags.Instance | BindingFlags.NonPublic);
-                var value = fieldInfo.GetValue(currentEventData);
+                // Investigation: Properties throws OOTB. Can access the member field but it has no values.
+                // var type = typeof(EventData);
+                // var fieldInfo = type.GetField("properties", BindingFlags.Instance | BindingFlags.NonPublic);
+                // var value = fieldInfo.GetValue(currentEventData);
 
                 var listViewItems = currentEventData.Properties.Select(p => new ListViewItem(new[] { p.Key, (p.Value ?? string.Empty).ToString() })).ToArray();
                 eventDataPropertyListView.Items.Clear();
@@ -1185,8 +1186,8 @@ EventProcessorCheckpointHelper.GetLease(ns, eventHub, consumerGroup.GroupName, p
                         if (InvokeRequired)
                         {
                             Invoke(new Action<long, long, long, bool>(InternalUpdateStatistics),
-                                   new object[] { receiveTuple.Item1, 
-                                                  receiveTuple.Item2, 
+                                   new object[] { receiveTuple.Item1,
+                                                  receiveTuple.Item2,
                                                   receiveTuple.Item3,
                                                   graph});
                         }
@@ -1357,7 +1358,7 @@ EventProcessorCheckpointHelper.GetLease(ns, eventHub, consumerGroup.GroupName, p
                                    cboReceiverInspector.Size.Height + 1);
         }
 
-        /// <summary> 
+        /// <summary>
         /// Clean up any resources being used.
         /// </summary>
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>

--- a/src/ServiceBusExplorer/Forms/EventDataForm.cs
+++ b/src/ServiceBusExplorer/Forms/EventDataForm.cs
@@ -1,20 +1,20 @@
 ﻿#region Copyright
 //=======================================================================================
-// Microsoft Azure Customer Advisory Team 
+// Microsoft Azure Customer Advisory Team
 //
 // This sample is supplemental to the technical guidance published on my personal
-// blog at http://blogs.msdn.com/b/paolos/. 
-// 
+// blog at http://blogs.msdn.com/b/paolos/.
+//
 // Author: Paolo Salvatori
 //=======================================================================================
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// 
-// LICENSED UNDER THE APACHE LICENSE, VERSION 2.0 (THE "LICENSE"); YOU MAY NOT USE THESE 
-// FILES EXCEPT IN COMPLIANCE WITH THE LICENSE. YOU MAY OBTAIN A COPY OF THE LICENSE AT 
+//
+// LICENSED UNDER THE APACHE LICENSE, VERSION 2.0 (THE "LICENSE"); YOU MAY NOT USE THESE
+// FILES EXCEPT IN COMPLIANCE WITH THE LICENSE. YOU MAY OBTAIN A COPY OF THE LICENSE AT
 // http://www.apache.org/licenses/LICENSE-2.0
-// UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, SOFTWARE DISTRIBUTED UNDER THE 
-// LICENSE IS DISTRIBUTED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
-// KIND, EITHER EXPRESS OR IMPLIED. SEE THE LICENSE FOR THE SPECIFIC LANGUAGE GOVERNING 
+// UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, SOFTWARE DISTRIBUTED UNDER THE
+// LICENSE IS DISTRIBUTED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED. SEE THE LICENSE FOR THE SPECIFIC LANGUAGE GOVERNING
 // PERMISSIONS AND LIMITATIONS UNDER THE LICENSE.
 //=======================================================================================
 #endregion
@@ -38,6 +38,8 @@ using ServiceBusExplorer.Utilities.Helpers;
 
 namespace ServiceBusExplorer.Forms
 {
+    using Abstractions;
+
     public partial class EventDataForm : Form
     {
         #region Private Constants
@@ -67,7 +69,7 @@ namespace ServiceBusExplorer.Forms
         private readonly ServiceBusHelper serviceBusHelper;
         private readonly WriteToLogDelegate writeToLog;
         private readonly BindingSource bindingSource = new BindingSource();
-        private readonly EventData eventData;
+        private readonly EventDataMessage eventData;
         #endregion
 
         #region Private Static Fields
@@ -75,7 +77,7 @@ namespace ServiceBusExplorer.Forms
         #endregion
 
         #region Public Constructor
-        public EventDataForm(EventData eventData, ServiceBusHelper serviceBusHelper, WriteToLogDelegate writeToLog)
+        public EventDataForm(EventDataMessage eventData, ServiceBusHelper serviceBusHelper, WriteToLogDelegate writeToLog)
         {
             this.eventData = eventData;
             this.serviceBusHelper = serviceBusHelper;
@@ -102,7 +104,7 @@ namespace ServiceBusExplorer.Forms
             }
 
             // Initialize the DataGridView.
-            bindingSource.DataSource = new BindingList<MessagePropertyInfo>(eventData.Properties.Select(p => new MessagePropertyInfo(p.Key, 
+            bindingSource.DataSource = new BindingList<MessagePropertyInfo>(eventData.Properties.Select(p => new MessagePropertyInfo(p.Key,
                                                                                                       p.Value.GetType().ToString().Substring(7),
                                                                                                       p.Value)).ToList());
             propertiesDataGridView.AutoGenerateColumns = false;
@@ -146,12 +148,12 @@ namespace ServiceBusExplorer.Forms
             propertiesDataGridView.DefaultCellStyle.SelectionBackColor = Color.FromArgb(92, 125, 150);
             propertiesDataGridView.DefaultCellStyle.SelectionForeColor = SystemColors.Window;
 
-            // Set RowHeadersDefaultCellStyle.SelectionBackColor so that its default 
+            // Set RowHeadersDefaultCellStyle.SelectionBackColor so that its default
             // value won't override DataGridView.DefaultCellStyle.SelectionBackColor.
             propertiesDataGridView.RowHeadersDefaultCellStyle.SelectionBackColor = Color.FromArgb(153, 180, 209);
 
-            // Set the background color for all rows and for alternating rows.  
-            // The value for alternating rows overrides the value for all rows. 
+            // Set the background color for all rows and for alternating rows.
+            // The value for alternating rows overrides the value for all rows.
             propertiesDataGridView.RowsDefaultCellStyle.BackColor = SystemColors.Window;
             propertiesDataGridView.RowsDefaultCellStyle.ForeColor = SystemColors.ControlText;
             //propertiesDataGridView.AlternatingRowsDefaultCellStyle.BackColor = Color.White;
@@ -286,7 +288,7 @@ namespace ServiceBusExplorer.Forms
                                  CultureInfo.CurrentCulture.TextInfo.ToTitleCase(serviceBusHelper.Namespace),
                                  DateTime.Now.ToString(CultureInfo.InvariantCulture).Replace('/', '-').Replace(':', '-'));
         }
-        
+
         private void propertiesDataGridView_DataError(object sender, DataGridViewDataErrorEventArgs e)
         {
             e.Cancel = true;

--- a/src/ServiceBusExplorer/UIHelpers/LanguageDetector.cs
+++ b/src/ServiceBusExplorer/UIHelpers/LanguageDetector.cs
@@ -1,21 +1,21 @@
 ﻿#region Copyright
 
 //=======================================================================================
-// Microsoft Azure Customer Advisory Team 
+// Microsoft Azure Customer Advisory Team
 //
 // This sample is supplemental to the technical guidance published on my personal
-// blog at http://blogs.msdn.com/b/paolos/. 
-// 
+// blog at http://blogs.msdn.com/b/paolos/.
+//
 // Author: Paolo Salvatori
 //=======================================================================================
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// 
-// LICENSED UNDER THE APACHE LICENSE, VERSION 2.0 (THE "LICENSE"); YOU MAY NOT USE THESE 
-// FILES EXCEPT IN COMPLIANCE WITH THE LICENSE. YOU MAY OBTAIN A COPY OF THE LICENSE AT 
+//
+// LICENSED UNDER THE APACHE LICENSE, VERSION 2.0 (THE "LICENSE"); YOU MAY NOT USE THESE
+// FILES EXCEPT IN COMPLIANCE WITH THE LICENSE. YOU MAY OBTAIN A COPY OF THE LICENSE AT
 // http://www.apache.org/licenses/LICENSE-2.0
-// UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, SOFTWARE DISTRIBUTED UNDER THE 
-// LICENSE IS DISTRIBUTED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
-// KIND, EITHER EXPRESS OR IMPLIED. SEE THE LICENSE FOR THE SPECIFIC LANGUAGE GOVERNING 
+// UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING, SOFTWARE DISTRIBUTED UNDER THE
+// LICENSE IS DISTRIBUTED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED. SEE THE LICENSE FOR THE SPECIFIC LANGUAGE GOVERNING
 // PERMISSIONS AND LIMITATIONS UNDER THE LICENSE.
 //=======================================================================================
 
@@ -35,6 +35,8 @@ using ServiceBusExplorer.Utilities.Helpers;
 
 namespace ServiceBusExplorer.UIHelpers
 {
+    using Abstractions;
+
     public class LanguageDetector
     {
         #region Public Static Methods
@@ -55,11 +57,11 @@ namespace ServiceBusExplorer.UIHelpers
                 throw new ArgumentNullException(nameof(textBox), $"{nameof(textBox)} parameter cannot be null");
             }
 
-            InternalSetFormattedMessage(serviceBusHelper.GetMessageText(message, 
+            InternalSetFormattedMessage(serviceBusHelper.GetMessageText(message,
                 MainForm.SingletonMainForm.UseAscii, out _), textBox);
         }
 
-        public static void SetFormattedMessage(ServiceBusHelper serviceBusHelper, EventData message, FastColoredTextBox textBox)
+        public static void SetFormattedMessage(ServiceBusHelper serviceBusHelper, EventDataMessage message, FastColoredTextBox textBox)
         {
             if (serviceBusHelper == null)
             {


### PR DESCRIPTION
Fixes #720 #738 #638 

A breaking change was introduced in the track 0 SDK `WindowsAzure.ServiceBus` somewhere after version `6.0.3`. As a result of that, it broke SBE ability to clone EventHub messages for UI purposes. This PR is a workaround for the issue to allow rendering EH messages, its custom and system properties, w/o throwing exceptions.

https://github.com/paolosalvatori/ServiceBusExplorer/assets/1309622/95ebead3-8968-403c-b5b6-30ce443253c5

Disclaimer: I have not tested all the permutations of what can be done with EH. I would appreciate it if someone could take a look to see if there are any undesirable side effects. This is merely an attempt to unblock those who need to be able to list and evaluate messages sent to EH.

