### PR TITLE
Use new functionality to force VS run in DPI unaware mode

### DIFF
--- a/src/ServiceBusExplorer/ServiceBusExplorer.csproj
+++ b/src/ServiceBusExplorer/ServiceBusExplorer.csproj
@@ -7,6 +7,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
 
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>


### PR DESCRIPTION
According to https://learn.microsoft.com/en-us/dotnet/desktop/winforms/whats-new/net80?view=netdesktop-8.0#visual-studio-dpi-improvements this will force VS to load the project in the selected DPI awareness mode. Unfortunately it does not work on my machine, but it may work on someone else's. 

I think anything that lessens the risk of the UI scaling issue #784 happening again is worth a lot.



