### PR TITLE
First set changes to enable high DPI in Service Bus Explorer

### DIFF
--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{DE07DBEB-D772-49BA-BCEB-A7CE29308AE3}</ProjectGuid>
     <RootNamespace>ServiceBusExplorer.Common</RootNamespace>
     <AssemblyName>ServiceBusExplorer.Common</AssemblyName>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/src/Common/app.config
+++ b/src/Common/app.config
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.6.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/src/Common/app.config
+++ b/src/Common/app.config
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.6.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -44,7 +44,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.6.0.0" newVersion="1.6.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.38.0.0" newVersion="1.38.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/NotificationHubs/NotificationHubs.csproj
+++ b/src/NotificationHubs/NotificationHubs.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{E836C914-9BFE-4C1C-96E5-6A414CDEF485}</ProjectGuid>
     <RootNamespace>ServiceBusExplorer.NotificationHubs</RootNamespace>
     <AssemblyName>ServiceBusExplorer.NotificationHubs</AssemblyName>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <AssemblyTitle>NotificationHubs</AssemblyTitle>
     <Product>NotificationHubs</Product>
     <Copyright>Copyright ©  2019</Copyright>

--- a/src/NotificationHubs/app.config
+++ b/src/NotificationHubs/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/ServiceBusExplorer.Tests/ServiceBusExplorer.Tests.csproj
+++ b/src/ServiceBusExplorer.Tests/ServiceBusExplorer.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{41D3C27D-37FF-43B8-AAC0-4F483E507698}</ProjectGuid>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyTitle>ServiceBusExplorer.Tests</AssemblyTitle>
     <Company>Microsoft</Company>

--- a/src/ServiceBusExplorer.Tests/ServiceBusExplorer.Tests.csproj
+++ b/src/ServiceBusExplorer.Tests/ServiceBusExplorer.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{41D3C27D-37FF-43B8-AAC0-4F483E507698}</ProjectGuid>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyTitle>ServiceBusExplorer.Tests</AssemblyTitle>
     <Company>Microsoft</Company>

--- a/src/ServiceBusExplorer.Tests/app.config
+++ b/src/ServiceBusExplorer.Tests/app.config
@@ -49,7 +49,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral"/>

--- a/src/ServiceBusExplorer/App.config
+++ b/src/ServiceBusExplorer/App.config
@@ -86,8 +86,4 @@
       </bindingExtensions>
     </extensions>
   </system.serviceModel>
-  <!--<System.Windows.Forms.ApplicationConfigurationSection>
-    <add key="DpiAwareness" value="PerMonitorV2" />
-    <add key="EnableWindowsFormsHighDpiAutoResizing" value="true" />
-  </System.Windows.Forms.ApplicationConfigurationSection>-->
 </configuration>

--- a/src/ServiceBusExplorer/App.config
+++ b/src/ServiceBusExplorer/App.config
@@ -55,9 +55,10 @@
     <add key="messageDeferProvider" value="ServiceBusExplorer.Helpers.InMemoryMessageDeferProvider,ServiceBusExplorer.Common" />
     <add key="Microsoft.ServiceBus.X509RevocationMode" value="NoCheck" />
     <add key="ClientSettingsProvider.ServiceUri" value="" />
+    <add key="EnableWindowsFormsHighDpiAutoResizing" value="true" />
   </appSettings>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
   </startup>
   <system.serviceModel>
     <extensions>
@@ -85,7 +86,8 @@
       </bindingExtensions>
     </extensions>
   </system.serviceModel>
-  <System.Windows.Forms.ApplicationConfigurationSection>
+  <!--<System.Windows.Forms.ApplicationConfigurationSection>
     <add key="DpiAwareness" value="PerMonitorV2" />
-  </System.Windows.Forms.ApplicationConfigurationSection>
+    <add key="EnableWindowsFormsHighDpiAutoResizing" value="true" />
+  </System.Windows.Forms.ApplicationConfigurationSection>-->
 </configuration>

--- a/src/ServiceBusExplorer/App.config
+++ b/src/ServiceBusExplorer/App.config
@@ -57,7 +57,7 @@
     <add key="ClientSettingsProvider.ServiceUri" value="" />
   </appSettings>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
   </startup>
   <system.serviceModel>
     <extensions>
@@ -85,4 +85,7 @@
       </bindingExtensions>
     </extensions>
   </system.serviceModel>
+  <System.Windows.Forms.ApplicationConfigurationSection>
+    <add key="DpiAwareness" value="PerMonitorV2" />
+  </System.Windows.Forms.ApplicationConfigurationSection>
 </configuration>

--- a/src/ServiceBusExplorer/Controls/Grouper.cs
+++ b/src/ServiceBusExplorer/Controls/Grouper.cs
@@ -26,443 +26,443 @@ using System.Windows.Forms;
 
 namespace ServiceBusExplorer.Controls
 {
-	/// <summary>A special custom rounding GroupBox with many painting features.</summary>
-	[ToolboxBitmap(typeof(Grouper), "CodeVendor.Controls.Grouper.bmp")]
-	[Designer("System.Windows.Forms.Design.ParentControlDesigner, System.Design", typeof(IDesigner))]
-	public class Grouper : UserControl
-	{
-		#region Enumerations
+    /// <summary>A special custom rounding GroupBox with many painting features.</summary>
+    [ToolboxBitmap(typeof(Grouper), "CodeVendor.Controls.Grouper.bmp")]
+    [Designer("System.Windows.Forms.Design.ParentControlDesigner, System.Design", typeof(IDesigner))]
+    public class Grouper : UserControl
+    {
+        #region Enumerations
 
-		/// <summary>A special gradient enumeration.</summary>
-		public enum GroupBoxGradientMode
-		{
-			/// <summary>Specifies no gradient mode.</summary>
-			None = 4,
+        /// <summary>A special gradient enumeration.</summary>
+        public enum GroupBoxGradientMode
+        {
+            /// <summary>Specifies no gradient mode.</summary>
+            None = 4,
 
-			/// <summary>Specifies a gradient from upper right to lower left.</summary>
-			BackwardDiagonal = 3,
+            /// <summary>Specifies a gradient from upper right to lower left.</summary>
+            BackwardDiagonal = 3,
 
-			/// <summary>Specifies a gradient from upper left to lower right.</summary>
-			ForwardDiagonal = 2,
+            /// <summary>Specifies a gradient from upper left to lower right.</summary>
+            ForwardDiagonal = 2,
 
-			/// <summary>Specifies a gradient from left to right.</summary>
-			Horizontal = 0,
+            /// <summary>Specifies a gradient from left to right.</summary>
+            Horizontal = 0,
 
-			/// <summary>Specifies a gradient from top to bottom.</summary>
-			Vertical = 1
-		}
+            /// <summary>Specifies a gradient from top to bottom.</summary>
+            Vertical = 1
+        }
 
-		
-		#endregion
+
+        #endregion
 
         public event Action<PaintEventArgs> CustomPaint;
 
-		#region Variables
+        #region Variables
 
-		private Container components = null;
-		private int V_RoundCorners = 10;
-		private string V_GroupTitle = "The Grouper";
-		private Color V_BorderColor = Color.Black;
-		private float V_BorderThickness = 1;
-		private bool V_ShadowControl = false;
-		private Color V_BackgroundColor = Color.White;
-		private Color V_BackgroundGradientColor = Color.White;
-		private GroupBoxGradientMode V_BackgroundGradientMode = GroupBoxGradientMode.None;
-		private Color V_ShadowColor = Color.DarkGray;
-		private int V_ShadowThickness = 3;
-		private Image V_GroupImage = null;
-		private Color V_CustomGroupBoxColor = Color.White;
-		private bool V_PaintGroupBox = false;
-		private Color V_BackColor = Color.Transparent;
+        private Container components = null;
+        private int V_RoundCorners = 10;
+        private string V_GroupTitle = "The Grouper";
+        private Color V_BorderColor = Color.Black;
+        private float V_BorderThickness = 1;
+        private bool V_ShadowControl = false;
+        private Color V_BackgroundColor = Color.White;
+        private Color V_BackgroundGradientColor = Color.White;
+        private GroupBoxGradientMode V_BackgroundGradientMode = GroupBoxGradientMode.None;
+        private Color V_ShadowColor = Color.DarkGray;
+        private int V_ShadowThickness = 3;
+        private Image V_GroupImage = null;
+        private Color V_CustomGroupBoxColor = Color.White;
+        private bool V_PaintGroupBox = false;
+        private Color V_BackColor = Color.Transparent;
 
-		#endregion
+        #endregion
 
-		#region Properties
+        #region Properties
 
-		/// <summary>This feature will paint the background color of the control.</summary>
-		[Category("Appearance"), Description("This feature will paint the background color of the control.")]
-		public override Color BackColor{get{return V_BackColor;} set{V_BackColor=value; this.Refresh();}}
+        /// <summary>This feature will paint the background color of the control.</summary>
+        [Category("Appearance"), Description("This feature will paint the background color of the control.")]
+        public override Color BackColor { get { return V_BackColor; } set { V_BackColor = value; this.Refresh(); } }
 
-		/// <summary>This feature will paint the group title background to the specified color if PaintGroupBox is set to true.</summary>
-		[Category("Appearance"), Description("This feature will paint the group title background to the specified color if PaintGroupBox is set to true.")]
-		public Color CustomGroupBoxColor{get{return V_CustomGroupBoxColor;} set{V_CustomGroupBoxColor=value; this.Refresh();}}
+        /// <summary>This feature will paint the group title background to the specified color if PaintGroupBox is set to true.</summary>
+        [Category("Appearance"), Description("This feature will paint the group title background to the specified color if PaintGroupBox is set to true.")]
+        public Color CustomGroupBoxColor { get { return V_CustomGroupBoxColor; } set { V_CustomGroupBoxColor = value; this.Refresh(); } }
 
-		/// <summary>This feature will paint the group title background to the CustomGroupBoxColor.</summary>
-		[Category("Appearance"), Description("This feature will paint the group title background to the CustomGroupBoxColor.")]
-		public bool PaintGroupBox{get{return V_PaintGroupBox;} set{V_PaintGroupBox=value; this.Refresh();}}
+        /// <summary>This feature will paint the group title background to the CustomGroupBoxColor.</summary>
+        [Category("Appearance"), Description("This feature will paint the group title background to the CustomGroupBoxColor.")]
+        public bool PaintGroupBox { get { return V_PaintGroupBox; } set { V_PaintGroupBox = value; this.Refresh(); } }
 
-		/// <summary>This feature can add a 16 x 16 image to the group title bar.</summary>
-		[Category("Appearance"), Description("This feature can add a 16 x 16 image to the group title bar.")]
-		public Image GroupImage{get{return V_GroupImage;} set{V_GroupImage=value; this.Refresh();}}
+        /// <summary>This feature can add a 16 x 16 image to the group title bar.</summary>
+        [Category("Appearance"), Description("This feature can add a 16 x 16 image to the group title bar.")]
+        public Image GroupImage { get { return V_GroupImage; } set { V_GroupImage = value; this.Refresh(); } }
 
-		/// <summary>This feature will change the control's shadow color.</summary>
-		[Category("Appearance"), Description("This feature will change the control's shadow color.")]
-		public Color ShadowColor{get{return V_ShadowColor;} set{V_ShadowColor=value; this.Refresh();}}
+        /// <summary>This feature will change the control's shadow color.</summary>
+        [Category("Appearance"), Description("This feature will change the control's shadow color.")]
+        public Color ShadowColor { get { return V_ShadowColor; } set { V_ShadowColor = value; this.Refresh(); } }
 
-		/// <summary>This feature will change the size of the shadow border.</summary>
-		[Category("Appearance"), Description("This feature will change the size of the shadow border.")]
-		public int ShadowThickness
-		{
-			get{return V_ShadowThickness;} 
-			set
-			{
-				if(value>10)
-				{
-					V_ShadowThickness=10;
-				}
-				else
-				{
-					if(value<1){V_ShadowThickness=1;}
-					else{V_ShadowThickness=value; }
-				}
+        /// <summary>This feature will change the size of the shadow border.</summary>
+        [Category("Appearance"), Description("This feature will change the size of the shadow border.")]
+        public int ShadowThickness
+        {
+            get { return V_ShadowThickness; }
+            set
+            {
+                if (value > 10)
+                {
+                    V_ShadowThickness = 10;
+                }
+                else
+                {
+                    if (value < 1) { V_ShadowThickness = 1; }
+                    else { V_ShadowThickness = value; }
+                }
 
-				this.Refresh();
-			}
-		}
-
-		
-		/// <summary>This feature will change the group control color. This color can also be used in combination with BackgroundGradientColor for a gradient paint.</summary>
-		[Category("Appearance"), Description("This feature will change the group control color. This color can also be used in combination with BackgroundGradientColor for a gradient paint.")]
-		public Color BackgroundColor{get{return V_BackgroundColor;} set{V_BackgroundColor=value; this.Refresh();}}
-
-		/// <summary>This feature can be used in combination with BackgroundColor to create a gradient background.</summary>
-		[Category("Appearance"), Description("This feature can be used in combination with BackgroundColor to create a gradient background.")]
-		public Color BackgroundGradientColor{get{return V_BackgroundGradientColor;} set{V_BackgroundGradientColor=value; this.Refresh();}}
-		
-		/// <summary>This feature turns on background gradient painting.</summary>
-		[Category("Appearance"), Description("This feature turns on background gradient painting.")]
-		public GroupBoxGradientMode BackgroundGradientMode{get{return V_BackgroundGradientMode;} set{V_BackgroundGradientMode=value; this.Refresh();}}
-
-		/// <summary>This feature will round the corners of the control.</summary>
-		[Category("Appearance"), Description("This feature will round the corners of the control.")]
-		public int RoundCorners
-		{
-			get{return V_RoundCorners;} 
-			set
-			{
-				if(value>25)
-				{
-					V_RoundCorners=25;
-				}
-				else
-				{
-					if(value<1){V_RoundCorners=1;}
-					else{V_RoundCorners=value; }
-				}
-				
-				this.Refresh();
-			}
-		}
-
-		/// <summary>This feature will add a group title to the control.</summary>
-		[Category("Appearance"), Description("This feature will add a group title to the control.")]
-		public string GroupTitle{get{return V_GroupTitle;} set{V_GroupTitle=value; this.Refresh();}}
-
-		/// <summary>This feature will allow you to change the color of the control's border.</summary>
-		[Category("Appearance"), Description("This feature will allow you to change the color of the control's border.")]
-		public Color BorderColor{get{return V_BorderColor;} set{V_BorderColor=value; this.Refresh();}}
-
-		/// <summary>This feature will allow you to set the control's border size.</summary>
-		[Category("Appearance"), Description("This feature will allow you to set the control's border size.")]
-		public float BorderThickness
-		{
-			get{return V_BorderThickness;} 
-			set
-			{
-				if(value>3)
-				{
-					V_BorderThickness=3;
-				}
-				else
-				{
-					if(value<1){V_BorderThickness=1;}
-					else{V_BorderThickness=value;}
-				}
-				this.Refresh();
-			}
-		}
-
-		/// <summary>This feature will allow you to turn on control shadowing.</summary>
-		[Category("Appearance"), Description("This feature will allow you to turn on control shadowing.")]
-		public bool ShadowControl{get{return V_ShadowControl;} set{V_ShadowControl=value; this.Refresh();}}
-
-		#endregion
-
-		#region Constructor
-		
-		/// <summary>This method will construct a new GroupBox control.</summary>
-		public Grouper()
-		{
-			InitializeStyles();
-			InitializeGroupBox();
-		}
-
-	
-		#endregion
-
-		#region DeConstructor
-
-		/// <summary>This method will dispose of the GroupBox control.</summary>
-		protected override void Dispose( bool disposing )
-		{
-			if(disposing){if(components!=null){components.Dispose();}}
-			base.Dispose(disposing);
-		}
+                this.Refresh();
+            }
+        }
 
 
-		#endregion
+        /// <summary>This feature will change the group control color. This color can also be used in combination with BackgroundGradientColor for a gradient paint.</summary>
+        [Category("Appearance"), Description("This feature will change the group control color. This color can also be used in combination with BackgroundGradientColor for a gradient paint.")]
+        public Color BackgroundColor { get { return V_BackgroundColor; } set { V_BackgroundColor = value; this.Refresh(); } }
 
-		#region Initialization
+        /// <summary>This feature can be used in combination with BackgroundColor to create a gradient background.</summary>
+        [Category("Appearance"), Description("This feature can be used in combination with BackgroundColor to create a gradient background.")]
+        public Color BackgroundGradientColor { get { return V_BackgroundGradientColor; } set { V_BackgroundGradientColor = value; this.Refresh(); } }
 
-		/// <summary>This method will initialize the controls custom styles.</summary>
-		private void InitializeStyles()
-		{
-			//Set the control styles----------------------------------
-			this.SetStyle(ControlStyles.DoubleBuffer, true);
-			this.SetStyle(ControlStyles.AllPaintingInWmPaint, true);
-			this.SetStyle(ControlStyles.UserPaint, true);
-			this.SetStyle(ControlStyles.SupportsTransparentBackColor, true);
-			//--------------------------------------------------------
-		}
+        /// <summary>This feature turns on background gradient painting.</summary>
+        [Category("Appearance"), Description("This feature turns on background gradient painting.")]
+        public GroupBoxGradientMode BackgroundGradientMode { get { return V_BackgroundGradientMode; } set { V_BackgroundGradientMode = value; this.Refresh(); } }
+
+        /// <summary>This feature will round the corners of the control.</summary>
+        [Category("Appearance"), Description("This feature will round the corners of the control.")]
+        public int RoundCorners
+        {
+            get { return V_RoundCorners; }
+            set
+            {
+                if (value > 25)
+                {
+                    V_RoundCorners = 25;
+                }
+                else
+                {
+                    if (value < 1) { V_RoundCorners = 1; }
+                    else { V_RoundCorners = value; }
+                }
+
+                this.Refresh();
+            }
+        }
+
+        /// <summary>This feature will add a group title to the control.</summary>
+        [Category("Appearance"), Description("This feature will add a group title to the control.")]
+        public string GroupTitle { get { return V_GroupTitle; } set { V_GroupTitle = value; this.Refresh(); } }
+
+        /// <summary>This feature will allow you to change the color of the control's border.</summary>
+        [Category("Appearance"), Description("This feature will allow you to change the color of the control's border.")]
+        public Color BorderColor { get { return V_BorderColor; } set { V_BorderColor = value; this.Refresh(); } }
+
+        /// <summary>This feature will allow you to set the control's border size.</summary>
+        [Category("Appearance"), Description("This feature will allow you to set the control's border size.")]
+        public float BorderThickness
+        {
+            get { return V_BorderThickness; }
+            set
+            {
+                if (value > 3)
+                {
+                    V_BorderThickness = 3;
+                }
+                else
+                {
+                    if (value < 1) { V_BorderThickness = 1; }
+                    else { V_BorderThickness = value; }
+                }
+                this.Refresh();
+            }
+        }
+
+        /// <summary>This feature will allow you to turn on control shadowing.</summary>
+        [Category("Appearance"), Description("This feature will allow you to turn on control shadowing.")]
+        public bool ShadowControl { get { return V_ShadowControl; } set { V_ShadowControl = value; this.Refresh(); } }
+
+        #endregion
+
+        #region Constructor
+
+        /// <summary>This method will construct a new GroupBox control.</summary>
+        public Grouper()
+        {
+            InitializeStyles();
+            InitializeGroupBox();
+        }
 
 
-		/// <summary>This method will initialize the GroupBox control.</summary>
-		private void InitializeGroupBox()
-		{
-			components = new Container();
-			this.Resize+=new EventHandler(GroupBox_Resize);
-			this.DockPadding.All = 20;
-			this.Name = "GroupBox";
-			this.Size = new Size(368, 288);
-		}
+        #endregion
 
-	
-		#endregion
+        #region DeConstructor
 
-		#region Protected Methods
-		
-		/// <summary>Overrides the OnPaint method to paint control.</summary>
-		/// <param name="e">The paint event arguments.</param>
-		protected override void OnPaint(PaintEventArgs e)
-		{
-			PaintBack(e.Graphics);
-			PaintGroupText(e.Graphics);
+        /// <summary>This method will dispose of the GroupBox control.</summary>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) { if (components != null) { components.Dispose(); } }
+            base.Dispose(disposing);
+        }
+
+
+        #endregion
+
+        #region Initialization
+
+        /// <summary>This method will initialize the controls custom styles.</summary>
+        private void InitializeStyles()
+        {
+            //Set the control styles----------------------------------
+            this.SetStyle(ControlStyles.DoubleBuffer, true);
+            this.SetStyle(ControlStyles.AllPaintingInWmPaint, true);
+            this.SetStyle(ControlStyles.UserPaint, true);
+            this.SetStyle(ControlStyles.SupportsTransparentBackColor, true);
+            //--------------------------------------------------------
+        }
+
+
+        /// <summary>This method will initialize the GroupBox control.</summary>
+        private void InitializeGroupBox()
+        {
+            components = new Container();
+            this.Resize += new EventHandler(GroupBox_Resize);
+            this.DockPadding.All = 20;
+            this.Name = "GroupBox";
+            this.Size = new Size(368, 288);
+        }
+
+
+        #endregion
+
+        #region Protected Methods
+
+        /// <summary>Overrides the OnPaint method to paint control.</summary>
+        /// <param name="e">The paint event arguments.</param>
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            PaintBack(e.Graphics);
+            PaintGroupText(e.Graphics);
             if (CustomPaint != null)
             {
                 CustomPaint(e);
             }
-		}
+        }
 
-		#endregion
+        #endregion
 
-		#region Private Methods
+        #region Private Methods
 
-		/// <summary>This method will paint the group title.</summary>
-		/// <param name="g">The paint event graphics object.</param>
-		private void PaintGroupText(Graphics g)
-		{
-			//Check if string has something-------------
-			if(GroupTitle==string.Empty){return;}
-			//------------------------------------------
+        /// <summary>This method will paint the group title.</summary>
+        /// <param name="g">The paint event graphics object.</param>
+        private void PaintGroupText(Graphics g)
+        {
+            //Check if string has something-------------
+            if (GroupTitle == string.Empty) { return; }
+            //------------------------------------------
 
-			//Set Graphics smoothing mode to Anit-Alias-- 
-			g.SmoothingMode = SmoothingMode.AntiAlias;
-			//-------------------------------------------
+            //Set Graphics smoothing mode to Anti-Alias-- 
+            g.SmoothingMode = SmoothingMode.AntiAlias;
+            //-------------------------------------------
 
-			//Declare Variables------------------
-			var StringSize = g.MeasureString(this.GroupTitle, this.Font);
-			var StringSize2 = StringSize.ToSize();
-			if(this.GroupImage!=null){StringSize2.Width+=18;}
-			var ArcWidth = this.RoundCorners;
-			var ArcHeight = this.RoundCorners;
-			var ArcX1 = 20;
-			var ArcX2 = (StringSize2.Width+34) - (ArcWidth + 1);
-			var ArcY1 = 0;
-			var ArcY2 = 24 - (ArcHeight + 1);
-			var path = new GraphicsPath();
-			Brush BorderBrush = new SolidBrush(this.BorderColor);
-			var BorderPen = new Pen(BorderBrush, this.BorderThickness);
-			LinearGradientBrush BackgroundGradientBrush = null;
-			Brush BackgroundBrush = (this.PaintGroupBox) ? new SolidBrush(this.CustomGroupBoxColor) : new SolidBrush(this.BackgroundColor);
-			var TextColorBrush = new SolidBrush(this.ForeColor);
-			SolidBrush ShadowBrush = null;
-			GraphicsPath ShadowPath  = null;
-			//-----------------------------------
+            //Declare Variables------------------
+            var StringSize = g.MeasureString(this.GroupTitle, this.Font);
+            var StringSize2 = StringSize.ToSize();
+            if (this.GroupImage != null) { StringSize2.Width += 18; }
+            var ArcWidth = this.RoundCorners;
+            var ArcHeight = this.RoundCorners;
+            var ArcX1 = 20;
+            var ArcX2 = (StringSize2.Width + 34) - (ArcWidth + 1);
+            var ArcY1 = 0;
+            var ArcY2 = LogicalToDeviceUnits(24 - (ArcHeight + 1));
+            var path = new GraphicsPath();
+            Brush BorderBrush = new SolidBrush(this.BorderColor);
+            var BorderPen = new Pen(BorderBrush, this.BorderThickness);
+            LinearGradientBrush BackgroundGradientBrush = null;
+            Brush BackgroundBrush = (this.PaintGroupBox) ? new SolidBrush(this.CustomGroupBoxColor) : new SolidBrush(this.BackgroundColor);
+            var TextColorBrush = new SolidBrush(this.ForeColor);
+            SolidBrush ShadowBrush = null;
+            GraphicsPath ShadowPath = null;
+            //-----------------------------------
 
-			//Check if shadow is needed----------
-			if(ShadowControl)
-			{
-				ShadowBrush = new SolidBrush(this.ShadowColor);
-				ShadowPath = new GraphicsPath();
-				ShadowPath.AddArc(ArcX1+(this.ShadowThickness-1), ArcY1+(this.ShadowThickness-1), ArcWidth, ArcHeight, 180, GroupBoxConstants.SweepAngle); // TopCount Left
-				ShadowPath.AddArc(ArcX2+(this.ShadowThickness-1), ArcY1+(this.ShadowThickness-1), ArcWidth, ArcHeight, 270, GroupBoxConstants.SweepAngle); //TopCount Right
-				ShadowPath.AddArc(ArcX2+(this.ShadowThickness-1), ArcY2+(this.ShadowThickness-1), ArcWidth, ArcHeight, 360, GroupBoxConstants.SweepAngle); //Bottom Right
-				ShadowPath.AddArc(ArcX1+(this.ShadowThickness-1), ArcY2+(this.ShadowThickness-1), ArcWidth, ArcHeight, 90, GroupBoxConstants.SweepAngle); //Bottom Left
-				ShadowPath.CloseAllFigures();
+            //Check if shadow is needed----------
+            if (ShadowControl)
+            {
+                ShadowBrush = new SolidBrush(this.ShadowColor);
+                ShadowPath = new GraphicsPath();
+                ShadowPath.AddArc(ArcX1 + (this.ShadowThickness - 1), ArcY1 + (this.ShadowThickness - 1), ArcWidth, ArcHeight, 180, GroupBoxConstants.SweepAngle); // TopCount Left
+                ShadowPath.AddArc(ArcX2 + (this.ShadowThickness - 1), ArcY1 + (this.ShadowThickness - 1), ArcWidth, ArcHeight, 270, GroupBoxConstants.SweepAngle); //TopCount Right
+                ShadowPath.AddArc(ArcX2 + (this.ShadowThickness - 1), ArcY2 + (this.ShadowThickness - 1), ArcWidth, ArcHeight, 360, GroupBoxConstants.SweepAngle); //Bottom Right
+                ShadowPath.AddArc(ArcX1 + (this.ShadowThickness - 1), ArcY2 + (this.ShadowThickness - 1), ArcWidth, ArcHeight, 90, GroupBoxConstants.SweepAngle); //Bottom Left
+                ShadowPath.CloseAllFigures();
 
-				//Paint Rounded Rectangle------------
-				g.FillPath(ShadowBrush, ShadowPath);
-				//-----------------------------------
-			}
-			//-----------------------------------
+                //Paint Rounded Rectangle------------
+                g.FillPath(ShadowBrush, ShadowPath);
+                //-----------------------------------
+            }
+            //-----------------------------------
 
-			//Create Rounded Rectangle Path------
-			path.AddArc(ArcX1, ArcY1, ArcWidth, ArcHeight, 180, GroupBoxConstants.SweepAngle); // TopCount Left
-			path.AddArc(ArcX2, ArcY1, ArcWidth, ArcHeight, 270, GroupBoxConstants.SweepAngle); //TopCount Right
-			path.AddArc(ArcX2, ArcY2, ArcWidth, ArcHeight, 360, GroupBoxConstants.SweepAngle); //Bottom Right
-			path.AddArc(ArcX1, ArcY2, ArcWidth, ArcHeight, 90, GroupBoxConstants.SweepAngle); //Bottom Left
-			path.CloseAllFigures(); 
-			//-----------------------------------
+            //Create Rounded Rectangle Path------
+            path.AddArc(ArcX1, ArcY1, ArcWidth, ArcHeight, 180, GroupBoxConstants.SweepAngle); // TopCount Left
+            path.AddArc(ArcX2, ArcY1, ArcWidth, ArcHeight, 270, GroupBoxConstants.SweepAngle); //TopCount Right
+            path.AddArc(ArcX2, ArcY2, ArcWidth, ArcHeight, 360, GroupBoxConstants.SweepAngle); //Bottom Right
+            path.AddArc(ArcX1, ArcY2, ArcWidth, ArcHeight, 90, GroupBoxConstants.SweepAngle); //Bottom Left
+            path.CloseAllFigures();
+            //-----------------------------------
 
-			//Check if Gradient Mode is enabled--
-			if(this.PaintGroupBox)
-			{
-				//Paint Rounded Rectangle------------
-				g.FillPath(BackgroundBrush, path);
-				//-----------------------------------
-			}
-			else
-			{
-				if(this.BackgroundGradientMode==GroupBoxGradientMode.None)
-				{
-					//Paint Rounded Rectangle------------
-					g.FillPath(BackgroundBrush, path);
-					//-----------------------------------
-				}
-				else
-				{
-					BackgroundGradientBrush = new LinearGradientBrush(new Rectangle(0,0,this.Width,this.Height), this.BackgroundColor, this.BackgroundGradientColor, (LinearGradientMode)this.BackgroundGradientMode);
-				
-					//Paint Rounded Rectangle------------
-					g.FillPath(BackgroundGradientBrush, path);
-					//-----------------------------------
-				}
-			}
-			//-----------------------------------
+            //Check if Gradient Mode is enabled--
+            if (this.PaintGroupBox)
+            {
+                //Paint Rounded Rectangle------------
+                g.FillPath(BackgroundBrush, path);
+                //-----------------------------------
+            }
+            else
+            {
+                if (this.BackgroundGradientMode == GroupBoxGradientMode.None)
+                {
+                    //Paint Rounded Rectangle------------
+                    g.FillPath(BackgroundBrush, path);
+                    //-----------------------------------
+                }
+                else
+                {
+                    BackgroundGradientBrush = new LinearGradientBrush(new Rectangle(0, 0, this.Width, this.Height), this.BackgroundColor, this.BackgroundGradientColor, (LinearGradientMode)this.BackgroundGradientMode);
 
-			//Paint Borded-----------------------
-			g.DrawPath(BorderPen, path);
-			//-----------------------------------
+                    //Paint Rounded Rectangle------------
+                    g.FillPath(BackgroundGradientBrush, path);
+                    //-----------------------------------
+                }
+            }
+            //-----------------------------------
 
-			//Paint Text-------------------------
-			var CustomStringWidth = (this.GroupImage!=null) ? 44 : 28;
-			g.DrawString(this.GroupTitle, this.Font, TextColorBrush, CustomStringWidth, 5);
-			//-----------------------------------
+            //Paint Border-----------------------
+            g.DrawPath(BorderPen, path);
+            //-----------------------------------
 
-			//Draw GroupImage if there is one----
-			if(this.GroupImage!=null)
-			{
-				g.DrawImage(this.GroupImage, 28,4, 16, 16);
-			}
-			//-----------------------------------
+            //Paint Text-------------------------
+            var CustomStringWidth = (this.GroupImage != null) ? 44 : 28;
+            g.DrawString(this.GroupTitle, this.Font, TextColorBrush, CustomStringWidth, 5);
+            //-----------------------------------
 
-			//Destroy Graphic Objects------------
-		    path?.Dispose();
-		    BorderBrush?.Dispose();
-		    BorderPen?.Dispose();
-		    BackgroundGradientBrush?.Dispose();
-		    BackgroundBrush?.Dispose();
-		    TextColorBrush?.Dispose();
-		    ShadowBrush?.Dispose();
-		    ShadowPath?.Dispose();
+            //Draw GroupImage if there is one----
+            if (this.GroupImage != null)
+            {
+                g.DrawImage(this.GroupImage, 28, 4, 16, 16);
+            }
+            //-----------------------------------
 
-		    //-----------------------------------
-		}
+            //Destroy Graphic Objects------------
+            path?.Dispose();
+            BorderBrush?.Dispose();
+            BorderPen?.Dispose();
+            BackgroundGradientBrush?.Dispose();
+            BackgroundBrush?.Dispose();
+            TextColorBrush?.Dispose();
+            ShadowBrush?.Dispose();
+            ShadowPath?.Dispose();
 
-		
-		/// <summary>This method will paint the control.</summary>
-		/// <param name="g">The paint event graphics object.</param>
-		private void PaintBack(Graphics g)
-		{
-			//Set Graphics smoothing mode to Anit-Alias-- 
-			g.SmoothingMode = SmoothingMode.AntiAlias;
-			//-------------------------------------------
-
-			//Declare Variables------------------
-			var ArcWidth = this.RoundCorners * 2;
-			var ArcHeight = this.RoundCorners * 2;
-			var ArcX1 = 0;
-			var ArcX2 = (this.ShadowControl) ? (this.Width - (ArcWidth + 1))-this.ShadowThickness : this.Width - (ArcWidth + 1);
-			var ArcY1 = 10;
-			var ArcY2 = (this.ShadowControl) ? (this.Height - (ArcHeight + 1))-this.ShadowThickness : this.Height - (ArcHeight + 1);
-			var path = new GraphicsPath();
-			Brush BorderBrush = new SolidBrush(this.BorderColor);
-			var BorderPen = new Pen(BorderBrush, this.BorderThickness);
-			LinearGradientBrush BackgroundGradientBrush = null;
-			Brush BackgroundBrush = new SolidBrush(this.BackgroundColor);
-			SolidBrush ShadowBrush = null;
-			GraphicsPath ShadowPath  = null;
-			//-----------------------------------
-
-			//Check if shadow is needed----------
-			if(this.ShadowControl)
-			{
-				ShadowBrush = new SolidBrush(this.ShadowColor);
-				ShadowPath = new GraphicsPath();
-				ShadowPath.AddArc(ArcX1+this.ShadowThickness, ArcY1+this.ShadowThickness, ArcWidth, ArcHeight, 180, GroupBoxConstants.SweepAngle); // TopCount Left
-				ShadowPath.AddArc(ArcX2+this.ShadowThickness, ArcY1+this.ShadowThickness, ArcWidth, ArcHeight, 270, GroupBoxConstants.SweepAngle); //TopCount Right
-				ShadowPath.AddArc(ArcX2+this.ShadowThickness, ArcY2+this.ShadowThickness, ArcWidth, ArcHeight, 360, GroupBoxConstants.SweepAngle); //Bottom Right
-				ShadowPath.AddArc(ArcX1+this.ShadowThickness, ArcY2+this.ShadowThickness, ArcWidth, ArcHeight, 90, GroupBoxConstants.SweepAngle); //Bottom Left
-				ShadowPath.CloseAllFigures();
-
-				//Paint Rounded Rectangle------------
-				g.FillPath(ShadowBrush, ShadowPath);
-				//-----------------------------------
-			}
-			//-----------------------------------
-
-			//Create Rounded Rectangle Path------
-			path.AddArc(ArcX1, ArcY1, ArcWidth, ArcHeight, 180, GroupBoxConstants.SweepAngle); // TopCount Left
-			path.AddArc(ArcX2, ArcY1, ArcWidth, ArcHeight, 270, GroupBoxConstants.SweepAngle); //TopCount Right
-			path.AddArc(ArcX2, ArcY2, ArcWidth, ArcHeight, 360, GroupBoxConstants.SweepAngle); //Bottom Right
-			path.AddArc(ArcX1, ArcY2, ArcWidth, ArcHeight, 90, GroupBoxConstants.SweepAngle); //Bottom Left
-			path.CloseAllFigures(); 
-			//-----------------------------------
-
-			//Check if Gradient Mode is enabled--
-			if(this.BackgroundGradientMode==GroupBoxGradientMode.None)
-			{
-				//Paint Rounded Rectangle------------
-				g.FillPath(BackgroundBrush, path);
-				//-----------------------------------
-			}
-			else
-			{
-				BackgroundGradientBrush = new LinearGradientBrush(new Rectangle(0,0,this.Width,this.Height), this.BackgroundColor, this.BackgroundGradientColor, (LinearGradientMode)this.BackgroundGradientMode);
-				
-				//Paint Rounded Rectangle------------
-				g.FillPath(BackgroundGradientBrush, path);
-				//-----------------------------------
-			}
-			//-----------------------------------
-
-			//Paint Borded-----------------------
-			g.DrawPath(BorderPen, path);
-			//-----------------------------------
-
-			//Destroy Graphic Objects------------
-		    path?.Dispose();
-		    BorderBrush?.Dispose();
-		    BorderPen?.Dispose();
-		    BackgroundGradientBrush?.Dispose();
-		    BackgroundBrush?.Dispose();
-		    ShadowBrush?.Dispose();
-		    ShadowPath?.Dispose();
-		    //-----------------------------------
-		}
-
-	
-		/// <summary>This method fires when the GroupBox resize event occurs.</summary>
-		/// <param name="sender">The object the sent the event.</param>
-		/// <param name="e">The event arguments.</param>
-		private void GroupBox_Resize(object sender, EventArgs e)
-		{
-			this.Refresh();
-		}
+            //-----------------------------------
+        }
 
 
-		#endregion
-	}
+        /// <summary>This method will paint the control.</summary>
+        /// <param name="g">The paint event graphics object.</param>
+        private void PaintBack(Graphics g)
+        {
+            //Set Graphics smoothing mode to Anti-Alias-- 
+            g.SmoothingMode = SmoothingMode.AntiAlias;
+            //-------------------------------------------
+
+            //Declare Variables------------------
+            var ArcWidth = this.RoundCorners * 2;
+            var ArcHeight = this.RoundCorners * 2;
+            var ArcX1 = 0;
+            var ArcX2 = (this.ShadowControl) ? (this.Width - (ArcWidth + 1)) - this.ShadowThickness : this.Width - (ArcWidth + 1);
+            var ArcY1 = 10;
+            var ArcY2 = (this.ShadowControl) ? (this.Height - (ArcHeight + 1)) - this.ShadowThickness : this.Height - (ArcHeight + 1);
+            var path = new GraphicsPath();
+            Brush BorderBrush = new SolidBrush(this.BorderColor);
+            var BorderPen = new Pen(BorderBrush, this.BorderThickness);
+            LinearGradientBrush BackgroundGradientBrush = null;
+            Brush BackgroundBrush = new SolidBrush(this.BackgroundColor);
+            SolidBrush ShadowBrush = null;
+            GraphicsPath ShadowPath = null;
+            //-----------------------------------
+
+            //Check if shadow is needed----------
+            if (this.ShadowControl)
+            {
+                ShadowBrush = new SolidBrush(this.ShadowColor);
+                ShadowPath = new GraphicsPath();
+                ShadowPath.AddArc(ArcX1 + this.ShadowThickness, ArcY1 + this.ShadowThickness, ArcWidth, ArcHeight, 180, GroupBoxConstants.SweepAngle); // TopCount Left
+                ShadowPath.AddArc(ArcX2 + this.ShadowThickness, ArcY1 + this.ShadowThickness, ArcWidth, ArcHeight, 270, GroupBoxConstants.SweepAngle); //TopCount Right
+                ShadowPath.AddArc(ArcX2 + this.ShadowThickness, ArcY2 + this.ShadowThickness, ArcWidth, ArcHeight, 360, GroupBoxConstants.SweepAngle); //Bottom Right
+                ShadowPath.AddArc(ArcX1 + this.ShadowThickness, ArcY2 + this.ShadowThickness, ArcWidth, ArcHeight, 90, GroupBoxConstants.SweepAngle); //Bottom Left
+                ShadowPath.CloseAllFigures();
+
+                //Paint Rounded Rectangle------------
+                g.FillPath(ShadowBrush, ShadowPath);
+                //-----------------------------------
+            }
+            //-----------------------------------
+
+            //Create Rounded Rectangle Path------
+            path.AddArc(ArcX1, ArcY1, ArcWidth, ArcHeight, 180, GroupBoxConstants.SweepAngle); // TopCount Left
+            path.AddArc(ArcX2, ArcY1, ArcWidth, ArcHeight, 270, GroupBoxConstants.SweepAngle); //TopCount Right
+            path.AddArc(ArcX2, ArcY2, ArcWidth, ArcHeight, 360, GroupBoxConstants.SweepAngle); //Bottom Right
+            path.AddArc(ArcX1, ArcY2, ArcWidth, ArcHeight, 90, GroupBoxConstants.SweepAngle); //Bottom Left
+            path.CloseAllFigures();
+            //-----------------------------------
+
+            //Check if Gradient Mode is enabled--
+            if (this.BackgroundGradientMode == GroupBoxGradientMode.None)
+            {
+                //Paint Rounded Rectangle------------
+                g.FillPath(BackgroundBrush, path);
+                //-----------------------------------
+            }
+            else
+            {
+                BackgroundGradientBrush = new LinearGradientBrush(new Rectangle(0, 0, this.Width, this.Height), this.BackgroundColor, this.BackgroundGradientColor, (LinearGradientMode)this.BackgroundGradientMode);
+
+                //Paint Rounded Rectangle------------
+                g.FillPath(BackgroundGradientBrush, path);
+                //-----------------------------------
+            }
+            //-----------------------------------
+
+            //Paint Border-----------------------
+            g.DrawPath(BorderPen, path);
+            //-----------------------------------
+
+            //Destroy Graphic Objects------------
+            path?.Dispose();
+            BorderBrush?.Dispose();
+            BorderPen?.Dispose();
+            BackgroundGradientBrush?.Dispose();
+            BackgroundBrush?.Dispose();
+            ShadowBrush?.Dispose();
+            ShadowPath?.Dispose();
+            //-----------------------------------
+        }
+
+
+        /// <summary>This method fires when the GroupBox resize event occurs.</summary>
+        /// <param name="sender">The object the sent the event.</param>
+        /// <param name="e">The event arguments.</param>
+        private void GroupBox_Resize(object sender, EventArgs e)
+        {
+            this.Refresh();
+        }
+
+
+        #endregion
+    }
 
     public class GroupBoxConstants
     {

--- a/src/ServiceBusExplorer/Controls/HandleTopicControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleTopicControl.cs
@@ -979,7 +979,7 @@ namespace ServiceBusExplorer.Controls
                     // If we have images, process them.
                     if (images != null)
                     {
-                        // Get sice and image.
+                        // Get size and image.
                         var size = images.ImageSize;
                         Image icon = null;
                         if (page.ImageIndex > -1)

--- a/src/ServiceBusExplorer/Controls/HeaderPanel.cs
+++ b/src/ServiceBusExplorer/Controls/HeaderPanel.cs
@@ -40,6 +40,7 @@ namespace ServiceBusExplorer.Controls
         private Color headerColor2 = SystemColors.ActiveCaption;
         private Color iconTransparentColor = Color.White;
         private Image icon = null;
+        private Bitmap iconBitmap = null;
         #endregion
 
         #region Public Properties
@@ -142,61 +143,56 @@ namespace ServiceBusExplorer.Controls
                 // Draw border;
                 DrawBorder(e.Graphics);
 
-                // Draw heaeder
+                // Draw header
                 DrawHeader(e.Graphics);
-
-                // Draw text
-                DrawText(e.Graphics);
 
                 // Draw Icon
                 DrawIcon(e.Graphics);
+
+                // Draw text
+                DrawText(e.Graphics);
             }
         }
 
         private void DrawBorder(Graphics graphics)
         {
-            using (var pen = new Pen(this.headerColor2))
-            {
-                graphics.DrawRectangle(pen, 0, 0, this.Width - 1, this.Height - 1);
-            }
+            using var pen = new Pen(this.headerColor2);
+            graphics.DrawRectangle(pen, 0, 0, this.Width - 1, this.Height - 1);
         }
 
         private void DrawHeader(Graphics graphics)
         {
-            var headerRect = new Rectangle(1, 1, this.Width - 2, this.headerHeight);
-            using (Brush brush = new LinearGradientBrush(headerRect, headerColor1, headerColor2, LinearGradientMode.Vertical))
-            {
-                graphics.FillRectangle(brush, headerRect);
-            }
+            var headerRect = new Rectangle(1, 1, this.Width - 2, LogicalToDeviceUnits(this.headerHeight));
+            using Brush brush = new LinearGradientBrush(headerRect, headerColor1, headerColor2, LinearGradientMode.Vertical);
+            graphics.FillRectangle(brush, headerRect);
         }
 
         private void DrawText(Graphics graphics)
         {
             if (string.IsNullOrWhiteSpace(this.headerText)) return;
             var size = graphics.MeasureString(this.headerText, this.headerFont);
-            using (Brush brush = new SolidBrush(ForeColor))
+            using Brush brush = new SolidBrush(ForeColor);
+            float x;
+            if (this.iconBitmap != null)
             {
-                float x;
-                if (this.icon != null)
-                {
-                    x = this.icon.Width + 6;
-                }
-                else
-                {
-                    x = 4;
-                }
-                graphics.DrawString(this.headerText, this.headerFont, brush, x, (headerHeight - size.Height) / 2);
+                x = this.iconBitmap.Width + 6;
             }
+            else
+            {
+                x = 4;
+            }
+            graphics.DrawString(this.headerText, this.headerFont, brush, x, (LogicalToDeviceUnits(this.headerHeight) - size.Height) / 2);
         }
 
         private void DrawIcon(Graphics graphics)
         {
             if (icon != null)
             {
-                var point = new Point(4, (headerHeight - icon.Height) / 2);
-                var bitmap = new Bitmap(icon);
-                bitmap.MakeTransparent(iconTransparentColor);
-                graphics.DrawImage(bitmap, point);
+                iconBitmap = new Bitmap(icon);
+                iconBitmap.MakeTransparent(iconTransparentColor);
+                ScaleBitmapLogicalToDevice(ref iconBitmap);
+                var point = new Point(4, (LogicalToDeviceUnits(this.headerHeight) - iconBitmap.Height) / 2);
+                graphics.DrawImage(iconBitmap, point);
             }
         }
         #endregion

--- a/src/ServiceBusExplorer/Forms/ChangeStatusForm.cs
+++ b/src/ServiceBusExplorer/Forms/ChangeStatusForm.cs
@@ -40,6 +40,7 @@ namespace ServiceBusExplorer.Forms
         private const string DisableFormat = "This operation will disable the {0} {1}. Do you want to continue?";
         private const string SetStatusFormat = "This operation will set the status of the {0} {1} to {2}. Do you want to continue?";
         private const string Unknown = "Unknown";
+        private const int widthPadding = 88;
         #endregion
 
         #region Public Constructor
@@ -60,7 +61,7 @@ namespace ServiceBusExplorer.Forms
                 lblMessage.Text = string.Format(SetStatusFormat, entityType ?? Unknown, entityName ?? Unknown, desiredStatus.ToString());
             }
             
-            Width = lblMessage.Width + 72;
+            Width = lblMessage.Width + LogicalToDeviceUnits(widthPadding);
         }
         #endregion
 

--- a/src/ServiceBusExplorer/Forms/ClipboardForm.cs
+++ b/src/ServiceBusExplorer/Forms/ClipboardForm.cs
@@ -31,12 +31,14 @@ namespace ServiceBusExplorer.Forms
 {
     public partial class ClipboardForm : Form
     {
+        private const int widthPadding = 88;
+
         #region Public Constructor
         public ClipboardForm(string url)
         {
             InitializeComponent();
             lblUrl.Text = string.Format(url);
-            Width = lblUrl.Width + 80;
+            Width = lblUrl.Width + LogicalToDeviceUnits(widthPadding);
         }
         #endregion
 

--- a/src/ServiceBusExplorer/Forms/ConnectForm.cs
+++ b/src/ServiceBusExplorer/Forms/ConnectForm.cs
@@ -23,15 +23,15 @@
 
 #region Using Directives
 
+using Microsoft.ServiceBus;
+using Microsoft.ServiceBus.Messaging;
+using ServiceBusExplorer.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
 using System.Linq;
 using System.Windows.Forms;
-using ServiceBusExplorer.Helpers;
-using Microsoft.ServiceBus;
-using Microsoft.ServiceBus.Messaging;
 
 #endregion
 
@@ -377,9 +377,11 @@ namespace ServiceBusExplorer.Forms
             if (cboServiceBusNamespace.Text == EnterConnectionString ||
                 connectionStringType == ServiceBusNamespaceType.OnPremises || containsStsEndpoint)
             {
+                var newHeight = txtIssuerSecret.Location.Y + txtIssuerSecret.Size.Height - txtUri.Location.Y;
+
                 lblUri.Text = ConnectionStringLabel;
                 txtUri.Multiline = true;
-                txtUri.Size = new Size(336, 220);
+                txtUri.Size = new Size(txtUri.Size.Width, newHeight);
                 txtUri.Text = string.Empty;
                 toolTip.SetToolTip(txtUri, ConnectionStringTooltip);
             }
@@ -387,7 +389,7 @@ namespace ServiceBusExplorer.Forms
             {
                 lblUri.Text = UriLabel;
                 txtUri.Multiline = false;
-                txtUri.Size = new Size(336, 20);
+                txtUri.Size = new Size(txtUri.Size.Width, 20);
                 toolTip.SetToolTip(txtUri, UriTooltip);
             }
             if (cboServiceBusNamespace.SelectedIndex <= 1)

--- a/src/ServiceBusExplorer/Forms/ConnectForm.designer.cs
+++ b/src/ServiceBusExplorer/Forms/ConnectForm.designer.cs
@@ -59,19 +59,6 @@ namespace ServiceBusExplorer.Forms
             this.btnOk = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
-            this.btnClearSubscriptionFilterExpression = new System.Windows.Forms.Button();
-            this.btnClearTopicFilterExpression = new System.Windows.Forms.Button();
-            this.btnClearQueueFilterExpression = new System.Windows.Forms.Button();
-            this.btnOpenSubscriptionFilterForm = new System.Windows.Forms.Button();
-            this.txtSubscriptionFilterExpression = new System.Windows.Forms.TextBox();
-            this.btnOpenTopicFilterForm = new System.Windows.Forms.Button();
-            this.btnOpenQueueFilterForm = new System.Windows.Forms.Button();
-            this.txtQueueFilterExpression = new System.Windows.Forms.TextBox();
-            this.txtTopicFilterExpression = new System.Windows.Forms.TextBox();
-            this.txtIssuerSecret = new System.Windows.Forms.TextBox();
-            this.txtIssuerName = new System.Windows.Forms.TextBox();
-            this.txtNamespace = new System.Windows.Forms.TextBox();
-            this.txtEntityPath = new System.Windows.Forms.TextBox();
             this.logoPictureBox = new System.Windows.Forms.PictureBox();
             this.btnSave = new System.Windows.Forms.Button();
             this.btnRename = new System.Windows.Forms.Button();
@@ -81,21 +68,33 @@ namespace ServiceBusExplorer.Forms
             this.grouperFilters = new ServiceBusExplorer.Controls.Grouper();
             this.lblSelectedEntities = new System.Windows.Forms.Label();
             this.cboSelectedEntities = new ServiceBusExplorer.Controls.CheckBoxComboBox();
+            this.btnClearSubscriptionFilterExpression = new System.Windows.Forms.Button();
+            this.btnClearTopicFilterExpression = new System.Windows.Forms.Button();
+            this.btnClearQueueFilterExpression = new System.Windows.Forms.Button();
+            this.btnOpenSubscriptionFilterForm = new System.Windows.Forms.Button();
+            this.txtSubscriptionFilterExpression = new System.Windows.Forms.TextBox();
             this.lblSubscriptionFilterExpression = new System.Windows.Forms.Label();
+            this.btnOpenTopicFilterForm = new System.Windows.Forms.Button();
+            this.btnOpenQueueFilterForm = new System.Windows.Forms.Button();
+            this.txtQueueFilterExpression = new System.Windows.Forms.TextBox();
             this.lblQueueFilterExpression = new System.Windows.Forms.Label();
+            this.txtTopicFilterExpression = new System.Windows.Forms.TextBox();
             this.lblTopicFilterExpression = new System.Windows.Forms.Label();
             this.grouperServiceBusNamespaceSettings = new ServiceBusExplorer.Controls.Grouper();
             this.useAmqpWebSocketsCheckBox = new System.Windows.Forms.CheckBox();
-            this.lblNewSdkTransportType = new System.Windows.Forms.Label();
             this.cboTransportType = new System.Windows.Forms.ComboBox();
             this.lblTransportType = new System.Windows.Forms.Label();
             this.cboConnectivityMode = new System.Windows.Forms.ComboBox();
             this.lblConnectivityMode = new System.Windows.Forms.Label();
             this.txtUri = new System.Windows.Forms.TextBox();
             this.lblUri = new System.Windows.Forms.Label();
+            this.txtIssuerSecret = new System.Windows.Forms.TextBox();
             this.lblIssuerSecret = new System.Windows.Forms.Label();
+            this.txtIssuerName = new System.Windows.Forms.TextBox();
             this.lblIssuerName = new System.Windows.Forms.Label();
+            this.txtNamespace = new System.Windows.Forms.TextBox();
             this.lblNamespace = new System.Windows.Forms.Label();
+            this.txtEntityPath = new System.Windows.Forms.TextBox();
             this.lblEntityPath = new System.Windows.Forms.Label();
             this.grouperServiceBusNamespaces = new ServiceBusExplorer.Controls.Grouper();
             this.cboServiceBusNamespace = new System.Windows.Forms.ComboBox();
@@ -114,7 +113,7 @@ namespace ServiceBusExplorer.Forms
             this.btnOk.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnOk.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnOk.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnOk.Location = new System.Drawing.Point(616, 443);
+            this.btnOk.Location = new System.Drawing.Point(676, 443);
             this.btnOk.Name = "btnOk";
             this.btnOk.Size = new System.Drawing.Size(72, 24);
             this.btnOk.TabIndex = 7;
@@ -132,7 +131,7 @@ namespace ServiceBusExplorer.Forms
             this.btnCancel.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCancel.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnCancel.Location = new System.Drawing.Point(696, 443);
+            this.btnCancel.Location = new System.Drawing.Point(756, 443);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(72, 24);
             this.btnCancel.TabIndex = 8;
@@ -142,227 +141,13 @@ namespace ServiceBusExplorer.Forms
             this.btnCancel.MouseEnter += new System.EventHandler(this.button_MouseEnter);
             this.btnCancel.MouseLeave += new System.EventHandler(this.button_MouseLeave);
             // 
-            // btnClearSubscriptionFilterExpression
-            // 
-            this.btnClearSubscriptionFilterExpression.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnClearSubscriptionFilterExpression.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
-            this.btnClearSubscriptionFilterExpression.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-            this.btnClearSubscriptionFilterExpression.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnClearSubscriptionFilterExpression.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnClearSubscriptionFilterExpression.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnClearSubscriptionFilterExpression.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnClearSubscriptionFilterExpression.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold);
-            this.btnClearSubscriptionFilterExpression.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(92)))), ((int)(((byte)(125)))), ((int)(((byte)(150)))));
-            this.btnClearSubscriptionFilterExpression.Location = new System.Drawing.Point(328, 190);
-            this.btnClearSubscriptionFilterExpression.Name = "btnClearSubscriptionFilterExpression";
-            this.btnClearSubscriptionFilterExpression.Size = new System.Drawing.Size(24, 21);
-            this.btnClearSubscriptionFilterExpression.TabIndex = 13;
-            this.btnClearSubscriptionFilterExpression.Text = "X";
-            this.btnClearSubscriptionFilterExpression.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-            this.toolTip.SetToolTip(this.btnClearSubscriptionFilterExpression, "Click to cancel the filter expression for subscriptions.");
-            this.btnClearSubscriptionFilterExpression.UseVisualStyleBackColor = false;
-            this.btnClearSubscriptionFilterExpression.Click += new System.EventHandler(this.btnClearSubscriptionFilterExpression_Click);
-            this.btnClearSubscriptionFilterExpression.MouseEnter += new System.EventHandler(this.button_MouseEnter);
-            this.btnClearSubscriptionFilterExpression.MouseLeave += new System.EventHandler(this.clearButton_MouseLeave);
-            // 
-            // btnClearTopicFilterExpression
-            // 
-            this.btnClearTopicFilterExpression.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnClearTopicFilterExpression.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
-            this.btnClearTopicFilterExpression.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-            this.btnClearTopicFilterExpression.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnClearTopicFilterExpression.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnClearTopicFilterExpression.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnClearTopicFilterExpression.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnClearTopicFilterExpression.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold);
-            this.btnClearTopicFilterExpression.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(92)))), ((int)(((byte)(125)))), ((int)(((byte)(150)))));
-            this.btnClearTopicFilterExpression.Location = new System.Drawing.Point(328, 142);
-            this.btnClearTopicFilterExpression.Name = "btnClearTopicFilterExpression";
-            this.btnClearTopicFilterExpression.Size = new System.Drawing.Size(24, 21);
-            this.btnClearTopicFilterExpression.TabIndex = 9;
-            this.btnClearTopicFilterExpression.Text = "X";
-            this.btnClearTopicFilterExpression.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-            this.toolTip.SetToolTip(this.btnClearTopicFilterExpression, "Click to cancel the filter expression for topics.");
-            this.btnClearTopicFilterExpression.UseVisualStyleBackColor = false;
-            this.btnClearTopicFilterExpression.Click += new System.EventHandler(this.btnClearTopicFilterExpression_Click);
-            this.btnClearTopicFilterExpression.MouseEnter += new System.EventHandler(this.button_MouseEnter);
-            this.btnClearTopicFilterExpression.MouseLeave += new System.EventHandler(this.clearButton_MouseLeave);
-            // 
-            // btnClearQueueFilterExpression
-            // 
-            this.btnClearQueueFilterExpression.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnClearQueueFilterExpression.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
-            this.btnClearQueueFilterExpression.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-            this.btnClearQueueFilterExpression.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnClearQueueFilterExpression.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnClearQueueFilterExpression.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnClearQueueFilterExpression.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnClearQueueFilterExpression.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold);
-            this.btnClearQueueFilterExpression.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(92)))), ((int)(((byte)(125)))), ((int)(((byte)(150)))));
-            this.btnClearQueueFilterExpression.Location = new System.Drawing.Point(328, 94);
-            this.btnClearQueueFilterExpression.Name = "btnClearQueueFilterExpression";
-            this.btnClearQueueFilterExpression.Size = new System.Drawing.Size(24, 21);
-            this.btnClearQueueFilterExpression.TabIndex = 5;
-            this.btnClearQueueFilterExpression.Text = "X";
-            this.btnClearQueueFilterExpression.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-            this.toolTip.SetToolTip(this.btnClearQueueFilterExpression, "Click to cancel the filter expression for queues.");
-            this.btnClearQueueFilterExpression.UseVisualStyleBackColor = false;
-            this.btnClearQueueFilterExpression.Click += new System.EventHandler(this.btnClearQueueFilterExpression_Click);
-            this.btnClearQueueFilterExpression.MouseEnter += new System.EventHandler(this.button_MouseEnter);
-            this.btnClearQueueFilterExpression.MouseLeave += new System.EventHandler(this.clearButton_MouseLeave);
-            // 
-            // btnOpenSubscriptionFilterForm
-            // 
-            this.btnOpenSubscriptionFilterForm.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnOpenSubscriptionFilterForm.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
-            this.btnOpenSubscriptionFilterForm.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnOpenSubscriptionFilterForm.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnOpenSubscriptionFilterForm.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnOpenSubscriptionFilterForm.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnOpenSubscriptionFilterForm.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnOpenSubscriptionFilterForm.Location = new System.Drawing.Point(296, 190);
-            this.btnOpenSubscriptionFilterForm.Name = "btnOpenSubscriptionFilterForm";
-            this.btnOpenSubscriptionFilterForm.Size = new System.Drawing.Size(24, 21);
-            this.btnOpenSubscriptionFilterForm.TabIndex = 12;
-            this.btnOpenSubscriptionFilterForm.Text = "...";
-            this.btnOpenSubscriptionFilterForm.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-            this.toolTip.SetToolTip(this.btnOpenSubscriptionFilterForm, "Click to open the filter expression dialog for subscriptions.");
-            this.btnOpenSubscriptionFilterForm.UseVisualStyleBackColor = false;
-            this.btnOpenSubscriptionFilterForm.Click += new System.EventHandler(this.btnOpenSubscriptionFilterForm_Click);
-            this.btnOpenSubscriptionFilterForm.MouseEnter += new System.EventHandler(this.button_MouseEnter);
-            this.btnOpenSubscriptionFilterForm.MouseLeave += new System.EventHandler(this.button_MouseLeave);
-            // 
-            // txtSubscriptionFilterExpression
-            // 
-            this.txtSubscriptionFilterExpression.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtSubscriptionFilterExpression.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.txtSubscriptionFilterExpression.Location = new System.Drawing.Point(16, 190);
-            this.txtSubscriptionFilterExpression.Name = "txtSubscriptionFilterExpression";
-            this.txtSubscriptionFilterExpression.Size = new System.Drawing.Size(272, 20);
-            this.txtSubscriptionFilterExpression.TabIndex = 11;
-            this.toolTip.SetToolTip(this.txtSubscriptionFilterExpression, "Gets or sets the OData filter for topics.");
-            // 
-            // btnOpenTopicFilterForm
-            // 
-            this.btnOpenTopicFilterForm.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnOpenTopicFilterForm.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
-            this.btnOpenTopicFilterForm.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnOpenTopicFilterForm.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnOpenTopicFilterForm.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnOpenTopicFilterForm.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnOpenTopicFilterForm.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnOpenTopicFilterForm.Location = new System.Drawing.Point(296, 142);
-            this.btnOpenTopicFilterForm.Name = "btnOpenTopicFilterForm";
-            this.btnOpenTopicFilterForm.Size = new System.Drawing.Size(24, 21);
-            this.btnOpenTopicFilterForm.TabIndex = 8;
-            this.btnOpenTopicFilterForm.Text = "...";
-            this.btnOpenTopicFilterForm.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-            this.toolTip.SetToolTip(this.btnOpenTopicFilterForm, "Click to open the filter expression dialog for topics.");
-            this.btnOpenTopicFilterForm.UseVisualStyleBackColor = false;
-            this.btnOpenTopicFilterForm.Click += new System.EventHandler(this.btnOpenTopicFilterForm_Click);
-            this.btnOpenTopicFilterForm.MouseEnter += new System.EventHandler(this.button_MouseEnter);
-            this.btnOpenTopicFilterForm.MouseLeave += new System.EventHandler(this.button_MouseLeave);
-            // 
-            // btnOpenQueueFilterForm
-            // 
-            this.btnOpenQueueFilterForm.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnOpenQueueFilterForm.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
-            this.btnOpenQueueFilterForm.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnOpenQueueFilterForm.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnOpenQueueFilterForm.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
-            this.btnOpenQueueFilterForm.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnOpenQueueFilterForm.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnOpenQueueFilterForm.Location = new System.Drawing.Point(296, 94);
-            this.btnOpenQueueFilterForm.Name = "btnOpenQueueFilterForm";
-            this.btnOpenQueueFilterForm.Size = new System.Drawing.Size(24, 21);
-            this.btnOpenQueueFilterForm.TabIndex = 4;
-            this.btnOpenQueueFilterForm.Text = "...";
-            this.btnOpenQueueFilterForm.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-            this.toolTip.SetToolTip(this.btnOpenQueueFilterForm, "Click to open the filter expression dialog for queues.");
-            this.btnOpenQueueFilterForm.UseVisualStyleBackColor = false;
-            this.btnOpenQueueFilterForm.Click += new System.EventHandler(this.btnOpenQueueFilterForm_Click);
-            this.btnOpenQueueFilterForm.MouseEnter += new System.EventHandler(this.button_MouseEnter);
-            this.btnOpenQueueFilterForm.MouseLeave += new System.EventHandler(this.button_MouseLeave);
-            // 
-            // txtQueueFilterExpression
-            // 
-            this.txtQueueFilterExpression.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtQueueFilterExpression.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.txtQueueFilterExpression.Location = new System.Drawing.Point(16, 94);
-            this.txtQueueFilterExpression.Multiline = true;
-            this.txtQueueFilterExpression.Name = "txtQueueFilterExpression";
-            this.txtQueueFilterExpression.Size = new System.Drawing.Size(272, 20);
-            this.txtQueueFilterExpression.TabIndex = 3;
-            this.toolTip.SetToolTip(this.txtQueueFilterExpression, "Gets or sets the OData filter for queues.");
-            // 
-            // txtTopicFilterExpression
-            // 
-            this.txtTopicFilterExpression.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtTopicFilterExpression.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.txtTopicFilterExpression.Location = new System.Drawing.Point(16, 142);
-            this.txtTopicFilterExpression.Name = "txtTopicFilterExpression";
-            this.txtTopicFilterExpression.Size = new System.Drawing.Size(272, 20);
-            this.txtTopicFilterExpression.TabIndex = 7;
-            this.toolTip.SetToolTip(this.txtTopicFilterExpression, "Gets or sets the OData filter for topics.");
-            // 
-            // txtIssuerSecret
-            // 
-            this.txtIssuerSecret.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtIssuerSecret.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.txtIssuerSecret.Location = new System.Drawing.Point(16, 240);
-            this.txtIssuerSecret.Name = "txtIssuerSecret";
-            this.txtIssuerSecret.PasswordChar = '*';
-            this.txtIssuerSecret.Size = new System.Drawing.Size(336, 20);
-            this.txtIssuerSecret.TabIndex = 9;
-            this.toolTip.SetToolTip(this.txtIssuerSecret, "Gets or sets the shared secret issuer secret.");
-            this.txtIssuerSecret.TextChanged += new System.EventHandler(this.validation_TextChanged);
-            // 
-            // txtIssuerName
-            // 
-            this.txtIssuerName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtIssuerName.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.txtIssuerName.Location = new System.Drawing.Point(16, 192);
-            this.txtIssuerName.Name = "txtIssuerName";
-            this.txtIssuerName.Size = new System.Drawing.Size(336, 20);
-            this.txtIssuerName.TabIndex = 7;
-            this.toolTip.SetToolTip(this.txtIssuerName, "Gets or sets the shared secret issuer name.");
-            this.txtIssuerName.TextChanged += new System.EventHandler(this.validation_TextChanged);
-            // 
-            // txtNamespace
-            // 
-            this.txtNamespace.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtNamespace.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.txtNamespace.Location = new System.Drawing.Point(16, 96);
-            this.txtNamespace.Name = "txtNamespace";
-            this.txtNamespace.Size = new System.Drawing.Size(336, 20);
-            this.txtNamespace.TabIndex = 3;
-            this.toolTip.SetToolTip(this.txtNamespace, "Gets or sets the name of the Service Bus namespace.");
-            this.txtNamespace.TextChanged += new System.EventHandler(this.validation_TextChanged);
-            // 
-            // txtEntityPath
-            // 
-            this.txtEntityPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtEntityPath.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.txtEntityPath.Location = new System.Drawing.Point(16, 144);
-            this.txtEntityPath.Name = "txtEntityPath";
-            this.txtEntityPath.Size = new System.Drawing.Size(336, 20);
-            this.txtEntityPath.TabIndex = 5;
-            this.toolTip.SetToolTip(this.txtEntityPath, "Gets or sets the name of the Service Bus namespace.");
-            // 
             // logoPictureBox
             // 
             this.logoPictureBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.logoPictureBox.BackgroundImage = global::ServiceBusExplorer.Properties.Resources.MicrosoftAzureWhiteLogo;
             this.logoPictureBox.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
             this.logoPictureBox.ErrorImage = null;
-            this.logoPictureBox.Location = new System.Drawing.Point(657, 8);
+            this.logoPictureBox.Location = new System.Drawing.Point(717, 8);
             this.logoPictureBox.Name = "logoPictureBox";
             this.logoPictureBox.Size = new System.Drawing.Size(110, 14);
             this.logoPictureBox.TabIndex = 34;
@@ -376,7 +161,7 @@ namespace ServiceBusExplorer.Forms
             this.btnSave.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnSave.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnSave.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.btnSave.Location = new System.Drawing.Point(536, 443);
+            this.btnSave.Location = new System.Drawing.Point(596, 443);
             this.btnSave.Name = "btnSave";
             this.btnSave.Size = new System.Drawing.Size(72, 24);
             this.btnSave.TabIndex = 6;
@@ -389,7 +174,7 @@ namespace ServiceBusExplorer.Forms
             // 
             // btnRename
             // 
-            this.btnRename.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnRename.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btnRename.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
             this.btnRename.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnRename.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
@@ -406,7 +191,7 @@ namespace ServiceBusExplorer.Forms
             // 
             // btnDelete
             // 
-            this.btnDelete.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnDelete.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btnDelete.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
             this.btnDelete.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.btnDelete.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
@@ -442,7 +227,7 @@ namespace ServiceBusExplorer.Forms
             this.grouperConfigFileUse.ShadowColor = System.Drawing.Color.DarkGray;
             this.grouperConfigFileUse.ShadowControl = false;
             this.grouperConfigFileUse.ShadowThickness = 1;
-            this.grouperConfigFileUse.Size = new System.Drawing.Size(368, 88);
+            this.grouperConfigFileUse.Size = new System.Drawing.Size(384, 88);
             this.grouperConfigFileUse.TabIndex = 2;
             // 
             // lblConfigFileUse
@@ -490,7 +275,7 @@ namespace ServiceBusExplorer.Forms
             this.grouperFilters.ShadowColor = System.Drawing.Color.DarkGray;
             this.grouperFilters.ShadowControl = false;
             this.grouperFilters.ShadowThickness = 1;
-            this.grouperFilters.Size = new System.Drawing.Size(368, 228);
+            this.grouperFilters.Size = new System.Drawing.Size(384, 228);
             this.grouperFilters.TabIndex = 1;
             this.grouperFilters.CustomPaint += new System.Action<System.Windows.Forms.PaintEventArgs>(this.grouperFilters_CustomPaint);
             // 
@@ -506,6 +291,8 @@ namespace ServiceBusExplorer.Forms
             // 
             // cboSelectedEntities
             // 
+            this.cboSelectedEntities.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             checkBoxProperties1.ForeColor = System.Drawing.SystemColors.ControlText;
             this.cboSelectedEntities.CheckBoxProperties = checkBoxProperties1;
             this.cboSelectedEntities.DisplayMemberSingleItem = "";
@@ -514,8 +301,109 @@ namespace ServiceBusExplorer.Forms
             this.cboSelectedEntities.FormattingEnabled = true;
             this.cboSelectedEntities.Location = new System.Drawing.Point(16, 46);
             this.cboSelectedEntities.Name = "cboSelectedEntities";
-            this.cboSelectedEntities.Size = new System.Drawing.Size(336, 21);
+            this.cboSelectedEntities.Size = new System.Drawing.Size(352, 21);
             this.cboSelectedEntities.TabIndex = 1;
+            // 
+            // btnClearSubscriptionFilterExpression
+            // 
+            this.btnClearSubscriptionFilterExpression.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnClearSubscriptionFilterExpression.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
+            this.btnClearSubscriptionFilterExpression.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            this.btnClearSubscriptionFilterExpression.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnClearSubscriptionFilterExpression.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnClearSubscriptionFilterExpression.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnClearSubscriptionFilterExpression.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnClearSubscriptionFilterExpression.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold);
+            this.btnClearSubscriptionFilterExpression.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(92)))), ((int)(((byte)(125)))), ((int)(((byte)(150)))));
+            this.btnClearSubscriptionFilterExpression.Location = new System.Drawing.Point(344, 190);
+            this.btnClearSubscriptionFilterExpression.Name = "btnClearSubscriptionFilterExpression";
+            this.btnClearSubscriptionFilterExpression.Size = new System.Drawing.Size(24, 21);
+            this.btnClearSubscriptionFilterExpression.TabIndex = 13;
+            this.btnClearSubscriptionFilterExpression.Text = "X";
+            this.btnClearSubscriptionFilterExpression.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.toolTip.SetToolTip(this.btnClearSubscriptionFilterExpression, "Click to cancel the filter expression for subscriptions.");
+            this.btnClearSubscriptionFilterExpression.UseVisualStyleBackColor = false;
+            this.btnClearSubscriptionFilterExpression.Click += new System.EventHandler(this.btnClearSubscriptionFilterExpression_Click);
+            this.btnClearSubscriptionFilterExpression.MouseEnter += new System.EventHandler(this.button_MouseEnter);
+            this.btnClearSubscriptionFilterExpression.MouseLeave += new System.EventHandler(this.clearButton_MouseLeave);
+            // 
+            // btnClearTopicFilterExpression
+            // 
+            this.btnClearTopicFilterExpression.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnClearTopicFilterExpression.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
+            this.btnClearTopicFilterExpression.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            this.btnClearTopicFilterExpression.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnClearTopicFilterExpression.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnClearTopicFilterExpression.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnClearTopicFilterExpression.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnClearTopicFilterExpression.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold);
+            this.btnClearTopicFilterExpression.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(92)))), ((int)(((byte)(125)))), ((int)(((byte)(150)))));
+            this.btnClearTopicFilterExpression.Location = new System.Drawing.Point(344, 142);
+            this.btnClearTopicFilterExpression.Name = "btnClearTopicFilterExpression";
+            this.btnClearTopicFilterExpression.Size = new System.Drawing.Size(24, 21);
+            this.btnClearTopicFilterExpression.TabIndex = 9;
+            this.btnClearTopicFilterExpression.Text = "X";
+            this.btnClearTopicFilterExpression.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.toolTip.SetToolTip(this.btnClearTopicFilterExpression, "Click to cancel the filter expression for topics.");
+            this.btnClearTopicFilterExpression.UseVisualStyleBackColor = false;
+            this.btnClearTopicFilterExpression.Click += new System.EventHandler(this.btnClearTopicFilterExpression_Click);
+            this.btnClearTopicFilterExpression.MouseEnter += new System.EventHandler(this.button_MouseEnter);
+            this.btnClearTopicFilterExpression.MouseLeave += new System.EventHandler(this.clearButton_MouseLeave);
+            // 
+            // btnClearQueueFilterExpression
+            // 
+            this.btnClearQueueFilterExpression.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnClearQueueFilterExpression.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
+            this.btnClearQueueFilterExpression.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            this.btnClearQueueFilterExpression.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnClearQueueFilterExpression.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnClearQueueFilterExpression.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnClearQueueFilterExpression.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnClearQueueFilterExpression.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold);
+            this.btnClearQueueFilterExpression.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(92)))), ((int)(((byte)(125)))), ((int)(((byte)(150)))));
+            this.btnClearQueueFilterExpression.Location = new System.Drawing.Point(344, 94);
+            this.btnClearQueueFilterExpression.Name = "btnClearQueueFilterExpression";
+            this.btnClearQueueFilterExpression.Size = new System.Drawing.Size(24, 21);
+            this.btnClearQueueFilterExpression.TabIndex = 5;
+            this.btnClearQueueFilterExpression.Text = "X";
+            this.btnClearQueueFilterExpression.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.toolTip.SetToolTip(this.btnClearQueueFilterExpression, "Click to cancel the filter expression for queues.");
+            this.btnClearQueueFilterExpression.UseVisualStyleBackColor = false;
+            this.btnClearQueueFilterExpression.Click += new System.EventHandler(this.btnClearQueueFilterExpression_Click);
+            this.btnClearQueueFilterExpression.MouseEnter += new System.EventHandler(this.button_MouseEnter);
+            this.btnClearQueueFilterExpression.MouseLeave += new System.EventHandler(this.clearButton_MouseLeave);
+            // 
+            // btnOpenSubscriptionFilterForm
+            // 
+            this.btnOpenSubscriptionFilterForm.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnOpenSubscriptionFilterForm.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
+            this.btnOpenSubscriptionFilterForm.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnOpenSubscriptionFilterForm.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnOpenSubscriptionFilterForm.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnOpenSubscriptionFilterForm.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnOpenSubscriptionFilterForm.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.btnOpenSubscriptionFilterForm.Location = new System.Drawing.Point(312, 190);
+            this.btnOpenSubscriptionFilterForm.Name = "btnOpenSubscriptionFilterForm";
+            this.btnOpenSubscriptionFilterForm.Size = new System.Drawing.Size(24, 21);
+            this.btnOpenSubscriptionFilterForm.TabIndex = 12;
+            this.btnOpenSubscriptionFilterForm.Text = "...";
+            this.btnOpenSubscriptionFilterForm.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.toolTip.SetToolTip(this.btnOpenSubscriptionFilterForm, "Click to open the filter expression dialog for subscriptions.");
+            this.btnOpenSubscriptionFilterForm.UseVisualStyleBackColor = false;
+            this.btnOpenSubscriptionFilterForm.Click += new System.EventHandler(this.btnOpenSubscriptionFilterForm_Click);
+            this.btnOpenSubscriptionFilterForm.MouseEnter += new System.EventHandler(this.button_MouseEnter);
+            this.btnOpenSubscriptionFilterForm.MouseLeave += new System.EventHandler(this.button_MouseLeave);
+            // 
+            // txtSubscriptionFilterExpression
+            // 
+            this.txtSubscriptionFilterExpression.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtSubscriptionFilterExpression.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.txtSubscriptionFilterExpression.Location = new System.Drawing.Point(16, 190);
+            this.txtSubscriptionFilterExpression.Name = "txtSubscriptionFilterExpression";
+            this.txtSubscriptionFilterExpression.Size = new System.Drawing.Size(288, 20);
+            this.txtSubscriptionFilterExpression.TabIndex = 11;
+            this.toolTip.SetToolTip(this.txtSubscriptionFilterExpression, "Gets or sets the OData filter for topics.");
             // 
             // lblSubscriptionFilterExpression
             // 
@@ -527,6 +415,60 @@ namespace ServiceBusExplorer.Forms
             this.lblSubscriptionFilterExpression.TabIndex = 10;
             this.lblSubscriptionFilterExpression.Text = "Subscription Filter Expression:";
             // 
+            // btnOpenTopicFilterForm
+            // 
+            this.btnOpenTopicFilterForm.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnOpenTopicFilterForm.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
+            this.btnOpenTopicFilterForm.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnOpenTopicFilterForm.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnOpenTopicFilterForm.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnOpenTopicFilterForm.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnOpenTopicFilterForm.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.btnOpenTopicFilterForm.Location = new System.Drawing.Point(312, 142);
+            this.btnOpenTopicFilterForm.Name = "btnOpenTopicFilterForm";
+            this.btnOpenTopicFilterForm.Size = new System.Drawing.Size(24, 21);
+            this.btnOpenTopicFilterForm.TabIndex = 8;
+            this.btnOpenTopicFilterForm.Text = "...";
+            this.btnOpenTopicFilterForm.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.toolTip.SetToolTip(this.btnOpenTopicFilterForm, "Click to open the filter expression dialog for topics.");
+            this.btnOpenTopicFilterForm.UseVisualStyleBackColor = false;
+            this.btnOpenTopicFilterForm.Click += new System.EventHandler(this.btnOpenTopicFilterForm_Click);
+            this.btnOpenTopicFilterForm.MouseEnter += new System.EventHandler(this.button_MouseEnter);
+            this.btnOpenTopicFilterForm.MouseLeave += new System.EventHandler(this.button_MouseLeave);
+            // 
+            // btnOpenQueueFilterForm
+            // 
+            this.btnOpenQueueFilterForm.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnOpenQueueFilterForm.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
+            this.btnOpenQueueFilterForm.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnOpenQueueFilterForm.FlatAppearance.MouseDownBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnOpenQueueFilterForm.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
+            this.btnOpenQueueFilterForm.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnOpenQueueFilterForm.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.btnOpenQueueFilterForm.Location = new System.Drawing.Point(312, 94);
+            this.btnOpenQueueFilterForm.Name = "btnOpenQueueFilterForm";
+            this.btnOpenQueueFilterForm.Size = new System.Drawing.Size(24, 21);
+            this.btnOpenQueueFilterForm.TabIndex = 4;
+            this.btnOpenQueueFilterForm.Text = "...";
+            this.btnOpenQueueFilterForm.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.toolTip.SetToolTip(this.btnOpenQueueFilterForm, "Click to open the filter expression dialog for queues.");
+            this.btnOpenQueueFilterForm.UseVisualStyleBackColor = false;
+            this.btnOpenQueueFilterForm.Click += new System.EventHandler(this.btnOpenQueueFilterForm_Click);
+            this.btnOpenQueueFilterForm.MouseEnter += new System.EventHandler(this.button_MouseEnter);
+            this.btnOpenQueueFilterForm.MouseLeave += new System.EventHandler(this.button_MouseLeave);
+            // 
+            // txtQueueFilterExpression
+            // 
+            this.txtQueueFilterExpression.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtQueueFilterExpression.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.txtQueueFilterExpression.Location = new System.Drawing.Point(16, 94);
+            this.txtQueueFilterExpression.Multiline = true;
+            this.txtQueueFilterExpression.Name = "txtQueueFilterExpression";
+            this.txtQueueFilterExpression.Size = new System.Drawing.Size(288, 20);
+            this.txtQueueFilterExpression.TabIndex = 3;
+            this.toolTip.SetToolTip(this.txtQueueFilterExpression, "Gets or sets the OData filter for queues.");
+            // 
             // lblQueueFilterExpression
             // 
             this.lblQueueFilterExpression.AutoSize = true;
@@ -536,6 +478,17 @@ namespace ServiceBusExplorer.Forms
             this.lblQueueFilterExpression.Size = new System.Drawing.Size(121, 13);
             this.lblQueueFilterExpression.TabIndex = 2;
             this.lblQueueFilterExpression.Text = "Queue Filter Expression:";
+            // 
+            // txtTopicFilterExpression
+            // 
+            this.txtTopicFilterExpression.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtTopicFilterExpression.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.txtTopicFilterExpression.Location = new System.Drawing.Point(16, 142);
+            this.txtTopicFilterExpression.Name = "txtTopicFilterExpression";
+            this.txtTopicFilterExpression.Size = new System.Drawing.Size(288, 20);
+            this.txtTopicFilterExpression.TabIndex = 7;
+            this.toolTip.SetToolTip(this.txtTopicFilterExpression, "Gets or sets the OData filter for topics.");
             // 
             // lblTopicFilterExpression
             // 
@@ -555,7 +508,6 @@ namespace ServiceBusExplorer.Forms
             this.grouperServiceBusNamespaceSettings.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.grouperServiceBusNamespaceSettings.BorderThickness = 1F;
             this.grouperServiceBusNamespaceSettings.Controls.Add(this.useAmqpWebSocketsCheckBox);
-            this.grouperServiceBusNamespaceSettings.Controls.Add(this.lblNewSdkTransportType);
             this.grouperServiceBusNamespaceSettings.Controls.Add(this.cboTransportType);
             this.grouperServiceBusNamespaceSettings.Controls.Add(this.lblTransportType);
             this.grouperServiceBusNamespaceSettings.Controls.Add(this.cboConnectivityMode);
@@ -575,7 +527,7 @@ namespace ServiceBusExplorer.Forms
             this.grouperServiceBusNamespaceSettings.ForeColor = System.Drawing.Color.White;
             this.grouperServiceBusNamespaceSettings.GroupImage = null;
             this.grouperServiceBusNamespaceSettings.GroupTitle = "Connection Settings";
-            this.grouperServiceBusNamespaceSettings.Location = new System.Drawing.Point(400, 24);
+            this.grouperServiceBusNamespaceSettings.Location = new System.Drawing.Point(418, 24);
             this.grouperServiceBusNamespaceSettings.Name = "grouperServiceBusNamespaceSettings";
             this.grouperServiceBusNamespaceSettings.Padding = new System.Windows.Forms.Padding(20);
             this.grouperServiceBusNamespaceSettings.PaintGroupBox = true;
@@ -583,7 +535,7 @@ namespace ServiceBusExplorer.Forms
             this.grouperServiceBusNamespaceSettings.ShadowColor = System.Drawing.Color.DarkGray;
             this.grouperServiceBusNamespaceSettings.ShadowControl = false;
             this.grouperServiceBusNamespaceSettings.ShadowThickness = 1;
-            this.grouperServiceBusNamespaceSettings.Size = new System.Drawing.Size(368, 408);
+            this.grouperServiceBusNamespaceSettings.Size = new System.Drawing.Size(410, 408);
             this.grouperServiceBusNamespaceSettings.TabIndex = 3;
             this.grouperServiceBusNamespaceSettings.CustomPaint += new System.Action<System.Windows.Forms.PaintEventArgs>(this.grouperServiceBusNamespaceSettings_CustomPaint);
             // 
@@ -591,30 +543,23 @@ namespace ServiceBusExplorer.Forms
             // 
             this.useAmqpWebSocketsCheckBox.AutoSize = true;
             this.useAmqpWebSocketsCheckBox.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.useAmqpWebSocketsCheckBox.Location = new System.Drawing.Point(337, 384);
+            this.useAmqpWebSocketsCheckBox.Location = new System.Drawing.Point(16, 371);
             this.useAmqpWebSocketsCheckBox.Name = "useAmqpWebSocketsCheckBox";
-            this.useAmqpWebSocketsCheckBox.Size = new System.Drawing.Size(15, 14);
+            this.useAmqpWebSocketsCheckBox.Size = new System.Drawing.Size(365, 17);
             this.useAmqpWebSocketsCheckBox.TabIndex = 15;
+            this.useAmqpWebSocketsCheckBox.Text = "Use AMQP Web Sockets for Microsoft.Azure.ServiceBus.dll (new client)";
             this.useAmqpWebSocketsCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // lblNewSdkTransportType
-            // 
-            this.lblNewSdkTransportType.AutoSize = true;
-            this.lblNewSdkTransportType.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblNewSdkTransportType.Location = new System.Drawing.Point(16, 368);
-            this.lblNewSdkTransportType.Name = "lblNewSdkTransportType";
-            this.lblNewSdkTransportType.Size = new System.Drawing.Size(346, 13);
-            this.lblNewSdkTransportType.TabIndex = 14;
-            this.lblNewSdkTransportType.Text = "Use AMQP Web Sockets for Microsoft.Azure.ServiceBus.dll (new client)";
             // 
             // cboTransportType
             // 
+            this.cboTransportType.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.cboTransportType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboTransportType.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cboTransportType.FormattingEnabled = true;
             this.cboTransportType.Location = new System.Drawing.Point(16, 336);
             this.cboTransportType.Name = "cboTransportType";
-            this.cboTransportType.Size = new System.Drawing.Size(336, 21);
+            this.cboTransportType.Size = new System.Drawing.Size(372, 21);
             this.cboTransportType.TabIndex = 13;
             this.cboTransportType.SelectedIndexChanged += new System.EventHandler(this.cboTransportType_SelectedIndexChanged);
             // 
@@ -630,12 +575,14 @@ namespace ServiceBusExplorer.Forms
             // 
             // cboConnectivityMode
             // 
+            this.cboConnectivityMode.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.cboConnectivityMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboConnectivityMode.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cboConnectivityMode.FormattingEnabled = true;
             this.cboConnectivityMode.Location = new System.Drawing.Point(16, 288);
             this.cboConnectivityMode.Name = "cboConnectivityMode";
-            this.cboConnectivityMode.Size = new System.Drawing.Size(336, 21);
+            this.cboConnectivityMode.Size = new System.Drawing.Size(372, 21);
             this.cboConnectivityMode.TabIndex = 11;
             // 
             // lblConnectivityMode
@@ -656,7 +603,7 @@ namespace ServiceBusExplorer.Forms
             this.txtUri.Location = new System.Drawing.Point(16, 48);
             this.txtUri.Multiline = true;
             this.txtUri.Name = "txtUri";
-            this.txtUri.Size = new System.Drawing.Size(336, 20);
+            this.txtUri.Size = new System.Drawing.Size(372, 20);
             this.txtUri.TabIndex = 1;
             this.txtUri.TextChanged += new System.EventHandler(this.validation_TextChanged);
             // 
@@ -670,6 +617,19 @@ namespace ServiceBusExplorer.Forms
             this.lblUri.TabIndex = 0;
             this.lblUri.Text = "Endpoint URI:";
             // 
+            // txtIssuerSecret
+            // 
+            this.txtIssuerSecret.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtIssuerSecret.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.txtIssuerSecret.Location = new System.Drawing.Point(16, 240);
+            this.txtIssuerSecret.Name = "txtIssuerSecret";
+            this.txtIssuerSecret.PasswordChar = '*';
+            this.txtIssuerSecret.Size = new System.Drawing.Size(372, 20);
+            this.txtIssuerSecret.TabIndex = 9;
+            this.toolTip.SetToolTip(this.txtIssuerSecret, "Gets or sets the shared secret issuer secret.");
+            this.txtIssuerSecret.TextChanged += new System.EventHandler(this.validation_TextChanged);
+            // 
             // lblIssuerSecret
             // 
             this.lblIssuerSecret.AutoSize = true;
@@ -679,6 +639,18 @@ namespace ServiceBusExplorer.Forms
             this.lblIssuerSecret.Size = new System.Drawing.Size(103, 13);
             this.lblIssuerSecret.TabIndex = 8;
             this.lblIssuerSecret.Text = "Shared Access Key:";
+            // 
+            // txtIssuerName
+            // 
+            this.txtIssuerName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtIssuerName.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.txtIssuerName.Location = new System.Drawing.Point(16, 192);
+            this.txtIssuerName.Name = "txtIssuerName";
+            this.txtIssuerName.Size = new System.Drawing.Size(372, 20);
+            this.txtIssuerName.TabIndex = 7;
+            this.toolTip.SetToolTip(this.txtIssuerName, "Gets or sets the shared secret issuer name.");
+            this.txtIssuerName.TextChanged += new System.EventHandler(this.validation_TextChanged);
             // 
             // lblIssuerName
             // 
@@ -690,6 +662,18 @@ namespace ServiceBusExplorer.Forms
             this.lblIssuerName.TabIndex = 6;
             this.lblIssuerName.Text = "Shared Access Key Name:";
             // 
+            // txtNamespace
+            // 
+            this.txtNamespace.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtNamespace.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.txtNamespace.Location = new System.Drawing.Point(16, 96);
+            this.txtNamespace.Name = "txtNamespace";
+            this.txtNamespace.Size = new System.Drawing.Size(372, 20);
+            this.txtNamespace.TabIndex = 3;
+            this.toolTip.SetToolTip(this.txtNamespace, "Gets or sets the name of the Service Bus namespace.");
+            this.txtNamespace.TextChanged += new System.EventHandler(this.validation_TextChanged);
+            // 
             // lblNamespace
             // 
             this.lblNamespace.AutoSize = true;
@@ -699,6 +683,17 @@ namespace ServiceBusExplorer.Forms
             this.lblNamespace.Size = new System.Drawing.Size(67, 13);
             this.lblNamespace.TabIndex = 2;
             this.lblNamespace.Text = "Namespace:";
+            // 
+            // txtEntityPath
+            // 
+            this.txtEntityPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtEntityPath.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.txtEntityPath.Location = new System.Drawing.Point(16, 144);
+            this.txtEntityPath.Name = "txtEntityPath";
+            this.txtEntityPath.Size = new System.Drawing.Size(372, 20);
+            this.txtEntityPath.TabIndex = 5;
+            this.toolTip.SetToolTip(this.txtEntityPath, "Gets or sets the name of the Service Bus namespace.");
             // 
             // lblEntityPath
             // 
@@ -731,7 +726,7 @@ namespace ServiceBusExplorer.Forms
             this.grouperServiceBusNamespaces.ShadowColor = System.Drawing.Color.DarkGray;
             this.grouperServiceBusNamespaces.ShadowControl = false;
             this.grouperServiceBusNamespaces.ShadowThickness = 1;
-            this.grouperServiceBusNamespaces.Size = new System.Drawing.Size(368, 72);
+            this.grouperServiceBusNamespaces.Size = new System.Drawing.Size(384, 72);
             this.grouperServiceBusNamespaces.TabIndex = 0;
             this.grouperServiceBusNamespaces.CustomPaint += new System.Action<System.Windows.Forms.PaintEventArgs>(this.grouperServiceBusNamespaces_CustomPaint);
             // 
@@ -743,9 +738,9 @@ namespace ServiceBusExplorer.Forms
             this.cboServiceBusNamespace.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboServiceBusNamespace.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.cboServiceBusNamespace.FormattingEnabled = true;
-            this.cboServiceBusNamespace.Location = new System.Drawing.Point(16, 32);
+            this.cboServiceBusNamespace.Location = new System.Drawing.Point(19, 32);
             this.cboServiceBusNamespace.Name = "cboServiceBusNamespace";
-            this.cboServiceBusNamespace.Size = new System.Drawing.Size(336, 21);
+            this.cboServiceBusNamespace.Size = new System.Drawing.Size(352, 21);
             this.cboServiceBusNamespace.TabIndex = 0;
             this.cboServiceBusNamespace.SelectedIndexChanged += new System.EventHandler(this.cboServiceBusNamespace_SelectedIndexChanged);
             // 
@@ -754,7 +749,7 @@ namespace ServiceBusExplorer.Forms
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
-            this.ClientSize = new System.Drawing.Size(784, 477);
+            this.ClientSize = new System.Drawing.Size(844, 477);
             this.Controls.Add(this.grouperConfigFileUse);
             this.Controls.Add(this.btnDelete);
             this.Controls.Add(this.btnRename);
@@ -829,7 +824,6 @@ namespace ServiceBusExplorer.Forms
         private System.Windows.Forms.Button btnDelete;
         private Grouper grouperConfigFileUse;
         private System.Windows.Forms.Label lblConfigFileUse;
-        private System.Windows.Forms.Label lblNewSdkTransportType;
         private System.Windows.Forms.CheckBox useAmqpWebSocketsCheckBox;
     }
 }

--- a/src/ServiceBusExplorer/Forms/DeleteForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/DeleteForm.Designer.cs
@@ -115,7 +115,7 @@ namespace ServiceBusExplorer.Forms
             // lblMessage
             // 
             this.lblMessage.AutoSize = true;
-            this.lblMessage.Location = new System.Drawing.Point(60, 24);
+            this.lblMessage.Location = new System.Drawing.Point(56, 24);
             this.lblMessage.Name = "lblMessage";
             this.lblMessage.Size = new System.Drawing.Size(33, 13);
             this.lblMessage.TabIndex = 0;

--- a/src/ServiceBusExplorer/Forms/DeleteForm.cs
+++ b/src/ServiceBusExplorer/Forms/DeleteForm.cs
@@ -38,6 +38,7 @@ namespace ServiceBusExplorer.Forms
         //***************************
         private const string MessageFormat = "The {0} {1} will be permanently deleted.";
         private const string Unknown = "Unknown";
+        private const int widthPadding = 88;
         #endregion
 
         #region Private Fields
@@ -50,7 +51,7 @@ namespace ServiceBusExplorer.Forms
         {
             InitializeComponent();
             lblMessage.Text = string.Format(message);
-            Width = lblMessage.Width + 88;
+            Width = lblMessage.Width + LogicalToDeviceUnits(widthPadding);
         }
 
         public DeleteForm(string entityName, string entityType)
@@ -59,7 +60,7 @@ namespace ServiceBusExplorer.Forms
             lblMessage.Text = string.Format(MessageFormat,
                                             entityType ?? Unknown,
                                             entityName ?? Unknown);
-            Width = lblMessage.Width + 88;
+            Width = lblMessage.Width + LogicalToDeviceUnits(widthPadding);
         }
         #endregion
 

--- a/src/ServiceBusExplorer/Forms/FilterForm.cs
+++ b/src/ServiceBusExplorer/Forms/FilterForm.cs
@@ -24,13 +24,11 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using ServiceBusExplorer.Controls;
-using ServiceBusExplorer.Helpers;
 using ServiceBusExplorer.Utilities.Helpers;
 
 #endregion
@@ -48,7 +46,7 @@ namespace ServiceBusExplorer.Forms
         private const string StartsWithFormat = "Startswith({0}, '{1}') Eq true";
         private const string MessageCountFormat = "MessageCount {0} {1}";
         private const string TimeFilterFormat = "{0} {1} '{2}'";
-        
+
         //***************************
         // Constants
         //***************************
@@ -65,7 +63,7 @@ namespace ServiceBusExplorer.Forms
         private const string TimeFilterOperator = "Operator";
         private const string TimeFilterValue = "Value";
 
-         //***************************
+        //***************************
         // RegeEx Patterns & Groups
         //***************************
         private const string AndPattern = @"\s+and\s+";
@@ -81,7 +79,7 @@ namespace ServiceBusExplorer.Forms
         #endregion
 
         #region Private Static Fields
-        private static readonly List<string> properties = new List<string> { "CreatedAt", "AccessedAt", "UpdatedAt"};
+        private static readonly List<string> properties = new List<string> { "CreatedAt", "AccessedAt", "UpdatedAt" };
         private static readonly List<string> operators = new List<string> { "Ge", "Gt", "Le", "Lt", "Eq", "Ne" };
         private static readonly List<TimeFilterInfo> timeFilters = new List<TimeFilterInfo>();
         #endregion
@@ -347,7 +345,7 @@ namespace ServiceBusExplorer.Forms
 
                 // Initialize control values
                 txtStartsWith.Text = string.Empty;
-                txtMessageCount.Text = string.Empty;              
+                txtMessageCount.Text = string.Empty;
                 cboMessageCountOperator.SelectedIndex = 0;
                 //timeFilterDataGridView.Rows.Clear();
                 timeFilters.Clear();
@@ -410,11 +408,11 @@ namespace ServiceBusExplorer.Forms
                             !string.IsNullOrWhiteSpace(timeFilterValue))
                         {
                             timeFilters.Add(new TimeFilterInfo
-                                {
-                                    Property = timeFilterProperty,
-                                    Operator = timeFilterOperator,
-                                    Value = DateTime.Parse(timeFilterValue)
-                                });
+                            {
+                                Property = timeFilterProperty,
+                                Operator = timeFilterOperator,
+                                Value = DateTime.Parse(timeFilterValue)
+                            });
                         }
                     }
                 }

--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -5259,7 +5259,7 @@ namespace ServiceBusExplorer.Forms
                 panelMain.BackColor = SystemColors.GradientInactiveCaption;
                 queueControl = new HandleQueueControl(WriteToLog, serviceBusHelper, queue, path, duplicateQueue);
                 queueControl.SuspendDrawing();
-                queueControl.Location = new Point(1, panelLog.HeaderHeight + 1);
+                queueControl.Location = new Point(1, LogicalToDeviceUnits(panelLog.HeaderHeight) + 1);
                 panelMain.Controls.Add(queueControl);
                 SetControlSize(queueControl);
                 queueControl.OnCancel += MainForm_OnCancel;
@@ -5364,7 +5364,7 @@ namespace ServiceBusExplorer.Forms
                 panelMain.BackColor = SystemColors.GradientInactiveCaption;
                 subscriptionControl = new HandleSubscriptionControl(WriteToLog, serviceBusHelper, wrapper, duplicateCurrentSubscription);
                 subscriptionControl.SuspendDrawing();
-                subscriptionControl.Location = new Point(1, panelLog.HeaderHeight + 1);
+                subscriptionControl.Location = new Point(1, LogicalToDeviceUnits(panelLog.HeaderHeight) + 1);
                 panelMain.Controls.Add(subscriptionControl);
                 SetControlSize(subscriptionControl);
                 subscriptionControl.OnCancel += MainForm_OnCancel;
@@ -5433,7 +5433,7 @@ namespace ServiceBusExplorer.Forms
                 panelMain.BackColor = SystemColors.GradientInactiveCaption;
                 relayServiceControl = new HandleRelayControl(WriteToLog, serviceBusHelper, relayService, path);
                 relayServiceControl.SuspendDrawing();
-                relayServiceControl.Location = new Point(1, panelLog.HeaderHeight + 1);
+                relayServiceControl.Location = new Point(1, LogicalToDeviceUnits(panelLog.HeaderHeight) + 1);
                 panelMain.Controls.Add(relayServiceControl);
                 SetControlSize(relayServiceControl);
                 relayServiceControl.OnCancel += MainForm_OnCancel;
@@ -5468,7 +5468,7 @@ namespace ServiceBusExplorer.Forms
                 panelMain.BackColor = SystemColors.GradientInactiveCaption;
                 ruleControl = new HandleRuleControl(WriteToLog, serviceBusHelper, wrapper, isFirstRule);
                 ruleControl.SuspendDrawing();
-                ruleControl.Location = new Point(1, panelLog.HeaderHeight + 1);
+                ruleControl.Location = new Point(1, LogicalToDeviceUnits(panelLog.HeaderHeight) + 1);
                 panelMain.Controls.Add(ruleControl);
                 SetControlSize(ruleControl);
                 ruleControl.OnCancel += MainForm_OnCancel;
@@ -5502,7 +5502,7 @@ namespace ServiceBusExplorer.Forms
                 panelMain.BackColor = SystemColors.GradientInactiveCaption;
                 eventHubControl = new HandleEventHubControl(WriteToLog, serviceBusHelper, eventHub);
                 eventHubControl.SuspendDrawing();
-                eventHubControl.Location = new Point(1, panelLog.HeaderHeight + 1);
+                eventHubControl.Location = new Point(1, LogicalToDeviceUnits(panelLog.HeaderHeight) + 1);
                 panelMain.Controls.Add(eventHubControl);
                 SetControlSize(eventHubControl);
                 eventHubControl.OnCancel += MainForm_OnCancel;
@@ -5547,7 +5547,7 @@ namespace ServiceBusExplorer.Forms
                 }
                 partitionControl = new HandlePartitionControl(WriteToLog, serviceBusHelper, partition);
                 partitionControl.SuspendDrawing();
-                partitionControl.Location = new Point(1, panelLog.HeaderHeight + 1);
+                partitionControl.Location = new Point(1, LogicalToDeviceUnits(panelLog.HeaderHeight) + 1);
                 panelMain.Controls.Add(partitionControl);
                 partitionControl.OnRefresh += MainForm_OnRefresh;
                 SetControlSize(partitionControl);
@@ -5581,7 +5581,7 @@ namespace ServiceBusExplorer.Forms
                 panelMain.BackColor = SystemColors.GradientInactiveCaption;
                 notificationHubControl = new HandleConsumerGroupControl(WriteToLog, serviceBusHelper, notificationHub, eventHubname);
                 notificationHubControl.SuspendDrawing();
-                notificationHubControl.Location = new Point(1, panelLog.HeaderHeight + 1);
+                notificationHubControl.Location = new Point(1, LogicalToDeviceUnits(panelLog.HeaderHeight) + 1);
                 panelMain.Controls.Add(notificationHubControl);
                 SetControlSize(notificationHubControl);
                 notificationHubControl.OnCancel += MainForm_OnCancel;
@@ -5616,7 +5616,7 @@ namespace ServiceBusExplorer.Forms
                 panelMain.BackColor = SystemColors.GradientInactiveCaption;
                 notificationHubControl = new HandleNotificationHubControl(WriteToLog, serviceBusHelper, notificationHub);
                 notificationHubControl.SuspendDrawing();
-                notificationHubControl.Location = new Point(1, panelLog.HeaderHeight + 1);
+                notificationHubControl.Location = new Point(1, LogicalToDeviceUnits(panelLog.HeaderHeight) + 1);
                 panelMain.Controls.Add(notificationHubControl);
                 SetControlSize(notificationHubControl);
                 notificationHubControl.OnCancel += MainForm_OnCancel;
@@ -5658,7 +5658,7 @@ namespace ServiceBusExplorer.Forms
                                                         serviceBusHelper,
                                                         queueDescription);
                     queueControl.SuspendDrawing();
-                    queueControl.Location = new Point(1, panelLog.HeaderHeight + 1);
+                    queueControl.Location = new Point(1, LogicalToDeviceUnits(panelLog.HeaderHeight) + 1);
                     panelMain.Controls.Add(queueControl);
                     SetControlSize(queueControl);
                     queueControl.OnCancel += MainForm_OnCancel;
@@ -5706,7 +5706,7 @@ namespace ServiceBusExplorer.Forms
                                                         topicDescription,
                                                         subscriptionList);
                     topicControl.SuspendDrawing();
-                    topicControl.Location = new Point(1, panelLog.HeaderHeight + 1);
+                    topicControl.Location = new Point(1, LogicalToDeviceUnits(panelLog.HeaderHeight) + 1);
                     panelMain.Controls.Add(topicControl);
                     SetControlSize(topicControl);
                     topicControl.OnCancel += MainForm_OnCancel;
@@ -5753,7 +5753,7 @@ namespace ServiceBusExplorer.Forms
                                                                       serviceBusHelper,
                                                                       subscriptionWrapper);
                     subscriptionControl.SuspendDrawing();
-                    subscriptionControl.Location = new Point(1, panelLog.HeaderHeight + 1);
+                    subscriptionControl.Location = new Point(1, LogicalToDeviceUnits(panelLog.HeaderHeight) + 1);
                     panelMain.Controls.Add(subscriptionControl);
                     SetControlSize(subscriptionControl);
                     subscriptionControl.OnCancel += MainForm_OnCancel;
@@ -5800,7 +5800,7 @@ namespace ServiceBusExplorer.Forms
                                                                relayDescription,
                                                                serviceBusHelper);
                     relayServiceControl.SuspendDrawing();
-                    relayServiceControl.Location = new Point(1, panelLog.HeaderHeight + 1);
+                    relayServiceControl.Location = new Point(1, LogicalToDeviceUnits(panelLog.HeaderHeight) + 1);
                     panelMain.Controls.Add(relayServiceControl);
                     SetControlSize(relayServiceControl);
                     relayServiceControl.OnCancel += MainForm_OnCancel;

--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -561,6 +561,7 @@ namespace ServiceBusExplorer.Forms
                 lstLog.Font = new Font(lstLog.Font.FontFamily, (float)optionForm.MainSettings.LogFontSize);
                 serviceBusTreeView.Font = new Font(serviceBusTreeView.Font.FontFamily,
                     (float)optionForm.MainSettings.TreeViewFontSize);
+                serviceBusTreeView.ItemHeight = serviceBusTreeView.Font.Height;
                 RetryHelper.RetryCount = optionForm.MainSettings.RetryCount;
                 RetryHelper.RetryTimeout = optionForm.MainSettings.RetryTimeout;
                 ReceiveTimeout = optionForm.MainSettings.ReceiveTimeout;
@@ -4043,6 +4044,7 @@ namespace ServiceBusExplorer.Forms
             {
                 treeViewFontSize = tempTreeViewFontSize;
                 serviceBusTreeView.Font = new Font(serviceBusTreeView.Font.FontFamily, (float)treeViewFontSize);
+                serviceBusTreeView.ItemHeight = serviceBusTreeView.Font.Height;
             }
 
             RetryHelper.RetryCount = readSettings.RetryCount;
@@ -4230,7 +4232,7 @@ namespace ServiceBusExplorer.Forms
                         ok = true;
                     }
                     var width = panelMain.Width - 4;
-                    var height = panelMain.Height - 26;
+                    var height = panelMain.Height - /*26;*/ (LogicalToDeviceUnits(panelMain.HeaderHeight) + 6);
                     control.Width = width < ControlMinWidth ? ControlMinWidth : width;
                     control.Height = height < ControlMinHeight ? ControlMinHeight : height;
                 }
@@ -5293,7 +5295,7 @@ namespace ServiceBusExplorer.Forms
                 panelMain.BackColor = SystemColors.GradientInactiveCaption;
                 topicControl = new HandleTopicControl(WriteToLog, serviceBusHelper, topic, path);
                 topicControl.SuspendDrawing();
-                topicControl.Location = new Point(1, panelLog.HeaderHeight + 1);
+                topicControl.Location = new Point(1, LogicalToDeviceUnits(panelLog.HeaderHeight) + 1);
                 panelMain.Controls.Add(topicControl);
                 SetControlSize(topicControl);
                 topicControl.OnCancel += MainForm_OnCancel;
@@ -5347,7 +5349,7 @@ namespace ServiceBusExplorer.Forms
         /// </summary>
         /// <param name="wrapper">Wrapper to </param>
         /// <param name="duplicateCurrentSubscription">If set the rendered subscription panel will be a "Duplicate" form.</param>
-        private void ShowSubscription(SubscriptionWrapper wrapper, bool duplicateCurrentSubscription = false) 
+        private void ShowSubscription(SubscriptionWrapper wrapper, bool duplicateCurrentSubscription = false)
         {
             HandleSubscriptionControl subscriptionControl = null;
 
@@ -6637,6 +6639,7 @@ namespace ServiceBusExplorer.Forms
             splitContainer.SplitterDistance = splitterContainerDistance;
             lstLog.Font = new Font(lstLog.Font.FontFamily, (float)logFontSize);
             serviceBusTreeView.Font = new Font(serviceBusTreeView.Font.FontFamily, (float)treeViewFontSize);
+            serviceBusTreeView.ItemHeight = serviceBusTreeView.Font.Height;
         }
 
         private void receiveMessages_Click(object sender, EventArgs e)
@@ -7443,13 +7446,13 @@ namespace ServiceBusExplorer.Forms
                     || (treeNode.Tag is UrlSegmentWrapper && (treeNode.Tag as UrlSegmentWrapper).EntityType == EntityType.Topic))
                 {
                     deleteConfirmation = $"Are you sure you want to purge {strategyDescription} from all topics{(treeNode.Tag is UrlSegmentWrapper ? " in this folder" : string.Empty)}?";
-                    
+
                     List<TreeNode> topicTreeNodes = new List<TreeNode>();
                     this.FindTopicsNodesRecursive(topicTreeNodes, treeNode);
 
                     subscriptions.AddRange(topicTreeNodes.SelectMany(subscriptionsExtractor));
                 }
-                else if (treeNode == FindNode(Constants.QueueEntities, rootNode) 
+                else if (treeNode == FindNode(Constants.QueueEntities, rootNode)
                     || (treeNode.Tag is UrlSegmentWrapper && (treeNode.Tag as UrlSegmentWrapper).EntityType == EntityType.Queue))
                 {
                     deleteConfirmation = $"Are you sure you want to purge {strategyDescription} from all queues{(treeNode.Tag is UrlSegmentWrapper ? " in this folder" : string.Empty)}?";

--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -4232,7 +4232,7 @@ namespace ServiceBusExplorer.Forms
                         ok = true;
                     }
                     var width = panelMain.Width - 4;
-                    var height = panelMain.Height - /*26;*/ (LogicalToDeviceUnits(panelMain.HeaderHeight) + 6);
+                    var height = panelMain.Height - (LogicalToDeviceUnits(panelMain.HeaderHeight) + 6);
                     control.Width = width < ControlMinWidth ? ControlMinWidth : width;
                     control.Height = height < ControlMinHeight ? ControlMinHeight : height;
                 }

--- a/src/ServiceBusExplorer/Forms/NewVersionAvailableForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/NewVersionAvailableForm.Designer.cs
@@ -54,33 +54,59 @@ namespace ServiceBusExplorer.Forms
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(NewVersionAvailableForm));
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.labelReleaseInfo = new System.Windows.Forms.Label();
+            this.linkLabelnewVersion = new System.Windows.Forms.LinkLabel();
+            this.labelLatestVersion = new System.Windows.Forms.Label();
             this.lblExeVersion = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
-            this.labelLatestVersion = new System.Windows.Forms.Label();
-            this.linkLabelnewVersion = new System.Windows.Forms.LinkLabel();
-            this.labelReleaseInfo = new System.Windows.Forms.Label();
+            this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
-            // lblExeVersion
+            // tableLayoutPanel1
             // 
-            this.lblExeVersion.AutoSize = true;
-            this.lblExeVersion.BackColor = System.Drawing.Color.Transparent;
-            this.lblExeVersion.Location = new System.Drawing.Point(16, 81);
-            this.lblExeVersion.Name = "lblExeVersion";
-            this.lblExeVersion.Size = new System.Drawing.Size(81, 13);
-            this.lblExeVersion.TabIndex = 1;
-            this.lblExeVersion.Text = "Version: 1.0.0.0";
+            this.tableLayoutPanel1.BackColor = System.Drawing.Color.Transparent;
+            this.tableLayoutPanel1.ColumnCount = 1;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Controls.Add(this.labelReleaseInfo, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.linkLabelnewVersion, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.labelLatestVersion, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.lblExeVersion, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.label2, 0, 0);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(12, 44);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 5;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(560, 343);
+            this.tableLayoutPanel1.TabIndex = 6;
             // 
-            // label2
+            // labelReleaseInfo
             // 
-            this.label2.AutoSize = true;
-            this.label2.BackColor = System.Drawing.Color.Transparent;
-            this.label2.Font = new System.Drawing.Font("Verdana", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(16, 54);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(158, 16);
-            this.label2.TabIndex = 0;
-            this.label2.Text = "Service Bus Explorer";
+            this.labelReleaseInfo.AutoSize = true;
+            this.labelReleaseInfo.BackColor = System.Drawing.Color.Transparent;
+            this.labelReleaseInfo.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.labelReleaseInfo.Location = new System.Drawing.Point(3, 100);
+            this.labelReleaseInfo.Name = "labelReleaseInfo";
+            this.labelReleaseInfo.Size = new System.Drawing.Size(554, 243);
+            this.labelReleaseInfo.TabIndex = 6;
+            this.labelReleaseInfo.Text = "releaseInfo";
+            // 
+            // linkLabelnewVersion
+            // 
+            this.linkLabelnewVersion.AutoSize = true;
+            this.linkLabelnewVersion.BackColor = System.Drawing.Color.Transparent;
+            this.linkLabelnewVersion.ForeColor = System.Drawing.Color.Navy;
+            this.linkLabelnewVersion.Location = new System.Drawing.Point(3, 75);
+            this.linkLabelnewVersion.Name = "linkLabelnewVersion";
+            this.linkLabelnewVersion.Size = new System.Drawing.Size(220, 13);
+            this.linkLabelnewVersion.TabIndex = 5;
+            this.linkLabelnewVersion.TabStop = true;
+            this.linkLabelnewVersion.Text = "https://github.com/xxxxxxxxxxxxxxxx/xxxxxxx";
+            this.linkLabelnewVersion.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelnewVersion_LinkClicked);
             // 
             // labelLatestVersion
             // 
@@ -88,36 +114,32 @@ namespace ServiceBusExplorer.Forms
             this.labelLatestVersion.BackColor = System.Drawing.Color.Transparent;
             this.labelLatestVersion.Font = new System.Drawing.Font("Verdana", 9.75F, System.Drawing.FontStyle.Bold);
             this.labelLatestVersion.ForeColor = System.Drawing.Color.Red;
-            this.labelLatestVersion.Location = new System.Drawing.Point(16, 106);
+            this.labelLatestVersion.Location = new System.Drawing.Point(3, 50);
             this.labelLatestVersion.Name = "labelLatestVersion";
-            this.labelLatestVersion.Size = new System.Drawing.Size(185, 16);
-            this.labelLatestVersion.TabIndex = 2;
+            this.labelLatestVersion.Size = new System.Drawing.Size(184, 16);
+            this.labelLatestVersion.TabIndex = 4;
             this.labelLatestVersion.Text = "New Version is Available";
             // 
-            // linkLabelnewVersion
+            // lblExeVersion
             // 
-            this.linkLabelnewVersion.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.linkLabelnewVersion.AutoSize = true;
-            this.linkLabelnewVersion.BackColor = System.Drawing.Color.Transparent;
-            this.linkLabelnewVersion.ForeColor = System.Drawing.Color.Navy;
-            this.linkLabelnewVersion.Location = new System.Drawing.Point(16, 134);
-            this.linkLabelnewVersion.Name = "linkLabelnewVersion";
-            this.linkLabelnewVersion.Size = new System.Drawing.Size(220, 13);
-            this.linkLabelnewVersion.TabIndex = 3;
-            this.linkLabelnewVersion.TabStop = true;
-            this.linkLabelnewVersion.Text = "https://github.com/xxxxxxxxxxxxxxxx/xxxxxxx";
-            this.linkLabelnewVersion.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelnewVersion_LinkClicked);
+            this.lblExeVersion.AutoSize = true;
+            this.lblExeVersion.BackColor = System.Drawing.Color.Transparent;
+            this.lblExeVersion.Location = new System.Drawing.Point(3, 25);
+            this.lblExeVersion.Name = "lblExeVersion";
+            this.lblExeVersion.Size = new System.Drawing.Size(81, 13);
+            this.lblExeVersion.TabIndex = 3;
+            this.lblExeVersion.Text = "Version: 1.0.0.0";
             // 
-            // labelReleaseInfo
+            // label2
             // 
-            this.labelReleaseInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.labelReleaseInfo.AutoSize = true;
-            this.labelReleaseInfo.BackColor = System.Drawing.Color.Transparent;
-            this.labelReleaseInfo.Location = new System.Drawing.Point(16, 159);
-            this.labelReleaseInfo.Name = "labelReleaseInfo";
-            this.labelReleaseInfo.Size = new System.Drawing.Size(59, 13);
-            this.labelReleaseInfo.TabIndex = 4;
-            this.labelReleaseInfo.Text = "releaseInfo";
+            this.label2.AutoSize = true;
+            this.label2.BackColor = System.Drawing.Color.Transparent;
+            this.label2.Font = new System.Drawing.Font("Verdana", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label2.Location = new System.Drawing.Point(3, 0);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(157, 16);
+            this.label2.TabIndex = 1;
+            this.label2.Text = "Service Bus Explorer";
             // 
             // NewVersionAvailableForm
             // 
@@ -127,11 +149,7 @@ namespace ServiceBusExplorer.Forms
             this.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("$this.BackgroundImage")));
             this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
             this.ClientSize = new System.Drawing.Size(584, 441);
-            this.Controls.Add(this.labelReleaseInfo);
-            this.Controls.Add(this.labelLatestVersion);
-            this.Controls.Add(this.linkLabelnewVersion);
-            this.Controls.Add(this.lblExeVersion);
-            this.Controls.Add(this.label2);
+            this.Controls.Add(this.tableLayoutPanel1);
             this.DoubleBuffered = true;
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
@@ -142,16 +160,19 @@ namespace ServiceBusExplorer.Forms
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Version Checker";
             this.Load += new System.EventHandler(this.NewVersionAvailableForm_Load);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
         #endregion
+
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.Label labelReleaseInfo;
+        private System.Windows.Forms.LinkLabel linkLabelnewVersion;
+        private System.Windows.Forms.Label labelLatestVersion;
         private System.Windows.Forms.Label lblExeVersion;
         private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.Label labelLatestVersion;
-        private System.Windows.Forms.LinkLabel linkLabelnewVersion;
-        private System.Windows.Forms.Label labelReleaseInfo;
     }
 }

--- a/src/ServiceBusExplorer/Forms/NewVersionAvailableForm.cs
+++ b/src/ServiceBusExplorer/Forms/NewVersionAvailableForm.cs
@@ -21,15 +21,11 @@
 
 #region Using Directives
 
-using System;
-using System.Collections;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Drawing;
-using System.Drawing.Drawing2D;
-using System.Windows.Forms;
 using ServiceBusExplorer.Helpers;
-using ServiceBusExplorer.Properties;
+using ServiceBusExplorer.UIHelpers;
+using System;
+using System.Diagnostics;
+using System.Windows.Forms;
 
 #endregion
 
@@ -49,36 +45,17 @@ namespace ServiceBusExplorer.Forms
                 ControlStyles.ResizeRedraw |
                 ControlStyles.UserPaint,
                 true);
-
         }
         #endregion
 
         #region Event Handlers
-       
-        private void siteLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-        {
-            Process.Start("https://github.com/paolosalvatori/ServiceBusExplorer");
-        }
-
-        private void mailLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-        {
-            Process.Start("mailto:paolos@microsoft.com?subject=Service%20Bus%20Explorer%20Feedback");
-        }
-
-        private void blogLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-        {
-            Process.Start("http://blogs.msdn.com/paolos");
-        }
-
-        private void twitterLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-        {
-            Process.Start("https://twitter.com/babosbird");
-        }
-
         private void NewVersionAvailableForm_Load(object sender, EventArgs e)
         {
+            this.SuspendDrawing();
+            this.SuspendLayout();
+
             lblExeVersion.Text = VersionProvider.GetExeVersion();
-            
+
             if (!VersionProvider.IsLatestVersion(out var releaseInfo))
             {
                 labelLatestVersion.Text = $"New Release {releaseInfo.Version} Available";
@@ -94,6 +71,9 @@ namespace ServiceBusExplorer.Forms
                 linkLabelnewVersion.Visible = false;
                 labelReleaseInfo.Visible = false;
             }
+
+            this.ResumeDrawing();
+            this.ResumeLayout();
         }
         #endregion
 

--- a/src/ServiceBusExplorer/Forms/ParameterForm.cs
+++ b/src/ServiceBusExplorer/Forms/ParameterForm.cs
@@ -34,8 +34,8 @@ namespace ServiceBusExplorer.Forms
     public partial class ParameterForm : Form
     {
         #region Private Fields
-        private IList<bool> canBeNullList;
-        private readonly IList<Control> textBoxList; 
+        private readonly IList<bool> canBeNullList;
+        private readonly IList<Control> textBoxList;
         #endregion
 
         #region Public Constructor
@@ -51,45 +51,56 @@ namespace ServiceBusExplorer.Forms
                 return;
             }
             this.canBeNullList = canBeNullList;
-            var labelY = 16;
-            var textBoxY = 32;
-            var textBoxWidth = mainPanel.Size.Width - 32;
+
+            var positionX = 16;
+            var labelY = LogicalToDeviceUnits(16);
+            var labelWidth = 400;
+            var labelHeight = LogicalToDeviceUnits(20);
+            var labelYStep = LogicalToDeviceUnits(48);
+
+            var textBoxY = LogicalToDeviceUnits(32);
+            var textBoxWidth = mainPanel.Size.Width - LogicalToDeviceUnits(32);
+            var textBoxHeight = LogicalToDeviceUnits(24);
+            var textBoxYStep = LogicalToDeviceUnits(48);
+
             for (var i = 0; i < parameterNameList.Count; i++)
             {
                 var parameter = parameterNameList[i];
                 var label = new Label
                 {
-                    Name = string.Format("lbl{0}", parameter),
-                    Text = string.Format("{0}:", parameter),
-                    Location = new Point(16, labelY),
-                    Size = new Size(400, 20)
+                    Name = $"lbl{parameter}",
+                    Text = $"{parameter}:",
+                    Location = new Point(positionX, labelY),
+                    Size = new Size(labelWidth, labelHeight)
                 };
                 mainPanel.Controls.Add(label);
+                
                 var textBox = new TextBox
                 {
-                    Name = string.Format("txt{0}", parameter),
+                    Name = $"txt{parameter}",
                     AutoSize = false,
-                    Size = new Size(textBoxWidth, 24),
-                    Location = new Point(16, textBoxY),
-                    Tag = i 
+                    Size = new Size(textBoxWidth, textBoxHeight),
+                    Location = new Point(positionX, textBoxY),
+                    Tag = i
                 };
-                
+
                 if (parameterNameList.Count == parameterValueList.Count)
                 {
                     textBox.Text = parameterValueList[i];
                 }
-                if (canBeNullList != null && 
+                if (canBeNullList != null &&
                     parameterValueList.Count == canBeNullList.Count)
                 {
                     textBox.TextChanged += textBox_TextChanged;
                 }
                 mainPanel.Controls.Add(textBox);
                 textBox.BringToFront();
-                labelY += 48;
-                textBoxY += 48;
+                labelY += labelYStep;
+                textBoxY += textBoxYStep;
             }
+
             textBoxList = mainPanel.Controls.Cast<Control>().Where(c => c is TextBox).ToList();
-            var delta = parameterNameList.Count*48;
+            var delta = parameterNameList.Count * labelYStep;
             Size = new Size(Size.Width, Size.Height + delta);
             textBox_TextChanged(null, null);
         }

--- a/src/ServiceBusExplorer/ServiceBusExplorer.csproj
+++ b/src/ServiceBusExplorer/ServiceBusExplorer.csproj
@@ -5,7 +5,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <ProjectGuid>{32754F39-E353-4607-94FE-B9B9ACFD58EF}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
 

--- a/src/ServiceBusExplorer/ServiceBusExplorer.csproj
+++ b/src/ServiceBusExplorer/ServiceBusExplorer.csproj
@@ -5,7 +5,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <ProjectGuid>{32754F39-E353-4607-94FE-B9B9ACFD58EF}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
 
@@ -70,6 +70,7 @@
     <PackageIcon>NewServiceBusExplorerLogo.jpg</PackageIcon>
     <RepositoryUrl>https://github.com/paolosalvatori/ServiceBusExplorer</RepositoryUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FastColoredTextBox">

--- a/src/ServiceBusExplorer/ServiceBusExplorer.csproj
+++ b/src/ServiceBusExplorer/ServiceBusExplorer.csproj
@@ -5,7 +5,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <ProjectGuid>{32754F39-E353-4607-94FE-B9B9ACFD58EF}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
 

--- a/src/ServiceBusExplorer/UIHelpers/ControlHelper.cs
+++ b/src/ServiceBusExplorer/UIHelpers/ControlHelper.cs
@@ -21,36 +21,34 @@
 
 #region Using Directives
 
-using System;
-using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 #endregion
 
 namespace ServiceBusExplorer.UIHelpers
 {
-    public static class ControlHelper 
-    {     
+    public static class ControlHelper
+    {
         #region Redraw Suspend/Resume
-        private const int WmSetredraw = 0xB;      
-        public static void SuspendDrawing(this Control target)     
+        private const int WmSetredraw = 0xB;
+        public static void SuspendDrawing(this Control target)
         {
-            NativeMethods.SendMessage(target.Handle, WmSetredraw, 0, 0);     
-        }      
-        
-        public static void ResumeDrawing(this Control target) 
-        { 
-            ResumeDrawing(target, true); 
-        }     
+            NativeMethods.SendMessage(target.Handle, WmSetredraw, 0, 0);
+        }
 
-        public static void ResumeDrawing(this Control target, bool redraw)     
-        {         
-            NativeMethods.SendMessage(target.Handle, WmSetredraw, 1, 0);          
-            if (redraw)         
-            {             
-                target.Refresh();         
-            }     
-        }     
-        #endregion 
-    } 
+        public static void ResumeDrawing(this Control target)
+        {
+            ResumeDrawing(target, true);
+        }
+
+        public static void ResumeDrawing(this Control target, bool redraw)
+        {
+            NativeMethods.SendMessage(target.Handle, WmSetredraw, 1, 0);
+            if (redraw)
+            {
+                target.Refresh();
+            }
+        }
+        #endregion
+    }
 }

--- a/src/ServiceBusExplorer/app.manifest
+++ b/src/ServiceBusExplorer/app.manifest
@@ -25,5 +25,24 @@
 
         </application>
     </compatibility>
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">system</dpiAwareness>
+        </windowsSettings>
+    </application>
 
+    <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+    <dependency>
+        <dependentAssembly>
+            <assemblyIdentity
+                type="win32"
+                name="Microsoft.Windows.Common-Controls"
+                version="6.0.0.0"
+                processorArchitecture="*"
+                publicKeyToken="6595b64144ccf1df"
+                language="*"
+        />
+        </dependentAssembly>
+    </dependency>
 </assembly>

--- a/src/ServiceBusExplorer/app.manifest
+++ b/src/ServiceBusExplorer/app.manifest
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+    <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- A list of the Windows versions that this application has been tested on
+            and is designed to work with. Uncomment the appropriate elements
+            and Windows will automatically select the most compatible environment. -->
+
+            <!-- Windows Vista -->
+            <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+            <!-- Windows 7 -->
+            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+
+            <!-- Windows 8 -->
+            <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+
+            <!-- Windows 8.1 -->
+            <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+
+            <!-- Windows 10 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+        </application>
+    </compatibility>
+
+</assembly>

--- a/src/Utilities/Helpers/GitHubReleaseProvider.cs
+++ b/src/Utilities/Helpers/GitHubReleaseProvider.cs
@@ -21,12 +21,12 @@
 
 namespace ServiceBusExplorer.Utilities.Helpers
 {
+    using Newtonsoft.Json;
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using Newtonsoft.Json;
 
     public class ReleaseInfo
     {
@@ -47,6 +47,8 @@ namespace ServiceBusExplorer.Utilities.Helpers
 
     public static class GitHubReleaseProvider
     {
+        private static readonly HttpClient client = new HttpClient();
+
         public class Release
         {
             [JsonProperty("url", NullValueHandling = NullValueHandling.Ignore)]
@@ -89,16 +91,40 @@ namespace ServiceBusExplorer.Utilities.Helpers
         public static async Task<ReleaseInfo> GetServiceBusClientLatestVersion(WriteToLogDelegate writeToLog = null)
         {
             var nextReleaseInfo = ReleaseInfo.Null;
-            using (var client = new HttpClient())
+            var responseBody = string.Empty;
+            try
             {
-                var responseBody = string.Empty;
+                client.DefaultRequestHeaders.Add("User-Agent", "ASBE");
+                responseBody = await client.GetStringAsync("https://api.github.com/repos/paolosalvatori/ServiceBusExplorer/releases/latest")
+                    .ConfigureAwait(false);
+            }
+            catch (HttpRequestException e)
+            {
+                if (writeToLog != null)
+                {
+                    writeToLog($"GitHubReleaseProvider::{e.Message} " + e?.InnerException);
+                }
+                else
+                {
+                    Console.WriteLine(e.Message);
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(responseBody))
+            {
                 try
                 {
-                    client.DefaultRequestHeaders.Add("User-Agent", "ASBE");
-                    responseBody = await client.GetStringAsync("https://api.github.com/repos/paolosalvatori/ServiceBusExplorer/releases/latest")
-                        .ConfigureAwait(false);
+                    var latestReleaseInfo = JsonConvert.DeserializeObject<Release>(responseBody);
+                    if (latestReleaseInfo != null && !string.IsNullOrWhiteSpace(latestReleaseInfo.Name))
+                    {
+                        var version = new Version(latestReleaseInfo.Name);
+                        var uri = latestReleaseInfo.HtmlUrl;
+                        var zipUrl = latestReleaseInfo.Assets.FirstOrDefault(x => x.Name.EndsWith(".zip"))?.BrowserDownloadUrl;
+                        nextReleaseInfo = new ReleaseInfo(uri, version,
+                            latestReleaseInfo.Body, zipUrl);
+                    }
                 }
-                catch (HttpRequestException e)
+                catch (Exception e)
                 {
                     if (writeToLog != null)
                     {
@@ -109,33 +135,7 @@ namespace ServiceBusExplorer.Utilities.Helpers
                         Console.WriteLine(e.Message);
                     }
                 }
-
-                if (!string.IsNullOrWhiteSpace(responseBody))
-                    try
-                    {
-                        var latestReleaseInfo = JsonConvert.DeserializeObject<Release>(responseBody);
-                        if (latestReleaseInfo != null && !string.IsNullOrWhiteSpace(latestReleaseInfo.Name))
-                        {
-                            var version = new Version(latestReleaseInfo.Name);
-                            var uri = latestReleaseInfo.HtmlUrl;
-                            var zipUrl = latestReleaseInfo.Assets.FirstOrDefault(x => x.Name.EndsWith(".zip"))?.BrowserDownloadUrl;
-                            nextReleaseInfo = new ReleaseInfo(uri, version,
-                                latestReleaseInfo.Body, zipUrl);
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        if (writeToLog != null)
-                        {
-                            writeToLog($"GitHubReleaseProvider::{e.Message} " + e?.InnerException);
-                        }
-                        else
-                        {
-                            Console.WriteLine(e.Message);
-                        }
-                    }
             }
-
             return nextReleaseInfo;
         }
     }


### PR DESCRIPTION
* Adding support for .NET Framework 4.7.2 and using the settings in the app.manifest file for enabling high DPI support, and for taking advantage of some new helper methods the framework offers for high DPI related calculations, such as LogicalToDeviceUnits and ScaleBitmapLogicalToDevice
* Changes for making the ConnectForm and MainForm work with high DPI, by fixing how the height of some controls are calculated, such as HeaderPanel or HandleTopicControl.
* Whitespace formatting in the FilterForm.
* Fixes for the message dialogs ChangeStatusForm, ClipboardForm and DeleteForm, so the message text is displayed completely. 
* Changes in the ParameterForm and the MainForm to display the ParameterForm properly in high DPI.
* Changes in the NewVersionAvailableForm, for showing the labels correctly in high DPI, besides removing some event handlers no longer called by the form.
* Small improvement in the GitHubReleaseProvider class, to have one static readonly HttpClient instance created.
* Fixing the height of the header box in the Grouper control, besides replacing tabs with spaces.
* Addressing some warnings in the Common project related to the app.config mapping and binding redirects.