### PR TITLE
Add the ability to cancel scheduled messages

### DIFF
--- a/src/Common/Helpers/ServiceBusHelper.cs
+++ b/src/Common/Helpers/ServiceBusHelper.cs
@@ -5337,7 +5337,7 @@ namespace ServiceBusExplorer
 
         public ServiceBusHelper2 GetServiceBusHelper2()
         {
-            var serviceBusHelper2 = new ServiceBusHelper2();
+            var serviceBusHelper2 = new ServiceBusHelper2(writeToLog);
             serviceBusHelper2.ConnectionString = ConnectionString;
             serviceBusHelper2.TransportType = UseAmqpWebSockets
                 ? Azure.Messaging.ServiceBus.ServiceBusTransportType.AmqpWebSockets

--- a/src/ServiceBus/Helpers/CancelScheduledMessagesHelper.cs
+++ b/src/ServiceBus/Helpers/CancelScheduledMessagesHelper.cs
@@ -1,6 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
+
+using Azure.Messaging.ServiceBus;
+
+using ServiceBusExplorer.Utilities.Helpers;
 
 namespace ServiceBusExplorer.ServiceBus.Helpers
 {
@@ -10,23 +15,39 @@ namespace ServiceBusExplorer.ServiceBus.Helpers
             string queueName, List<long> sequenceNumbersToCancel)
         {
             var client = serviceBusHelper.CreateServiceBusClient();
-            var sender = client.CreateSender(queueName);
 
-            serviceBusHelper.WriteToLog($"Starting cancellation of scheduled messages on queue {queueName}.");
-
-            var stopwatch = Stopwatch.StartNew();
-
-            // Got lots of Azure.Messaging.ServiceBus.ServiceBusExceptions and the UI stopped working when testing 
-            // with 1000 messages when calling using Task.WhenAll. So, doing it one by one instead.
-            foreach (var sequenceNumber in sequenceNumbersToCancel)
+            try
             {
-                await sender.CancelScheduledMessageAsync(sequenceNumber);
-                serviceBusHelper.WriteToLog($"Cancelled scheduled message with sequence number {sequenceNumber}.");
+                var sender = client.CreateSender(queueName);
+
+                serviceBusHelper.WriteToLog($"Starting cancellation of scheduled messages on queue {queueName}.");
+
+                var stopwatch = Stopwatch.StartNew();
+                var semaphore = new SemaphoreSlim(40); // As recommended by https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#settling-send-operations
+                var tasks = new List<Task>(sequenceNumbersToCancel.Count);
+
+                foreach (long sequenceNumber in sequenceNumbersToCancel)
+                {
+                    await semaphore.WaitAsync();
+                    tasks.Add(CancelScheduledMessageWithLogAsync(sender, sequenceNumber, serviceBusHelper.WriteToLog)
+                        .ContinueWith((t) => semaphore.Release()));
+                }
+
+                await Task.WhenAll(tasks);
+                stopwatch.Stop();
+                serviceBusHelper.WriteToLog($"Cancelled {sequenceNumbersToCancel.Count} scheduled message(s) in {stopwatch.ElapsedMilliseconds / 1000} seconds.");
             }
+            finally
+            {
+               await client.DisposeAsync();
+            }
+        }
 
-            stopwatch.Stop();
-
-            serviceBusHelper.WriteToLog($"Cancelled {sequenceNumbersToCancel.Count} scheduled message(s) in {stopwatch.ElapsedMilliseconds / 1000} seconds.");
+        static async Task CancelScheduledMessageWithLogAsync(ServiceBusSender sender, 
+            long sequenceNumber, WriteToLogDelegate writeToLog)
+        {
+            await sender.CancelScheduledMessageAsync(sequenceNumber);
+            writeToLog($"Cancelled scheduled message with sequence number {sequenceNumber}.");
         }
     }
 }

--- a/src/ServiceBus/Helpers/CancelScheduledMessagesHelper.cs
+++ b/src/ServiceBus/Helpers/CancelScheduledMessagesHelper.cs
@@ -35,7 +35,8 @@ namespace ServiceBusExplorer.ServiceBus.Helpers
 
                 await Task.WhenAll(tasks);
                 stopwatch.Stop();
-                serviceBusHelper.WriteToLog($"Cancelled {sequenceNumbersToCancel.Count} scheduled message(s) in {stopwatch.ElapsedMilliseconds / 1000} seconds.");
+                Func<string> singleOrPlural = () => sequenceNumbersToCancel.Count() > 1 ? "messages": "message";
+                serviceBusHelper.WriteToLog($"Cancelled {sequenceNumbersToCancel.Count} scheduled {singleOrPlural()} in {stopwatch.Elapsed}.");
             }
             finally
             {

--- a/src/ServiceBus/Helpers/CancelScheduledMessagesHelper.cs
+++ b/src/ServiceBus/Helpers/CancelScheduledMessagesHelper.cs
@@ -46,8 +46,10 @@ namespace ServiceBusExplorer.ServiceBus.Helpers
         static async Task CancelScheduledMessageWithLogAsync(ServiceBusSender sender, 
             long sequenceNumber, WriteToLogDelegate writeToLog)
         {
-            await sender.CancelScheduledMessageAsync(sequenceNumber);
-            writeToLog($"Cancelled scheduled message with sequence number {sequenceNumber}.");
+            var task = sender.CancelScheduledMessageAsync(sequenceNumber).ContinueWith(
+               (t, state) => writeToLog($"Cancelled scheduled message with sequence number {state}."),
+                sequenceNumber);
+            return task;
         }
     }
 }

--- a/src/ServiceBus/Helpers/CancelScheduledMessagesHelper.cs
+++ b/src/ServiceBus/Helpers/CancelScheduledMessagesHelper.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace ServiceBusExplorer.ServiceBus.Helpers
+{
+    public static class CancelScheduledMessagesHelper
+    {
+        public static async Task CancelScheduledMessages(ServiceBusHelper2 serviceBusHelper,
+            string queueName, List<long> sequenceNumbersToCancel)
+        {
+            var client = serviceBusHelper.CreateServiceBusClient();
+            var sender = client.CreateSender(queueName);
+
+            serviceBusHelper.WriteToLog($"Starting cancellation of scheduled messages on queue {queueName}.");
+
+            var stopwatch = Stopwatch.StartNew();
+
+            // Got lots of Azure.Messaging.ServiceBus.ServiceBusExceptions and the UI stopped working when testing 
+            // with 1000 messages when calling using Task.WhenAll. So, doing it one by one instead.
+            foreach (var sequenceNumber in sequenceNumbersToCancel)
+            {
+                await sender.CancelScheduledMessageAsync(sequenceNumber);
+                serviceBusHelper.WriteToLog($"Cancelled scheduled message with sequence number {sequenceNumber}.");
+            }
+
+            stopwatch.Stop();
+
+            serviceBusHelper.WriteToLog($"Cancelled {sequenceNumbersToCancel.Count} scheduled message(s) in {stopwatch.ElapsedMilliseconds / 1000} seconds.");
+        }
+    }
+}

--- a/src/ServiceBus/Helpers/CancelScheduledMessagesHelper.cs
+++ b/src/ServiceBus/Helpers/CancelScheduledMessagesHelper.cs
@@ -30,7 +30,7 @@ namespace ServiceBusExplorer.ServiceBus.Helpers
                 {
                     await semaphore.WaitAsync();
                     tasks.Add(CancelScheduledMessageWithLogAsync(sender, sequenceNumber, serviceBusHelper.WriteToLog)
-                        .ContinueWith((t) => semaphore.Release()));
+                        .ContinueWith((t, state) => ((SemaphoreSlim)state)?.Release()));
                 }
 
                 await Task.WhenAll(tasks);

--- a/src/ServiceBus/Helpers/CancelScheduledMessagesHelper.cs
+++ b/src/ServiceBus/Helpers/CancelScheduledMessagesHelper.cs
@@ -45,15 +45,16 @@ namespace ServiceBusExplorer.ServiceBus.Helpers
                 await Task.WhenAll(tasks);
                 stopwatch.Stop();
 
-                Func<string> successesSingleOrPlural = () => successes.Count > 1 ? "messages" : "message";
+                Func<int, string> singleOrPlural = (c) => c > 1 ? "messages" : "message";
 
-                serviceBusHelper.WriteToLog($"Successfully cancelled {successes.Count} scheduled {successesSingleOrPlural()} in {stopwatch.Elapsed}.");
+
+                serviceBusHelper.WriteToLog($"Successfully cancelled {successes.Count} " +
+                    $"scheduled {singleOrPlural(successes.Count)} in {stopwatch.Elapsed}.");
 
                 if (failures.Count > 0)
                 {
-                    Func<string> failuresSingleOrPlural = () => failures.Count > 1 ? "messages" : "message";
-
-                    serviceBusHelper.WriteToLog($"Failed to cancel {failures.Count} {failuresSingleOrPlural()}.");
+                    serviceBusHelper.WriteToLog($"Failed to cancel {failures.Count} " +
+                        $"{singleOrPlural(failures.Count)}.");
                 }
             }
             finally

--- a/src/ServiceBus/Helpers/ServiceBusHelper2.cs
+++ b/src/ServiceBus/Helpers/ServiceBusHelper2.cs
@@ -62,9 +62,8 @@ namespace ServiceBusExplorer.ServiceBus.Helpers
             return false;
         }
 
-        // 
         /// <summary>
-        ///  It is the callers responsibility to dispose the returned ServiceBusClient object by calling DisposeAsync() on it.
+        ///  Dispose of the returned ServiceBusClient object by calling DisposeAsync().
         /// </summary>
         /// <returns>An Azure.Messaging.ServiceBus.ServiceBusClient</returns>
         public ServiceBusClient CreateServiceBusClient()

--- a/src/ServiceBus/Helpers/ServiceBusHelper2.cs
+++ b/src/ServiceBus/Helpers/ServiceBusHelper2.cs
@@ -62,7 +62,11 @@ namespace ServiceBusExplorer.ServiceBus.Helpers
             return false;
         }
 
-        // Remember to dispose of the client after use, using client.DisposeAsync()
+        // 
+        /// <summary>
+        ///  It is the callers responsibility to dispose the returned ServiceBusClient object by calling DisposeAsync() on it.
+        /// </summary>
+        /// <returns>An Azure.Messaging.ServiceBus.ServiceBusClient</returns>
         public ServiceBusClient CreateServiceBusClient()
         {
             return new ServiceBusClient(

--- a/src/ServiceBus/Helpers/ServiceBusHelper2.cs
+++ b/src/ServiceBus/Helpers/ServiceBusHelper2.cs
@@ -34,7 +34,6 @@ namespace ServiceBusExplorer.ServiceBus.Helpers
     {
         readonly WriteToLogDelegate writeToLog;
 
-
         public string ConnectionString { get; set; }
         public ServiceBusTransportType TransportType { get; set; }
 
@@ -46,7 +45,7 @@ namespace ServiceBusExplorer.ServiceBus.Helpers
             }
         }
 
-        private ServiceBusHelper2(WriteToLogDelegate writeToLog)
+        public ServiceBusHelper2(WriteToLogDelegate writeToLog)
         {
             this.writeToLog = writeToLog;
         }

--- a/src/ServiceBus/Helpers/ServiceBusHelper2.cs
+++ b/src/ServiceBus/Helpers/ServiceBusHelper2.cs
@@ -20,8 +20,11 @@
 #endregion
 
 using System.Threading.Tasks;
+
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
+
+using ServiceBusExplorer.Utilities.Helpers;
 
 // ReSharper disable CheckNamespace
 namespace ServiceBusExplorer.ServiceBus.Helpers
@@ -29,19 +32,42 @@ namespace ServiceBusExplorer.ServiceBus.Helpers
 {
     public class ServiceBusHelper2
     {
+        readonly WriteToLogDelegate writeToLog;
+
+
         public string ConnectionString { get; set; }
         public ServiceBusTransportType TransportType { get; set; }
+
+        public WriteToLogDelegate WriteToLog
+        {
+            get
+            {
+                return writeToLog;
+            }
+        }
+
+        private ServiceBusHelper2(WriteToLogDelegate writeToLog)
+        {
+            this.writeToLog = writeToLog;
+        }
 
         public bool ConnectionStringContainsEntityPath()
         {
             var connectionStringProperties = ServiceBusConnectionStringProperties.Parse(ConnectionString);
-            
+
             if (connectionStringProperties?.EntityPath != null)
             {
                 return true;
             }
 
             return false;
+        }
+
+        public ServiceBusClient CreateServiceBusClient()
+        {
+            return new ServiceBusClient(
+                ConnectionString,
+                new ServiceBusClientOptions { TransportType = this.TransportType });
         }
 
         public async Task<bool> IsPremiumNamespace()

--- a/src/ServiceBus/Helpers/ServiceBusHelper2.cs
+++ b/src/ServiceBus/Helpers/ServiceBusHelper2.cs
@@ -62,6 +62,7 @@ namespace ServiceBusExplorer.ServiceBus.Helpers
             return false;
         }
 
+        // Remember to dispose of the client after use, using client.DisposeAsync()
         public ServiceBusClient CreateServiceBusClient()
         {
             return new ServiceBusClient(

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.Designer.cs
@@ -117,8 +117,9 @@
             this.messagesContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.repairAndResubmitMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resubmitMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.cancelScheduledMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.selectAllMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resubmitSelectedMessagesInBatchModeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.cancelScheduledMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.saveSelectedMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveSelectedMessageBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -127,6 +128,7 @@
             this.deadletterContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.repairAndResubmitDeadletterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resubmitDeadletterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.selectAllDeadletterMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.saveSelectedDeadletteredMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -144,6 +146,7 @@
             this.transferDeadletterBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.transferDeadletterContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.repairAndResubmitTransferDeadletterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.selectAllTransferDeadletterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resubmitSelectedTransferDeadletterInBatchModeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.saveSelectedTransferDeadletteredMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -1150,7 +1153,7 @@
         '\"',
         '\'',
         '\''};
-            this.txtMessageText.AutoScrollMinSize = new System.Drawing.Size(27, 14);
+            this.txtMessageText.AutoScrollMinSize = new System.Drawing.Size(2, 14);
             this.txtMessageText.BackBrush = null;
             this.txtMessageText.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.txtMessageText.CharHeight = 14;
@@ -1449,7 +1452,7 @@
         '\"',
         '\'',
         '\''};
-            this.txtDeadletterText.AutoScrollMinSize = new System.Drawing.Size(27, 14);
+            this.txtDeadletterText.AutoScrollMinSize = new System.Drawing.Size(2, 14);
             this.txtDeadletterText.BackBrush = null;
             this.txtDeadletterText.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.txtDeadletterText.CharHeight = 14;
@@ -1731,7 +1734,7 @@
         '\"',
         '\'',
         '\''};
-            this.txtTransferDeadletterText.AutoScrollMinSize = new System.Drawing.Size(27, 14);
+            this.txtTransferDeadletterText.AutoScrollMinSize = new System.Drawing.Size(2, 14);
             this.txtTransferDeadletterText.BackBrush = null;
             this.txtTransferDeadletterText.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.txtTransferDeadletterText.CharHeight = 14;
@@ -2095,6 +2098,7 @@
             this.messagesContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.repairAndResubmitMessageToolStripMenuItem,
             this.resubmitMessageToolStripMenuItem,
+            this.selectAllMessagesToolStripMenuItem,
             this.resubmitSelectedMessagesInBatchModeToolStripMenuItem,
             this.cancelScheduledMessageToolStripMenuItem,
             this.toolStripSeparator1,
@@ -2120,13 +2124,13 @@
             this.resubmitMessageToolStripMenuItem.ToolTipText = "Resubmits the message with unchanged body.";
             this.resubmitMessageToolStripMenuItem.Click += new System.EventHandler(this.resubmitMessageToolStripMenuItem_Click);
             // 
-            // cancelScheduledMessageToolStripMenuItem
+            // selectAllMessagesToolStripMenuItem
             // 
-            this.cancelScheduledMessageToolStripMenuItem.Name = "cancelScheduledMessageToolStripMenuItem";
-            this.cancelScheduledMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.cancelScheduledMessageToolStripMenuItem.Text = "Cancel Selected Scheduled Message";
-            this.cancelScheduledMessageToolStripMenuItem.Visible = false;
-            this.cancelScheduledMessageToolStripMenuItem.Click += new System.EventHandler(this.cancelScheduledMessageToolStripMenuItem_Click);
+            this.selectAllMessagesToolStripMenuItem.Name = "selectAllMessagesToolStripMenuItem";
+            this.selectAllMessagesToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A)));
+            this.selectAllMessagesToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.selectAllMessagesToolStripMenuItem.Text = "Select All Messages";
+            this.selectAllMessagesToolStripMenuItem.Click += new System.EventHandler(this.selectAllMessagesToolStripMenuItem_Click);
             // 
             // resubmitSelectedMessagesInBatchModeToolStripMenuItem
             // 
@@ -2134,6 +2138,14 @@
             this.resubmitSelectedMessagesInBatchModeToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.resubmitSelectedMessagesInBatchModeToolStripMenuItem.Text = "Resubmit Selected Messages In Batch Mode";
             this.resubmitSelectedMessagesInBatchModeToolStripMenuItem.Click += new System.EventHandler(this.resubmitSelectedMessagesInBatchModeToolStripMenuItem_Click);
+            // 
+            // cancelScheduledMessageToolStripMenuItem
+            // 
+            this.cancelScheduledMessageToolStripMenuItem.Name = "cancelScheduledMessageToolStripMenuItem";
+            this.cancelScheduledMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.cancelScheduledMessageToolStripMenuItem.Text = "Cancel Selected Scheduled Message";
+            this.cancelScheduledMessageToolStripMenuItem.Visible = false;
+            this.cancelScheduledMessageToolStripMenuItem.Click += new System.EventHandler(this.cancelScheduledMessageToolStripMenuItem_Click);
             // 
             // toolStripSeparator1
             // 
@@ -2174,6 +2186,7 @@
             this.deadletterContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.repairAndResubmitDeadletterToolStripMenuItem,
             this.resubmitDeadletterToolStripMenuItem,
+            this.selectAllDeadletterMessagesToolStripMenuItem,
             this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem,
             this.toolStripSeparator2,
             this.saveSelectedDeadletteredMessageToolStripMenuItem,
@@ -2183,7 +2196,7 @@
             this.deleteSelectedMessageToolStripMenuItem,
             this.deleteSelectedMessagesToolStripMenuItem});
             this.deadletterContextMenuStrip.Name = "registrationContextMenuStrip";
-            this.deadletterContextMenuStrip.Size = new System.Drawing.Size(306, 208);
+            this.deadletterContextMenuStrip.Size = new System.Drawing.Size(306, 252);
             // 
             // repairAndResubmitDeadletterToolStripMenuItem
             // 
@@ -2199,6 +2212,14 @@
             this.resubmitDeadletterToolStripMenuItem.Text = "Resubmit Selected Message";
             this.resubmitDeadletterToolStripMenuItem.ToolTipText = "Resubmits the deadletter message with unchanged body.";
             this.resubmitDeadletterToolStripMenuItem.Click += new System.EventHandler(this.resubmitDeadletterMessageToolStripMenuItem_Click);
+            // 
+            // selectAllDeadletterMessagesToolStripMenuItem
+            // 
+            this.selectAllDeadletterMessagesToolStripMenuItem.Name = "selectAllDeadletterMessagesToolStripMenuItem";
+            this.selectAllDeadletterMessagesToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A)));
+            this.selectAllDeadletterMessagesToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.selectAllDeadletterMessagesToolStripMenuItem.Text = "Select All Messages";
+            this.selectAllDeadletterMessagesToolStripMenuItem.Click += new System.EventHandler(this.selectAllDeadletterMessagesToolStripMenuItem_Click);
             // 
             // resubmitSelectedDeadletterInBatchModeToolStripMenuItem
             // 
@@ -2278,6 +2299,7 @@
             this.transferDeadletterContextMenuStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.transferDeadletterContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.repairAndResubmitTransferDeadletterToolStripMenuItem,
+            this.selectAllTransferDeadletterToolStripMenuItem,
             this.resubmitSelectedTransferDeadletterInBatchModeToolStripMenuItem,
             this.toolStripSeparator3,
             this.saveSelectedTransferDeadletteredMessageToolStripMenuItem,
@@ -2285,7 +2307,7 @@
             this.saveSelectedTransferDeadletteredMessagesToolStripMenuItem,
             this.saveSelectedTransferDeadletteredMessagesBodyAsFileToolStripMenuItem});
             this.transferDeadletterContextMenuStrip.Name = "registrationContextMenuStrip";
-            this.transferDeadletterContextMenuStrip.Size = new System.Drawing.Size(306, 142);
+            this.transferDeadletterContextMenuStrip.Size = new System.Drawing.Size(306, 164);
             this.transferDeadletterContextMenuStrip.Click += new System.EventHandler(this.resubmitSelectedTransferDeadletterMessagesInBatchModeToolStripMenuItem_Click);
             // 
             // repairAndResubmitTransferDeadletterToolStripMenuItem
@@ -2294,6 +2316,14 @@
             this.repairAndResubmitTransferDeadletterToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.repairAndResubmitTransferDeadletterToolStripMenuItem.Text = "Repair and Resubmit Selected Message";
             this.repairAndResubmitTransferDeadletterToolStripMenuItem.Click += new System.EventHandler(this.repairAndResubmitTransferDeadletterMessageToolStripMenuItem_Click);
+            // 
+            // selectAllTransferDeadletterToolStripMenuItem
+            // 
+            this.selectAllTransferDeadletterToolStripMenuItem.Name = "selectAllTransferDeadletterToolStripMenuItem";
+            this.selectAllTransferDeadletterToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A)));
+            this.selectAllTransferDeadletterToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.selectAllTransferDeadletterToolStripMenuItem.Text = "Select All Messages";
+            this.selectAllTransferDeadletterToolStripMenuItem.Click += new System.EventHandler(this.selectAllTransferDeadletterToolStripMenuItem_Click);
             // 
             // resubmitSelectedTransferDeadletterInBatchModeToolStripMenuItem
             // 
@@ -2590,5 +2620,8 @@
         private System.Windows.Forms.ToolStripMenuItem resubmitDeadletterToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem resubmitMessageToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem cancelScheduledMessageToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem selectAllMessagesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem selectAllDeadletterMessagesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem selectAllTransferDeadletterToolStripMenuItem;
     }
 }

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.Designer.cs
@@ -117,6 +117,7 @@
             this.messagesContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.repairAndResubmitMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resubmitMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.cancelScheduledMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resubmitSelectedMessagesInBatchModeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.saveSelectedMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -1149,13 +1150,14 @@
         '\"',
         '\'',
         '\''};
-            this.txtMessageText.AutoScrollMinSize = new System.Drawing.Size(2, 14);
+            this.txtMessageText.AutoScrollMinSize = new System.Drawing.Size(27, 14);
             this.txtMessageText.BackBrush = null;
             this.txtMessageText.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.txtMessageText.CharHeight = 14;
             this.txtMessageText.CharWidth = 8;
             this.txtMessageText.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.txtMessageText.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
+            this.txtMessageText.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.txtMessageText.ForeColor = System.Drawing.SystemColors.ControlText;
             this.txtMessageText.IsReplaceMode = false;
             this.txtMessageText.Location = new System.Drawing.Point(16, 32);
@@ -1447,13 +1449,14 @@
         '\"',
         '\'',
         '\''};
-            this.txtDeadletterText.AutoScrollMinSize = new System.Drawing.Size(2, 14);
+            this.txtDeadletterText.AutoScrollMinSize = new System.Drawing.Size(27, 14);
             this.txtDeadletterText.BackBrush = null;
             this.txtDeadletterText.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.txtDeadletterText.CharHeight = 14;
             this.txtDeadletterText.CharWidth = 8;
             this.txtDeadletterText.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.txtDeadletterText.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
+            this.txtDeadletterText.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.txtDeadletterText.ForeColor = System.Drawing.SystemColors.ControlText;
             this.txtDeadletterText.IsReplaceMode = false;
             this.txtDeadletterText.Location = new System.Drawing.Point(16, 32);
@@ -1728,13 +1731,14 @@
         '\"',
         '\'',
         '\''};
-            this.txtTransferDeadletterText.AutoScrollMinSize = new System.Drawing.Size(2, 14);
+            this.txtTransferDeadletterText.AutoScrollMinSize = new System.Drawing.Size(27, 14);
             this.txtTransferDeadletterText.BackBrush = null;
             this.txtTransferDeadletterText.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.txtTransferDeadletterText.CharHeight = 14;
             this.txtTransferDeadletterText.CharWidth = 8;
             this.txtTransferDeadletterText.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.txtTransferDeadletterText.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
+            this.txtTransferDeadletterText.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.txtTransferDeadletterText.ForeColor = System.Drawing.SystemColors.ControlText;
             this.txtTransferDeadletterText.IsReplaceMode = false;
             this.txtTransferDeadletterText.Location = new System.Drawing.Point(16, 32);
@@ -2092,13 +2096,14 @@
             this.repairAndResubmitMessageToolStripMenuItem,
             this.resubmitMessageToolStripMenuItem,
             this.resubmitSelectedMessagesInBatchModeToolStripMenuItem,
+            this.cancelScheduledMessageToolStripMenuItem,
             this.toolStripSeparator1,
             this.saveSelectedMessageToolStripMenuItem,
             this.saveSelectedMessageBodyAsFileToolStripMenuItem,
             this.saveSelectedMessagesToolStripMenuItem,
             this.saveSelectedMessagesBodyAsFileToolStripMenuItem});
             this.messagesContextMenuStrip.Name = "registrationContextMenuStrip";
-            this.messagesContextMenuStrip.Size = new System.Drawing.Size(306, 186);
+            this.messagesContextMenuStrip.Size = new System.Drawing.Size(306, 208);
             // 
             // repairAndResubmitMessageToolStripMenuItem
             // 
@@ -2114,6 +2119,14 @@
             this.resubmitMessageToolStripMenuItem.Text = "Resubmit Selected Message";
             this.resubmitMessageToolStripMenuItem.ToolTipText = "Resubmits the message with unchanged body.";
             this.resubmitMessageToolStripMenuItem.Click += new System.EventHandler(this.resubmitMessageToolStripMenuItem_Click);
+            // 
+            // cancelScheduledMessageToolStripMenuItem
+            // 
+            this.cancelScheduledMessageToolStripMenuItem.Name = "cancelScheduledMessageToolStripMenuItem";
+            this.cancelScheduledMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.cancelScheduledMessageToolStripMenuItem.Text = "Cancel Selected Scheduled Message";
+            this.cancelScheduledMessageToolStripMenuItem.Visible = false;
+            this.cancelScheduledMessageToolStripMenuItem.Click += new System.EventHandler(this.cancelScheduledMessageToolStripMenuItem_Click);
             // 
             // resubmitSelectedMessagesInBatchModeToolStripMenuItem
             // 
@@ -2576,5 +2589,6 @@
         private System.Windows.Forms.PropertyGrid transferDeadletterCustomPropertyGrid;
         private System.Windows.Forms.ToolStripMenuItem resubmitDeadletterToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem resubmitMessageToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem cancelScheduledMessageToolStripMenuItem;
     }
 }

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -531,7 +531,7 @@ namespace ServiceBusExplorer.Controls
 
         #endregion
 
-#       region Privare Instance Methods
+        #region Private Instance Methods
 
         private void InitializeControls(bool initialCall)
         {

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -525,17 +525,8 @@ namespace ServiceBusExplorer.Controls
 
         static bool AreAllSelectedMessageScheduled(DataGridViewSelectedRowCollection selectedRows)
         {
-            foreach (DataGridViewRow row in selectedRows)
-            {
-                var brokeredMessage = row.DataBoundItem as BrokeredMessage;
-
-                if (brokeredMessage?.State != MessageState.Scheduled)
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return selectedRows.Cast<DataGridViewRow>()
+                .All(row => (row.DataBoundItem as BrokeredMessage)?.State == MessageState.Scheduled);
         }
 
         #endregion


### PR DESCRIPTION
Fixes #360

This PR adds the ability to cancel scheduled messages on queues. The Service bus API does not support browsing scheduled messages on subscriptions. 

A new context menu item "Cancel Scheduled Message" has been added as shown below:
![image](https://github.com/paolosalvatori/ServiceBusExplorer/assets/9644248/341455c3-a6b4-42e0-8850-06b485627624)

If multiple messages are selected it says "Cancel Scheduled Messages" instead:
![image](https://github.com/paolosalvatori/ServiceBusExplorer/assets/9644248/7db04b45-5f2f-4b4f-8d76-8dc477dc36a1)

If the _Disable Accidental Deletion Prevention_ is disabled, a message box will ask for confirmation. 

The rows in the grid will not update, nor will the message count for the queue in the tree view. That is something that may be added later.
