### PR TITLE
Change the way the tenantId is used in the Event Grid login

### DIFF
--- a/src/EventGridExplorerLibrary/EventGridLibrary.cs
+++ b/src/EventGridExplorerLibrary/EventGridLibrary.cs
@@ -36,19 +36,18 @@ namespace EventGridExplorerLibrary
         private EventGridManagementClient controlPlaneClient;
         private Dictionary<string, EventGridClient> dataPlaneClients = new Dictionary<string, EventGridClient>();
         private int retryTimeout;
-        private string tenantId;
         private readonly WriteToLogDelegate writeToLog = default;
         #endregion
 
         public EventGridLibrary(string subscriptionId, string apiVersion, int retryTimeout, string cloudTenant, string customId, WriteToLogDelegate writeToLog)
         {
-            controlPlaneClient = new EventGridManagementClient(new Uri(ArmEndpointUrl), GetTokenCredential(), subscriptionId, apiVersion, retryTimeout);
+            string tenantId = customId == string.Empty ? null : customId;
+            controlPlaneClient = new EventGridManagementClient(new Uri(ArmEndpointUrl), GetTokenCredential(tenantId), subscriptionId, apiVersion, retryTimeout);
             this.retryTimeout = retryTimeout;
-            this.tenantId = customId == string.Empty ? tenantIds[cloudTenant] : customId;
             this.writeToLog = writeToLog;
         }
 
-        public TokenCredentials GetTokenCredential()
+        public TokenCredentials GetTokenCredential(string tenantId)
         {
             string[] scope = { ScopeUrl };
 

--- a/src/EventGridExplorerLibrary/EventGridLibrary.cs
+++ b/src/EventGridExplorerLibrary/EventGridLibrary.cs
@@ -37,20 +37,19 @@ namespace EventGridExplorerLibrary
         private EventGridManagementClient controlPlaneClient;
         private Dictionary<string, EventGridClient> dataPlaneClients = new Dictionary<string, EventGridClient>();
         private int retryTimeout;
-        private string tenantId;
         private readonly WriteToLogDelegate writeToLog = default;
         #endregion
 
         public EventGridLibrary(string subscriptionId, string apiVersion, int retryTimeout, string cloudTenant, string customId, WriteToLogDelegate writeToLog)
         {
+            string tenantId = customId == string.Empty ? null : customId;
             var apiVersionToUse = string.IsNullOrEmpty(apiVersion) ? DefaultApiVersion : apiVersion;
-            controlPlaneClient = new EventGridManagementClient(new Uri(ArmEndpointUrl), GetTokenCredential(), subscriptionId, apiVersionToUse , retryTimeout);
+            controlPlaneClient = new EventGridManagementClient(new Uri(ArmEndpointUrl), GetTokenCredential(tenantId), subscriptionId, apiVersionToUse , retryTimeout);
             this.retryTimeout = retryTimeout;
-            this.tenantId = customId == string.Empty ? tenantIds[cloudTenant] : customId;
             this.writeToLog = writeToLog;
         }
 
-        public TokenCredentials GetTokenCredential()
+        public TokenCredentials GetTokenCredential(string tenantId)
         {
             string[] scope = { ScopeUrl };
 


### PR DESCRIPTION
The tenantId field was always null when calling InteractiveBrowserCredential. This seems to work with work accounts but not personal Microsoft accounts. 

This PR sets the tenantId to the custom tenantId, if it is specified.