### PR TITLE
Implement issue 802

### DIFF
--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -1831,7 +1831,7 @@ namespace ServiceBusExplorer.Forms
             }
 
             //record the original subscriptions node is expanded
-            var originalSubscriptionsNode = selectedNode.Nodes.Find(SubscriptionEntities, false).First();
+            var originalSubscriptionsNode = selectedNode.Nodes.Find(SubscriptionEntities, false).FirstOrDefault();
             if (originalSubscriptionsNode != null)
             {
                 wasSubscriptionsNodeExpaned = originalSubscriptionsNode.IsExpanded;

--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -1817,7 +1817,7 @@ namespace ServiceBusExplorer.Forms
         private void RefreshIndividualTopic(TreeNode selectedNode)
         {
             var wasTopicNodeExpanded = selectedNode.IsExpanded;
-            var wasSubscriptionsNodeExpaned = false;
+            var wasSubscriptionsNodeExpanded = false;
 
             var topicDescription = selectedNode.Tag as TopicDescription;
 
@@ -1834,7 +1834,7 @@ namespace ServiceBusExplorer.Forms
             var originalSubscriptionsNode = selectedNode.Nodes.Find(SubscriptionEntities, false).FirstOrDefault();
             if (originalSubscriptionsNode != null)
             {
-                wasSubscriptionsNodeExpaned = originalSubscriptionsNode.IsExpanded;
+                wasSubscriptionsNodeExpanded = originalSubscriptionsNode.IsExpanded;
             }
 
             selectedNode.Nodes.Clear();
@@ -1860,7 +1860,7 @@ namespace ServiceBusExplorer.Forms
 
             if (wasTopicNodeExpanded)
                 selectedNode.Expand();
-            if (wasSubscriptionsNodeExpaned == true)
+            if (wasSubscriptionsNodeExpanded == true)
             {
                 subscriptionsNode.Expand();
             }

--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -1817,6 +1817,7 @@ namespace ServiceBusExplorer.Forms
         private void RefreshIndividualTopic(TreeNode selectedNode)
         {
             var wasTopicNodeExpanded = selectedNode.IsExpanded;
+            var wasSubscriptionsNodeExpaned = false;
 
             var topicDescription = selectedNode.Tag as TopicDescription;
 
@@ -1827,6 +1828,13 @@ namespace ServiceBusExplorer.Forms
             {
                 selectedNode.Nodes.Clear();
                 return;
+            }
+
+            //record the original subscriptions node is expanded
+            var originalSubscriptionsNode = selectedNode.Nodes.Find(SubscriptionEntities, false).First();
+            if (originalSubscriptionsNode != null)
+            {
+                wasSubscriptionsNodeExpaned = originalSubscriptionsNode.IsExpanded;
             }
 
             selectedNode.Nodes.Clear();
@@ -1852,6 +1860,10 @@ namespace ServiceBusExplorer.Forms
 
             if (wasTopicNodeExpanded)
                 selectedNode.Expand();
+            if (wasSubscriptionsNodeExpaned == true)
+            {
+                subscriptionsNode.Expand();
+            }
         }
 
         private void createEntity_Click(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #802 

just implement the feature when refresh the topic node.
not sure is it necessary to implement at other mode(Queues, Eventhhubs), as their Treeview structure was different.
not keep subscription node and rule node expaned, as it will add some ugly compare code in Foreach cycle and in daily use I just want keep subscriptions node expaned.