### PR TITLE
Add selective delete to Transfer deadletter subqueues and fix the context menus for the Transfer Deadletter grid view

### DIFF
--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.Designer.cs
@@ -2232,14 +2232,14 @@
             this.deleteSelectedMessageToolStripMenuItem.Name = "deleteSelectedMessageToolStripMenuItem";
             this.deleteSelectedMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.deleteSelectedMessageToolStripMenuItem.Text = "Delete Selected Message";
-            this.deleteSelectedMessageToolStripMenuItem.Click += new System.EventHandler(this.deleteSelectedMessageToolStripMenuItem_Click);
+            this.deleteSelectedMessageToolStripMenuItem.Click += new System.EventHandler(this.deleteSelectedDeadLetterMessageToolStripMenuItem_Click);
             // 
             // deleteSelectedMessagesToolStripMenuItem
             // 
             this.deleteSelectedMessagesToolStripMenuItem.Name = "deleteSelectedMessagesToolStripMenuItem";
             this.deleteSelectedMessagesToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.deleteSelectedMessagesToolStripMenuItem.Text = "Delete Selected Messages";
-            this.deleteSelectedMessagesToolStripMenuItem.Click += new System.EventHandler(this.deleteSelectedMessagesToolStripMenuItem_Click);
+            this.deleteSelectedMessagesToolStripMenuItem.Click += new System.EventHandler(this.deleteSelectedDeadLetterMessagesToolStripMenuItem_Click);
             // 
             // btnPurgeMessages
             // 

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.Designer.cs
@@ -123,17 +123,17 @@
             this.saveSelectedMessageBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveSelectedMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveSelectedMessagesBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.deadletterContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.repairAndResubmitDeadletterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.resubmitDeadletterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.sharedDeadletterContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.repairAndResubmitSharedDeadletterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resubmitSharedDeadletterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resubmitSelectedSharedDeadletterInBatchModeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-            this.saveSelectedDeadletteredMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveSelectedDeadletteredMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.deleteSelectedMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.deleteSelectedMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveSelectedSharedDeadletteredMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveSelectedSharedDeadletteredMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.deleteSelectedSharedDeadletterMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.deleteSelectedSharedDeadletterMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.messagesBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.sessionsBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.deadletterBindingSource = new System.Windows.Forms.BindingSource(this.components);
@@ -141,14 +141,6 @@
             this.saveFileDialog = new System.Windows.Forms.SaveFileDialog();
             this.btnPurgeMessages = new System.Windows.Forms.Button();
             this.transferDeadletterBindingSource = new System.Windows.Forms.BindingSource(this.components);
-            this.transferDeadletterContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.repairAndResubmitTransferDeadletterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.resubmitSelectedTransferDeadletterInBatchModeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-            this.saveSelectedTransferDeadletteredMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveSelectedTransferDeadletteredMessageBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveSelectedTransferDeadletteredMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveSelectedTransferDeadletteredMessagesBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.mainTabControl.SuspendLayout();
             this.tabPageDescription.SuspendLayout();
             this.grouperAutoDeleteOnIdle.SuspendLayout();
@@ -238,13 +230,12 @@
             this.grouperSessionState.SuspendLayout();
             this.grouperSessionProperties.SuspendLayout();
             this.messagesContextMenuStrip.SuspendLayout();
-            this.deadletterContextMenuStrip.SuspendLayout();
+            this.sharedDeadletterContextMenuStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.messagesBindingSource)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.sessionsBindingSource)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.deadletterBindingSource)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.authorizationRulesBindingSource)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.transferDeadletterBindingSource)).BeginInit();
-            this.transferDeadletterContextMenuStrip.SuspendLayout();
             this.SuspendLayout();
             // 
             // btnPurgeDeadletterQueueMessages
@@ -1156,6 +1147,7 @@
             this.txtMessageText.CharWidth = 8;
             this.txtMessageText.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.txtMessageText.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
+            this.txtMessageText.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.txtMessageText.ForeColor = System.Drawing.SystemColors.ControlText;
             this.txtMessageText.IsReplaceMode = false;
             this.txtMessageText.Location = new System.Drawing.Point(16, 32);
@@ -1454,6 +1446,7 @@
             this.txtDeadletterText.CharWidth = 8;
             this.txtDeadletterText.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.txtDeadletterText.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
+            this.txtDeadletterText.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.txtDeadletterText.ForeColor = System.Drawing.SystemColors.ControlText;
             this.txtDeadletterText.IsReplaceMode = false;
             this.txtDeadletterText.Location = new System.Drawing.Point(16, 32);
@@ -1735,6 +1728,7 @@
             this.txtTransferDeadletterText.CharWidth = 8;
             this.txtTransferDeadletterText.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.txtTransferDeadletterText.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
+            this.txtTransferDeadletterText.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.txtTransferDeadletterText.ForeColor = System.Drawing.SystemColors.ControlText;
             this.txtTransferDeadletterText.IsReplaceMode = false;
             this.txtTransferDeadletterText.Location = new System.Drawing.Point(16, 32);
@@ -2098,7 +2092,7 @@
             this.saveSelectedMessagesToolStripMenuItem,
             this.saveSelectedMessagesBodyAsFileToolStripMenuItem});
             this.messagesContextMenuStrip.Name = "registrationContextMenuStrip";
-            this.messagesContextMenuStrip.Size = new System.Drawing.Size(306, 186);
+            this.messagesContextMenuStrip.Size = new System.Drawing.Size(306, 164);
             // 
             // repairAndResubmitMessageToolStripMenuItem
             // 
@@ -2155,91 +2149,91 @@
             this.saveSelectedMessagesBodyAsFileToolStripMenuItem.Text = "Save Selected Messages Text as File";
             this.saveSelectedMessagesBodyAsFileToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedMessagesBodyAsFileToolStripMenuItem_Click);
             // 
-            // deadletterContextMenuStrip
+            // sharedDeadletterContextMenuStrip
             // 
-            this.deadletterContextMenuStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.deadletterContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.repairAndResubmitDeadletterToolStripMenuItem,
-            this.resubmitDeadletterToolStripMenuItem,
-            this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem,
+            this.sharedDeadletterContextMenuStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
+            this.sharedDeadletterContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.repairAndResubmitSharedDeadletterToolStripMenuItem,
+            this.resubmitSharedDeadletterToolStripMenuItem,
+            this.resubmitSelectedSharedDeadletterInBatchModeToolStripMenuItem,
             this.toolStripSeparator2,
-            this.saveSelectedDeadletteredMessageToolStripMenuItem,
-            this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem,
-            this.saveSelectedDeadletteredMessagesToolStripMenuItem,
-            this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem,
-            this.deleteSelectedMessageToolStripMenuItem,
-            this.deleteSelectedMessagesToolStripMenuItem});
-            this.deadletterContextMenuStrip.Name = "registrationContextMenuStrip";
-            this.deadletterContextMenuStrip.Size = new System.Drawing.Size(306, 208);
+            this.saveSelectedSharedDeadletteredMessageToolStripMenuItem,
+            this.saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem,
+            this.saveSelectedSharedDeadletteredMessagesToolStripMenuItem,
+            this.saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem,
+            this.deleteSelectedSharedDeadletterMessageToolStripMenuItem,
+            this.deleteSelectedSharedDeadletterMessagesToolStripMenuItem});
+            this.sharedDeadletterContextMenuStrip.Name = "registrationContextMenuStrip";
+            this.sharedDeadletterContextMenuStrip.Size = new System.Drawing.Size(306, 230);
             // 
-            // repairAndResubmitDeadletterToolStripMenuItem
+            // repairAndResubmitSharedDeadletterToolStripMenuItem
             // 
-            this.repairAndResubmitDeadletterToolStripMenuItem.Name = "repairAndResubmitDeadletterToolStripMenuItem";
-            this.repairAndResubmitDeadletterToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.repairAndResubmitDeadletterToolStripMenuItem.Text = "Repair And Resubmit Selected Message";
-            this.repairAndResubmitDeadletterToolStripMenuItem.Click += new System.EventHandler(this.repairAndResubmitDeadletterMessageToolStripMenuItem_Click);
+            this.repairAndResubmitSharedDeadletterToolStripMenuItem.Name = "repairAndResubmitSharedDeadletterToolStripMenuItem";
+            this.repairAndResubmitSharedDeadletterToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.repairAndResubmitSharedDeadletterToolStripMenuItem.Text = "Repair And Resubmit Selected Message";
+            this.repairAndResubmitSharedDeadletterToolStripMenuItem.Click += new System.EventHandler(this.repairAndResubmitSharedDeadletterMessageToolStripMenuItem_Click);
             // 
-            // resubmitDeadletterToolStripMenuItem
+            // resubmitSharedDeadletterToolStripMenuItem
             // 
-            this.resubmitDeadletterToolStripMenuItem.Name = "resubmitDeadletterToolStripMenuItem";
-            this.resubmitDeadletterToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.resubmitDeadletterToolStripMenuItem.Text = "Resubmit Selected Message";
-            this.resubmitDeadletterToolStripMenuItem.ToolTipText = "Resubmits the deadletter message with unchanged body.";
-            this.resubmitDeadletterToolStripMenuItem.Click += new System.EventHandler(this.resubmitDeadletterMessageToolStripMenuItem_Click);
+            this.resubmitSharedDeadletterToolStripMenuItem.Name = "resubmitSharedDeadletterToolStripMenuItem";
+            this.resubmitSharedDeadletterToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.resubmitSharedDeadletterToolStripMenuItem.Text = "Resubmit Selected Message";
+            this.resubmitSharedDeadletterToolStripMenuItem.ToolTipText = "Resubmits the deadletter message with unchanged body.";
+            this.resubmitSharedDeadletterToolStripMenuItem.Click += new System.EventHandler(this.resubmitSharedDeadletterMessageToolStripMenuItem_Click);
             // 
-            // resubmitSelectedDeadletterInBatchModeToolStripMenuItem
+            // resubmitSelectedSharedDeadletterInBatchModeToolStripMenuItem
             // 
-            this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem.Name = "resubmitSelectedDeadletterInBatchModeToolStripMenuItem";
-            this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem.Text = "Resubmit Selected Messages In Batch Mode";
-            this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem.Click += new System.EventHandler(this.resubmitSelectedDeadletterMessagesInBatchModeToolStripMenuItem_Click);
+            this.resubmitSelectedSharedDeadletterInBatchModeToolStripMenuItem.Name = "resubmitSelectedSharedDeadletterInBatchModeToolStripMenuItem";
+            this.resubmitSelectedSharedDeadletterInBatchModeToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.resubmitSelectedSharedDeadletterInBatchModeToolStripMenuItem.Text = "Resubmit Selected Messages In Batch Mode";
+            this.resubmitSelectedSharedDeadletterInBatchModeToolStripMenuItem.Click += new System.EventHandler(this.resubmitSelectedSharedDeadletterMessagesInBatchModeToolStripMenuItem_Click);
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
             this.toolStripSeparator2.Size = new System.Drawing.Size(302, 6);
             // 
-            // saveSelectedDeadletteredMessageToolStripMenuItem
+            // saveSelectedSharedDeadletteredMessageToolStripMenuItem
             // 
-            this.saveSelectedDeadletteredMessageToolStripMenuItem.Name = "saveSelectedDeadletteredMessageToolStripMenuItem";
-            this.saveSelectedDeadletteredMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.saveSelectedDeadletteredMessageToolStripMenuItem.Text = "Save Selected Message";
-            this.saveSelectedDeadletteredMessageToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedDeadletteredMessageToolStripMenuItem_Click);
+            this.saveSelectedSharedDeadletteredMessageToolStripMenuItem.Name = "saveSelectedSharedDeadletteredMessageToolStripMenuItem";
+            this.saveSelectedSharedDeadletteredMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.saveSelectedSharedDeadletteredMessageToolStripMenuItem.Text = "Save Selected Message";
+            this.saveSelectedSharedDeadletteredMessageToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedSharedDeadletteredMessageToolStripMenuItem_Click);
             // 
-            // saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem
+            // saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem
             // 
-            this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem.Name = "saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem";
-            this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem.Text = "Save Selected Message Text as File";
-            this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem_Click);
+            this.saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem.Name = "saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem";
+            this.saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem.Text = "Save Selected Message Text as File";
+            this.saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem_Click);
             // 
-            // saveSelectedDeadletteredMessagesToolStripMenuItem
+            // saveSelectedSharedDeadletteredMessagesToolStripMenuItem
             // 
-            this.saveSelectedDeadletteredMessagesToolStripMenuItem.Name = "saveSelectedDeadletteredMessagesToolStripMenuItem";
-            this.saveSelectedDeadletteredMessagesToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.saveSelectedDeadletteredMessagesToolStripMenuItem.Text = "Save Selected Messages";
-            this.saveSelectedDeadletteredMessagesToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedDeadletteredMessagesToolStripMenuItem_Click);
+            this.saveSelectedSharedDeadletteredMessagesToolStripMenuItem.Name = "saveSelectedSharedDeadletteredMessagesToolStripMenuItem";
+            this.saveSelectedSharedDeadletteredMessagesToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.saveSelectedSharedDeadletteredMessagesToolStripMenuItem.Text = "Save Selected Messages";
+            this.saveSelectedSharedDeadletteredMessagesToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedSharedDeadletteredMessagesToolStripMenuItem_Click);
             // 
-            // saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem
+            // saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem
             // 
-            this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem.Name = "saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem";
-            this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem.Text = "Save Selected Messages Text as File";
-            this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem_Click);
+            this.saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem.Name = "saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem";
+            this.saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem.Text = "Save Selected Messages Text as File";
+            this.saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem_Click);
             // 
-            // deleteSelectedMessageToolStripMenuItem
+            // deleteSelectedSharedDeadletterMessageToolStripMenuItem
             // 
-            this.deleteSelectedMessageToolStripMenuItem.Name = "deleteSelectedMessageToolStripMenuItem";
-            this.deleteSelectedMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.deleteSelectedMessageToolStripMenuItem.Text = "Delete Selected Message";
-            this.deleteSelectedMessageToolStripMenuItem.Click += new System.EventHandler(this.deleteSelectedDeadLetterMessageToolStripMenuItem_Click);
+            this.deleteSelectedSharedDeadletterMessageToolStripMenuItem.Name = "deleteSelectedSharedDeadletterMessageToolStripMenuItem";
+            this.deleteSelectedSharedDeadletterMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.deleteSelectedSharedDeadletterMessageToolStripMenuItem.Text = "Delete Selected Message";
+            this.deleteSelectedSharedDeadletterMessageToolStripMenuItem.Click += new System.EventHandler(this.deleteSelectedSharedDeadLetterMessageToolStripMenuItem_Click);
             // 
-            // deleteSelectedMessagesToolStripMenuItem
+            // deleteSelectedSharedDeadletterMessagesToolStripMenuItem
             // 
-            this.deleteSelectedMessagesToolStripMenuItem.Name = "deleteSelectedMessagesToolStripMenuItem";
-            this.deleteSelectedMessagesToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.deleteSelectedMessagesToolStripMenuItem.Text = "Delete Selected Messages";
-            this.deleteSelectedMessagesToolStripMenuItem.Click += new System.EventHandler(this.deleteSelectedDeadLetterMessagesToolStripMenuItem_Click);
+            this.deleteSelectedSharedDeadletterMessagesToolStripMenuItem.Name = "deleteSelectedSharedDeadletterMessagesToolStripMenuItem";
+            this.deleteSelectedSharedDeadletterMessagesToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.deleteSelectedSharedDeadletterMessagesToolStripMenuItem.Text = "Delete Selected Messages";
+            this.deleteSelectedSharedDeadletterMessagesToolStripMenuItem.Click += new System.EventHandler(this.deleteSelectedSharedDeadLetterMessagesToolStripMenuItem_Click);
             // 
             // btnPurgeMessages
             // 
@@ -2259,67 +2253,6 @@
             this.btnPurgeMessages.Click += new System.EventHandler(this.btnPurgeMessages_Click);
             this.btnPurgeMessages.MouseEnter += new System.EventHandler(this.button_MouseEnter);
             this.btnPurgeMessages.MouseLeave += new System.EventHandler(this.button_MouseLeave);
-            // 
-            // transferDeadletterContextMenuStrip
-            // 
-            this.transferDeadletterContextMenuStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.transferDeadletterContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.repairAndResubmitTransferDeadletterToolStripMenuItem,
-            this.resubmitSelectedTransferDeadletterInBatchModeToolStripMenuItem,
-            this.toolStripSeparator3,
-            this.saveSelectedTransferDeadletteredMessageToolStripMenuItem,
-            this.saveSelectedTransferDeadletteredMessageBodyAsFileToolStripMenuItem,
-            this.saveSelectedTransferDeadletteredMessagesToolStripMenuItem,
-            this.saveSelectedTransferDeadletteredMessagesBodyAsFileToolStripMenuItem});
-            this.transferDeadletterContextMenuStrip.Name = "registrationContextMenuStrip";
-            this.transferDeadletterContextMenuStrip.Size = new System.Drawing.Size(306, 142);
-            this.transferDeadletterContextMenuStrip.Click += new System.EventHandler(this.resubmitSelectedTransferDeadletterMessagesInBatchModeToolStripMenuItem_Click);
-            // 
-            // repairAndResubmitTransferDeadletterToolStripMenuItem
-            // 
-            this.repairAndResubmitTransferDeadletterToolStripMenuItem.Name = "repairAndResubmitTransferDeadletterToolStripMenuItem";
-            this.repairAndResubmitTransferDeadletterToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.repairAndResubmitTransferDeadletterToolStripMenuItem.Text = "Repair and Resubmit Selected Message";
-            this.repairAndResubmitTransferDeadletterToolStripMenuItem.Click += new System.EventHandler(this.repairAndResubmitTransferDeadletterMessageToolStripMenuItem_Click);
-            // 
-            // resubmitSelectedTransferDeadletterInBatchModeToolStripMenuItem
-            // 
-            this.resubmitSelectedTransferDeadletterInBatchModeToolStripMenuItem.Name = "resubmitSelectedTransferDeadletterInBatchModeToolStripMenuItem";
-            this.resubmitSelectedTransferDeadletterInBatchModeToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.resubmitSelectedTransferDeadletterInBatchModeToolStripMenuItem.Text = "Resubmit Selected Messages In Batch Mode";
-            // 
-            // toolStripSeparator3
-            // 
-            this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(302, 6);
-            // 
-            // saveSelectedTransferDeadletteredMessageToolStripMenuItem
-            // 
-            this.saveSelectedTransferDeadletteredMessageToolStripMenuItem.Name = "saveSelectedTransferDeadletteredMessageToolStripMenuItem";
-            this.saveSelectedTransferDeadletteredMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.saveSelectedTransferDeadletteredMessageToolStripMenuItem.Text = "Save Selected Message";
-            this.saveSelectedTransferDeadletteredMessageToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedTransferDeadletteredMessageToolStripMenuItem_Click);
-            // 
-            // saveSelectedTransferDeadletteredMessageBodyAsFileToolStripMenuItem
-            // 
-            this.saveSelectedTransferDeadletteredMessageBodyAsFileToolStripMenuItem.Name = "saveSelectedTransferDeadletteredMessageBodyAsFileToolStripMenuItem";
-            this.saveSelectedTransferDeadletteredMessageBodyAsFileToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.saveSelectedTransferDeadletteredMessageBodyAsFileToolStripMenuItem.Text = "Save Selected Message Text as File";
-            this.saveSelectedTransferDeadletteredMessageBodyAsFileToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedTransferDeadletteredMessageBodyAsFileToolStripMenuItem_Click);
-            // 
-            // saveSelectedTransferDeadletteredMessagesToolStripMenuItem
-            // 
-            this.saveSelectedTransferDeadletteredMessagesToolStripMenuItem.Name = "saveSelectedTransferDeadletteredMessagesToolStripMenuItem";
-            this.saveSelectedTransferDeadletteredMessagesToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.saveSelectedTransferDeadletteredMessagesToolStripMenuItem.Text = "Save Selected Messages";
-            this.saveSelectedTransferDeadletteredMessagesToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedTransferDeadletteredMessagesToolStripMenuItem_Click);
-            // 
-            // saveSelectedTransferDeadletteredMessagesBodyAsFileToolStripMenuItem
-            // 
-            this.saveSelectedTransferDeadletteredMessagesBodyAsFileToolStripMenuItem.Name = "saveSelectedTransferDeadletteredMessagesBodyAsFileToolStripMenuItem";
-            this.saveSelectedTransferDeadletteredMessagesBodyAsFileToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.saveSelectedTransferDeadletteredMessagesBodyAsFileToolStripMenuItem.Text = "Save Selected Messages Text as File";
-            this.saveSelectedTransferDeadletteredMessagesBodyAsFileToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedTransferDeadletteredMessagesBodyAsFileToolStripMenuItem_Click);
             // 
             // HandleQueueControl
             // 
@@ -2431,13 +2364,12 @@
             this.grouperSessionState.PerformLayout();
             this.grouperSessionProperties.ResumeLayout(false);
             this.messagesContextMenuStrip.ResumeLayout(false);
-            this.deadletterContextMenuStrip.ResumeLayout(false);
+            this.sharedDeadletterContextMenuStrip.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.messagesBindingSource)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.sessionsBindingSource)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.deadletterBindingSource)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.authorizationRulesBindingSource)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.transferDeadletterBindingSource)).EndInit();
-            this.transferDeadletterContextMenuStrip.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -2508,9 +2440,9 @@
         private System.Windows.Forms.ContextMenuStrip messagesContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem repairAndResubmitMessageToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem resubmitSelectedMessagesInBatchModeToolStripMenuItem;
-        private System.Windows.Forms.ContextMenuStrip deadletterContextMenuStrip;
-        private System.Windows.Forms.ToolStripMenuItem repairAndResubmitDeadletterToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem resubmitSelectedDeadletterInBatchModeToolStripMenuItem;
+        private System.Windows.Forms.ContextMenuStrip sharedDeadletterContextMenuStrip;
+        private System.Windows.Forms.ToolStripMenuItem repairAndResubmitSharedDeadletterToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem resubmitSelectedSharedDeadletterInBatchModeToolStripMenuItem;
         private System.Windows.Forms.PictureBox pictFindMessages;
         private System.Windows.Forms.PictureBox pictFindDeadletter;
         private System.Windows.Forms.PictureBox pictFindMessagesByDate;
@@ -2523,8 +2455,8 @@
         private System.Windows.Forms.SaveFileDialog saveFileDialog;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
-        private System.Windows.Forms.ToolStripMenuItem saveSelectedDeadletteredMessageToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem saveSelectedDeadletteredMessagesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveSelectedSharedDeadletteredMessageToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveSelectedSharedDeadletteredMessagesToolStripMenuItem;
         private System.Windows.Forms.Button btnPurgeDeadletterQueueMessages;
         private System.Windows.Forms.Button btnPurgeMessages;
         private System.Windows.Forms.TabPage tabPageTransferDeadletter;
@@ -2535,14 +2467,8 @@
         private System.Windows.Forms.PictureBox pictureBox1;
         private System.Windows.Forms.DataGridView transferDeadletterDataGridView;
         private System.Windows.Forms.BindingSource transferDeadletterBindingSource;
-        private System.Windows.Forms.ContextMenuStrip transferDeadletterContextMenuStrip;
-        private System.Windows.Forms.ToolStripMenuItem repairAndResubmitTransferDeadletterToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem resubmitSelectedTransferDeadletterInBatchModeToolStripMenuItem;
-        private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
-        private System.Windows.Forms.ToolStripMenuItem saveSelectedTransferDeadletteredMessageToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem saveSelectedTransferDeadletteredMessagesToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem deleteSelectedMessageToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem deleteSelectedMessagesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem deleteSelectedSharedDeadletterMessageToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem deleteSelectedSharedDeadletterMessagesToolStripMenuItem;
         private Grouper grouperMessageText;
         private FastColoredTextBoxNS.FastColoredTextBox txtMessageText;
         private System.Windows.Forms.SplitContainer messagePropertiesSplitContainer;
@@ -2563,10 +2489,8 @@
         private Grouper grouperTransferDeadletterCustomProperties;
         private System.Windows.Forms.ToolStripMenuItem saveSelectedMessageBodyAsFileToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveSelectedMessagesBodyAsFileToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem saveSelectedTransferDeadletteredMessageBodyAsFileToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem saveSelectedTransferDeadletteredMessagesBodyAsFileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem;
         private TimeSpanControl tsAutoDeleteOnIdle;
         private TimeSpanControl tsDefaultMessageTimeToLive;
         private TimeSpanControl tsLockDuration;
@@ -2574,7 +2498,7 @@
         private System.Windows.Forms.PropertyGrid messageCustomPropertyGrid;
         private System.Windows.Forms.PropertyGrid deadletterCustomPropertyGrid;
         private System.Windows.Forms.PropertyGrid transferDeadletterCustomPropertyGrid;
-        private System.Windows.Forms.ToolStripMenuItem resubmitDeadletterToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem resubmitSharedDeadletterToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem resubmitMessageToolStripMenuItem;
     }
 }

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -4286,12 +4286,13 @@ namespace ServiceBusExplorer.Controls
             resubmitSharedDeadletterToolStripMenuItem.Visible = !multipleSelectedRows;
             saveSelectedSharedDeadletteredMessageToolStripMenuItem.Visible = !multipleSelectedRows;
             saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem.Visible = !multipleSelectedRows;
-            deleteSelectedSharedDeadLetterMessageToolStripMenuItem.Visible = !multipleSelectedRows;
+            deleteSelectedSharedDeadletterMessageToolStripMenuItem.Visible = !multipleSelectedRows;
+
 
             resubmitSelectedSharedDeadletterInBatchModeToolStripMenuItem.Visible = multipleSelectedRows;
             saveSelectedSharedDeadletteredMessagesToolStripMenuItem.Visible = multipleSelectedRows;
             saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem.Visible = multipleSelectedRows;
-            deleteSelectedSharedDeadLetterMessagesToolStripMenuItem.Visible = multipleSelectedRows;
+            deleteSelectedSharedDeadletterMessagesToolStripMenuItem.Visible = multipleSelectedRows;
 
             sharedDeadletterContextMenuStrip.Show(Cursor.Position);
         }

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -3169,7 +3169,7 @@ namespace ServiceBusExplorer.Controls
                 return;
             }
             using (var messageForm = new MessageForm(queueDescription, 
-                MessageForm.SubqueueType.NotASubqueue, bindingList[e.RowIndex], serviceBusHelper, writeToLog))
+                MessageForm.QueueType.PrimaryQueue, bindingList[e.RowIndex], serviceBusHelper, writeToLog))
             {
                 messageForm.ShowDialog();
             }
@@ -3323,7 +3323,7 @@ namespace ServiceBusExplorer.Controls
 
             using (var form = new MessageForm(
                 queueDescription, 
-                MessageForm.SubqueueType.NotASubqueue,
+                MessageForm.QueueType.PrimaryQueue,
                 messagesDataGridView.SelectedRows.Cast<DataGridViewRow>()
                         .Select(r => (BrokeredMessage)r.DataBoundItem), 
                 serviceBusHelper, writeToLog))
@@ -3453,8 +3453,8 @@ namespace ServiceBusExplorer.Controls
                 using (var form = new MessageForm(
                     queueDescription, 
                     dataGridView == deadletterDataGridView 
-                        ? MessageForm.SubqueueType.Deadletter 
-                        : MessageForm.SubqueueType.TransferDeadletter, 
+                        ? MessageForm.QueueType.Deadletter 
+                        : MessageForm.QueueType.TransferDeadletter, 
                     dataGridView.SelectedRows.Cast<DataGridViewRow>()
                            .Select(r => (BrokeredMessage)r.DataBoundItem), 
                     serviceBusHelper, writeToLog))
@@ -4317,8 +4317,8 @@ namespace ServiceBusExplorer.Controls
 
             using (var messageForm = new MessageForm(queueDescription,
                 activeGridView == deadletterDataGridView 
-                    ? MessageForm.SubqueueType.Deadletter 
-                    : MessageForm.SubqueueType.TransferDeadletter, 
+                    ? MessageForm.QueueType.Deadletter 
+                    : MessageForm.QueueType.TransferDeadletter, 
                 bindingList[e.RowIndex], 
                 serviceBusHelper, 
                 writeToLog))

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.resx
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.resx
@@ -235,7 +235,7 @@
   <metadata name="messagesContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>975, 17</value>
   </metadata>
-  <metadata name="deadletterContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="sharedDeadletterContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>646, 58</value>
   </metadata>
   <metadata name="messagesBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -255,9 +255,6 @@
   </metadata>
   <metadata name="transferDeadletterBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>146, 58</value>
-  </metadata>
-  <metadata name="transferDeadletterContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>390, 57</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>116</value>

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.Designer.cs
@@ -1699,16 +1699,16 @@
             this.deadletterContextMenuStrip.Name = "registrationContextMenuStrip";
             this.deadletterContextMenuStrip.Size = new System.Drawing.Size(306, 186);
             // 
-            // repairAndResubmitDeadletterToolStripMenuItem
+            // repairAndResubmitSharedDeadletterToolStripMenuItem
             // 
-            this.repairAndResubmitDeadletterToolStripMenuItem.Name = "repairAndResubmitDeadletterToolStripMenuItem";
+            this.repairAndResubmitDeadletterToolStripMenuItem.Name = "repairAndResubmitSharedDeadletterToolStripMenuItem";
             this.repairAndResubmitDeadletterToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.repairAndResubmitDeadletterToolStripMenuItem.Text = "Repair And Resubmit Selected Message";
             this.repairAndResubmitDeadletterToolStripMenuItem.Click += new System.EventHandler(this.repairAndResubmitDeadletterMessageToolStripMenuItem_Click);
             // 
-            // resubmitDeadletterToolStripMenuItem
+            // resubmitSharedDeadletterToolStripMenuItem
             // 
-            this.resubmitDeadletterToolStripMenuItem.Name = "resubmitDeadletterToolStripMenuItem";
+            this.resubmitDeadletterToolStripMenuItem.Name = "resubmitSharedDeadletterToolStripMenuItem";
             this.resubmitDeadletterToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.resubmitDeadletterToolStripMenuItem.Text = "Resubmit Selected Message";
             this.resubmitDeadletterToolStripMenuItem.ToolTipText = "Resubmits the deadletter message with unchanged body.";
@@ -1740,16 +1740,16 @@
             this.saveSelectedDeadletteredMessagesToolStripMenuItem.Text = "Save Selected Messages";
             this.saveSelectedDeadletteredMessagesToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedDeadletteredMessagesToolStripMenuItem_Click);
             // 
-            // deleteSelectedMessageToolStripMenuItem
+            // deleteSelectedSharedDeadletterMessageToolStripMenuItem
             // 
-            this.deleteSelectedMessageToolStripMenuItem.Name = "deleteSelectedMessageToolStripMenuItem";
+            this.deleteSelectedMessageToolStripMenuItem.Name = "deleteSelectedSharedDeadletterMessageToolStripMenuItem";
             this.deleteSelectedMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.deleteSelectedMessageToolStripMenuItem.Text = "Delete Selected Message";
             this.deleteSelectedMessageToolStripMenuItem.Click += new System.EventHandler(this.deleteSelectedMessageToolStripMenuItem_Click);
             // 
-            // deleteSelectedMessagesToolStripMenuItem
+            // deleteSelectedSharedDeadletterMessagesToolStripMenuItem
             // 
-            this.deleteSelectedMessagesToolStripMenuItem.Name = "deleteSelectedMessagesToolStripMenuItem";
+            this.deleteSelectedMessagesToolStripMenuItem.Name = "deleteSelectedSharedDeadletterMessagesToolStripMenuItem";
             this.deleteSelectedMessagesToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.deleteSelectedMessagesToolStripMenuItem.Text = "Delete Selected Messages";
             this.deleteSelectedMessagesToolStripMenuItem.Click += new System.EventHandler(this.deleteSelectedMessagesToolStripMenuItem_Click);

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -2383,7 +2383,7 @@ namespace ServiceBusExplorer.Controls
                 stopwatch.Start();
 
                 var messagesDeleteCount = sequenceNumbersToDelete.Count;
-                var result = await deadLetterMessageHandler.DeleteMessages(sequenceNumbersToDelete);
+                var result = await deadLetterMessageHandler.DeleteMessages(sequenceNumbersToDelete, TransferDLQ: false);
                 RemoveDeadletterDataGridRows(result.DeletedSequenceNumbers);
 
                 if (messagesDeleteCount > result.DeletedSequenceNumbers.Count)

--- a/src/ServiceBusExplorer/Forms/MessageForm.cs
+++ b/src/ServiceBusExplorer/Forms/MessageForm.cs
@@ -82,7 +82,7 @@ namespace ServiceBusExplorer.Forms
         #endregion
 
         #region Private Instance Fields
-        SubqueueType subqueueType = SubqueueType.NotSet;
+        QueueType queueType = QueueType.NotSet;
 
         readonly IEnumerable<BrokeredMessage> brokeredMessages;
         readonly BrokeredMessage brokeredMessage;
@@ -118,10 +118,10 @@ namespace ServiceBusExplorer.Forms
         #endregion
 
         #region Public Enums
-        public enum SubqueueType
+        public enum QueueType
         {
             NotSet,
-            NotASubqueue,
+            PrimaryQueue,
             Deadletter,
             TransferDeadletter
         }
@@ -221,12 +221,12 @@ namespace ServiceBusExplorer.Forms
             }
         }
 
-        public MessageForm(QueueDescription queueDescription, SubqueueType subqueueType,  BrokeredMessage brokeredMessage,
+        public MessageForm(QueueDescription queueDescription, QueueType queueType,  BrokeredMessage brokeredMessage,
             ServiceBusHelper serviceBusHelper, WriteToLogDelegate writeToLog) :
             this(brokeredMessage, serviceBusHelper, writeToLog)
         {
             this.queueDescription = queueDescription;
-            this.subqueueType = subqueueType;
+            this.queueType = queueType;
         }
 
         public MessageForm(SubscriptionWrapper subscriptionWrapper, BrokeredMessage brokeredMessage,
@@ -273,12 +273,12 @@ namespace ServiceBusExplorer.Forms
             }
         }
 
-        public MessageForm(QueueDescription queueDescription, SubqueueType subqueueType, IEnumerable<BrokeredMessage> brokeredMessages,
+        public MessageForm(QueueDescription queueDescription, QueueType queueType, IEnumerable<BrokeredMessage> brokeredMessages,
             ServiceBusHelper serviceBusHelper, WriteToLogDelegate writeToLog) :
             this(brokeredMessages, serviceBusHelper, writeToLog)
         {
             this.queueDescription = queueDescription;
-            this.subqueueType = subqueueType;
+            this.queueType = queueType;
         }
 
         public MessageForm(SubscriptionWrapper subscriptionWrapper, IEnumerable<BrokeredMessage> brokeredMessages,
@@ -505,7 +505,7 @@ namespace ServiceBusExplorer.Forms
 
                             var result = await messageHandler.MoveMessages(messageSender,
                                 sequenceNumbers, 
-                                transferDLQ: subqueueType == SubqueueType.TransferDeadletter ? true: false, 
+                                transferDLQ: queueType == QueueType.TransferDeadletter, 
                                 outboundMessages);
 
                             RemovedSequenceNumbers = result.DeletedSequenceNumbers;

--- a/src/ServiceBusExplorer/UIHelpers/DataGridViewHelper.cs
+++ b/src/ServiceBusExplorer/UIHelpers/DataGridViewHelper.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+
+using Microsoft.ServiceBus.Messaging;
+
+namespace ServiceBusExplorer.UIHelpers
+{
+    internal static class DataGridViewHelper
+    {
+        static public void RemoveDataGridRowsUsingSequenceNumbers(DataGridView dataGridView,
+            IEnumerable<long> sequenceNumbersToRemove)
+        {
+            var rowsToRemove = new List<DataGridViewRow>(sequenceNumbersToRemove.Count());
+
+            foreach (DataGridViewRow row in dataGridView.Rows)
+            {
+                var message = (BrokeredMessage)row.DataBoundItem;
+
+                if (sequenceNumbersToRemove.Contains(message.SequenceNumber))
+                {
+                    rowsToRemove.Add(row);
+
+                    if (rowsToRemove.Count >= sequenceNumbersToRemove.Count())
+                    {
+                        break;
+                    }
+                }
+            }
+
+            for (var rowIndex = rowsToRemove.Count - 1; rowIndex >= 0; --rowIndex)
+            {
+                var row = rowsToRemove[rowIndex];
+                dataGridView.Rows.Remove(row);
+            }
+
+            dataGridView.ClearSelection();
+        }
+    }
+}


### PR DESCRIPTION
Before this PR the context menu when selecting a single Transfer DLQ message looks like this:
![image](https://github.com/paolosalvatori/ServiceBusExplorer/assets/9644248/2d37db61-62ac-45d5-899d-e0bc47c5b81e)

and when selecting multiple messages it looks like this:
![image](https://github.com/paolosalvatori/ServiceBusExplorer/assets/9644248/7e019adf-b340-4bcf-a7b1-66c6824790f7)

This PR removes the separate handling of the Transfer Deadletter context menus, they are now the same as for the Deadletter context menus. A lot of the code for handling messages in these subqueues is now shared. 

Also added the feature to selectively delete Transfer deadletter messages.

The above is only added for queues and not for subscriptions as the transfer deadletter support is a bit mysterious for subscriptions.