### PR TITLE
Show error message when a fatal error occurs

### DIFF
--- a/src/ServiceBusExplorer/Program.cs
+++ b/src/ServiceBusExplorer/Program.cs
@@ -70,7 +70,7 @@ namespace ServiceBusExplorer
             }
             catch (Exception e)
             {
-                MessageBox.Show(text: $"A fatal exception occurred. ServiceBusExplorer will now shutdown. \n\n{e.Message}.", 
+                MessageBox.Show(text: $"A fatal exception occurred. ServiceBusExplorer will now shut down. \n\n{e.Message}.", 
                     caption: "ServiceBusExplorer", 
                     buttons: MessageBoxButtons.OK,
                     icon: MessageBoxIcon.Stop);

--- a/src/ServiceBusExplorer/Program.cs
+++ b/src/ServiceBusExplorer/Program.cs
@@ -68,10 +68,12 @@ namespace ServiceBusExplorer
                     Application.Run(new MainForm(helpText));
                 }
             }
-            // ReSharper disable EmptyGeneralCatchClause
-            catch (Exception)
-            // ReSharper restore EmptyGeneralCatchClause
+            catch (Exception e)
             {
+                MessageBox.Show(text: $"A fatal exception occurred. ServiceBusExplorer will now shutdown. \n\n{e.Message}.", 
+                    caption: "ServiceBusExplorer", 
+                    buttons: MessageBoxButtons.OK,
+                    icon: MessageBoxIcon.Stop);
             }
         }
         


### PR DESCRIPTION
This happens if the user configuration contains invalid XML, for instance. 