### PR TITLE
fixes an issue when connection string ending with ";" causes an exception

### DIFF
--- a/src/Common/Helpers/ServiceBusNamespace.cs
+++ b/src/Common/Helpers/ServiceBusNamespace.cs
@@ -231,7 +231,8 @@ namespace ServiceBusExplorer.Helpers
 
             var isUserCreated = !(key == "CustomConnectionString" || key == "SASConnectionString");
             var toLower = connectionString.ToLower();
-            var parameters = connectionString.Split(';').ToDictionary(s => s.Substring(0, s.IndexOf('=')).ToLower(), s => s.Substring(s.IndexOf('=') + 1));
+            var parameters = connectionString.Split([';'], StringSplitOptions.RemoveEmptyEntries)
+                .ToDictionary(s => s.Substring(0, s.IndexOf('=')).ToLower(), s => s.Substring(s.IndexOf('=') + 1));
 
             if (toLower.Contains(ConnectionStringEndpoint) &&
                 toLower.Contains(ConnectionStringSharedAccessKeyName) &&


### PR DESCRIPTION
If a connection string ends with a ";" semi colon the split function returns an empty string as the last entry causing an exception.

By removing those empty entries, exception can be avoided, and application works as expected.