### PR TITLE
Fix Issue #633: Resubmit Selected Messages In Batch Mode

### DIFF
--- a/src/ServiceBusExplorer/Forms/MessageForm.cs
+++ b/src/ServiceBusExplorer/Forms/MessageForm.cs
@@ -412,18 +412,21 @@ namespace ServiceBusExplorer.Forms
                                     var messageText = serviceBusHelper.GetMessageText(message,
                                         MainForm.SingletonMainForm.UseAscii, out bodyType);
 
-                                    if (messageText.GetType() == typeof(string))
+                                    if (bodyType == BodyType.ByteArray)
+                                    {
+                                        // For body type ByteArray cloning is not an option. When cloned, supplied body can be only of a string or stream types, but not byte array :(
+                                        outboundMessage = message.CloneWithByteArrayBodyType(messageText, messagesSplitContainer.Visible);
+                                    }
+                                    else if (messageText.Contains("@\u0006string\b3http://schemas.microsoft.com/2003/10/Serialization/�G"))
                                     {
                                         // Remove any serialization text from the message body string
                                         messageText = messageText.Replace("@\u0006string\b3http://schemas.microsoft.com/2003/10/Serialization/�G", string.Empty);
                                         outboundMessage = message.Clone(messageText, messagesSplitContainer.Visible);
-                                    }
+                                    } 
                                     else
                                     {
-                                        // For body type ByteArray cloning is not an option. When cloned, supplied body can be only of a string or stream types, but not byte array :(
-                                        outboundMessage = bodyType == BodyType.ByteArray ?
-                                                          message.CloneWithByteArrayBodyType(messageText, messagesSplitContainer.Visible) :
-                                                          message.Clone(message.GetBody<Stream>(), messagesSplitContainer.Visible);
+                                        // Process as Stream
+                                        outboundMessage = message.Clone(message.GetBody<Stream>(), messagesSplitContainer.Visible);
                                     }
                                 }
 

--- a/src/ServiceBusExplorer/Forms/MessageForm.cs
+++ b/src/ServiceBusExplorer/Forms/MessageForm.cs
@@ -417,17 +417,17 @@ namespace ServiceBusExplorer.Forms
                                         // For body type ByteArray cloning is not an option. When cloned, supplied body can be only of a string or stream types, but not byte array :(
                                         outboundMessage = message.CloneWithByteArrayBodyType(messageText, messagesSplitContainer.Visible);
                                     }
-                                    else if (messageText.Contains("@\u0006string\b3http://schemas.microsoft.com/2003/10/Serialization/�G"))
+                                    else
                                     {
                                         // Remove any serialization text from the message body string
                                         messageText = messageText.Replace("@\u0006string\b3http://schemas.microsoft.com/2003/10/Serialization/�G", string.Empty);
                                         outboundMessage = message.Clone(messageText, messagesSplitContainer.Visible);
                                     } 
-                                    else
-                                    {
-                                        // Process as Stream
-                                        outboundMessage = message.Clone(message.GetBody<Stream>(), messagesSplitContainer.Visible);
-                                    }
+                                    //else
+                                    //{
+                                    //    // Process as Stream
+                                    //    outboundMessage = message.Clone(message.GetBody<Stream>(), messagesSplitContainer.Visible);
+                                    //}
                                 }
 
                                 outboundMessage = serviceBusHelper.CreateMessageForApiReceiver(outboundMessage,

--- a/src/ServiceBusExplorer/Forms/MessageForm.cs
+++ b/src/ServiceBusExplorer/Forms/MessageForm.cs
@@ -410,24 +410,28 @@ namespace ServiceBusExplorer.Forms
                                 else
                                 {
                                     var messageText = serviceBusHelper.GetMessageText(message,
-                                        MainForm.SingletonMainForm.UseAscii, out bodyType);
+                                        MainForm.SingletonMainForm.UseAscii, out _);
 
                                     if (bodyType == BodyType.ByteArray)
                                     {
                                         // For body type ByteArray cloning is not an option. When cloned, supplied body can be only of a string or stream types, but not byte array :(
                                         outboundMessage = message.CloneWithByteArrayBodyType(messageText, messagesSplitContainer.Visible);
                                     }
-                                    else
+                                    else if (bodyType == BodyType.String)
                                     {
                                         // Remove any serialization text from the message body string
-                                        messageText = messageText.Replace("@\u0006string\b3http://schemas.microsoft.com/2003/10/Serialization/�G", string.Empty);
+                                        if (messageText.StartsWith("@\u0006string\b3http://schemas.microsoft.com/2003/10/Serialization/�G"))
+                                        {
+                                            messageText = messageText.Replace("@\u0006string\b3http://schemas.microsoft.com/2003/10/Serialization/�G", string.Empty);
+                                        }
+
                                         outboundMessage = message.Clone(messageText, messagesSplitContainer.Visible);
-                                    } 
-                                    //else
-                                    //{
-                                    //    // Process as Stream
-                                    //    outboundMessage = message.Clone(message.GetBody<Stream>(), messagesSplitContainer.Visible);
-                                    //}
+                                    }
+                                    else
+                                    {
+                                        // Process as Stream
+                                        outboundMessage = message.Clone(message.GetBody<Stream>(), messagesSplitContainer.Visible);
+                                    }
                                 }
 
                                 outboundMessage = serviceBusHelper.CreateMessageForApiReceiver(outboundMessage,

--- a/src/ServiceBusExplorer/Forms/MessageForm.cs
+++ b/src/ServiceBusExplorer/Forms/MessageForm.cs
@@ -412,10 +412,19 @@ namespace ServiceBusExplorer.Forms
                                     var messageText = serviceBusHelper.GetMessageText(message,
                                         MainForm.SingletonMainForm.UseAscii, out bodyType);
 
-                                    // For body type ByteArray cloning is not an option. When cloned, supplied body can be only of a string or stream types, but not byte array :(
-                                    outboundMessage = bodyType == BodyType.ByteArray ?
-                                                      message.CloneWithByteArrayBodyType(messageText, messagesSplitContainer.Visible) :
-                                                      message.Clone(message.GetBody<Stream>(), messagesSplitContainer.Visible);
+                                    if (messageText.GetType() == typeof(string))
+                                    {
+                                        // Remove any serialization text from the message body string
+                                        messageText = messageText.Replace("@\u0006string\b3http://schemas.microsoft.com/2003/10/Serialization/�G", string.Empty);
+                                        outboundMessage = message.Clone(messageText, messagesSplitContainer.Visible);
+                                    }
+                                    else
+                                    {
+                                        // For body type ByteArray cloning is not an option. When cloned, supplied body can be only of a string or stream types, but not byte array :(
+                                        outboundMessage = bodyType == BodyType.ByteArray ?
+                                                          message.CloneWithByteArrayBodyType(messageText, messagesSplitContainer.Visible) :
+                                                          message.Clone(message.GetBody<Stream>(), messagesSplitContainer.Visible);
+                                    }
                                 }
 
                                 outboundMessage = serviceBusHelper.CreateMessageForApiReceiver(outboundMessage,


### PR DESCRIPTION
To address issue #633 (Resubmit Selected Messages In Batch Mode issue) 

I have added a check on the messageType's value and parsed it as a string if it is one. Also removed the added serialization text `"@\u0006string\b3http://schemas.microsoft.com/2003/10/Serialization/�G"` to prevent messages from becoming corrupted when resubmitting.

Using this build, you should be able to resubmit batches of messages without running into message body corruption.