### PR TITLE
Put back the submenus for Set Status

### DIFF
--- a/src/ServiceBusExplorer/Forms/MainForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.Designer.cs
@@ -1637,6 +1637,16 @@ namespace ServiceBusExplorer.Forms
             this.changeStatusQueueMenuItem.Name = "changeStatusQueueMenuItem";
             this.changeStatusQueueMenuItem.Size = new System.Drawing.Size(312, 22);
             this.changeStatusQueueMenuItem.Text = "Set Status";
+            this.changeStatusQueueMenuItem.DropDownOpening += changeStatusQueueMenuItem_DropDownOpening;
+            this.changeStatusQueueMenuItem.DropDownItemClicked += changeStatusQueue_Click;
+            this.changeStatusQueueMenuItem.DropDownItems.Add(EntityStatus.Active.ToString())
+                .Tag = EntityStatus.Active;
+            this.changeStatusQueueMenuItem.DropDownItems.Add(EntityStatus.Disabled.ToString())
+                .Tag = EntityStatus.Disabled;
+            this.changeStatusQueueMenuItem.DropDownItems.Add(EntityStatus.SendDisabled.ToString())
+                .Tag = EntityStatus.SendDisabled;
+            this.changeStatusQueueMenuItem.DropDownItems.Add(EntityStatus.ReceiveDisabled.ToString())
+                .Tag = EntityStatus.ReceiveDisabled;
             // 
             // deleteQueueMenuItem
             // 


### PR DESCRIPTION
It now looks like this again:
![image](https://github.com/paolosalvatori/ServiceBusExplorer/assets/9644248/0a5ac00f-b7db-443c-bb18-180e9defd717)

Seems that these changes were lost when another PR was merged.

Fixes #760