### PR TITLE
Default to use the config file in user profile

### DIFF
--- a/src/Common/Helpers/TwoFilesConfiguration.cs
+++ b/src/Common/Helpers/TwoFilesConfiguration.cs
@@ -616,7 +616,7 @@ namespace ServiceBusExplorer.Helpers
                     ConfigurationParameters.ConfigurationConfigFileParameter, resultStringApp, typeof(ConfigFileUse));
             }
 
-            return ConfigFileUse.ApplicationConfig;  // Default to Application for backwards compability
+            return ConfigFileUse.UserConfig;  // Default to User file for better performance
         }
 
         static ConfigFileUse AquireConfigFileUseValue()


### PR DESCRIPTION
Default to use the config file in the user profile directory instead of the application directory. 

Fixes #621 