### PR TITLE
#686: Move Topic management functions to separate class

### DIFF
--- a/src/Common/Helpers/ServiceBusHelper.cs
+++ b/src/Common/Helpers/ServiceBusHelper.cs
@@ -1941,27 +1941,27 @@ namespace ServiceBusExplorer
         /// Deletes all the queues in the list.
         /// <param name="queues">A list of queues to delete.</param>
         /// </summary>
-        public Task DeleteQueues(IEnumerable<string> queues)
+        public async Task DeleteQueues(IEnumerable<string> queues)
         {
-            return serviceBusQueue.DeleteQueues(queues);
+            await serviceBusQueue.DeleteQueues(queues);
         }
 
         /// <summary>
         /// Deletes the queue described by the relative name of the service namespace base address.
         /// </summary>
         /// <param name="path">Path of the queue relative to the service namespace base address.</param>
-        public Task DeleteQueue(string path)
+        public async Task DeleteQueue(string path)
         {
-            return serviceBusQueue.DeleteQueue(path);
+            await serviceBusQueue.DeleteQueue(path);
         }
 
         /// <summary>
         /// Deletes the queue passed as a argument.
         /// </summary>
         /// <param name="queueDescription">The queue to delete.</param>
-        public Task DeleteQueue(QueueDescription queueDescription)
+        public async Task DeleteQueue(QueueDescription queueDescription)
         {
-            return serviceBusQueue.DeleteQueue(queueDescription);
+            await serviceBusQueue.DeleteQueue(queueDescription);
         }
 
         /// <summary>
@@ -2009,27 +2009,27 @@ namespace ServiceBusExplorer
         /// Deletes all the topics in the list.
         /// <param name="topics">A list of topics to delete.</param>
         /// </summary>
-        public Task DeleteTopics(IEnumerable<string> topics)
+        public async Task DeleteTopics(IEnumerable<string> topics)
         {
-            return serviceBusTopic.DeleteTopics(topics);
+            await serviceBusTopic.DeleteTopics(topics);
         }
 
         /// <summary>
         /// Deletes the topic described by the relative name of the service namespace base address.
         /// </summary>
         /// <param name="path">Path of the topic relative to the service namespace base address.</param>
-        public Task DeleteTopic(string path)
+        public async Task DeleteTopic(string path)
         {
-            return serviceBusTopic.DeleteTopic(path);
+            await serviceBusTopic.DeleteTopic(path);
         }
 
         /// <summary>
         /// Deletes the topic passed as a argument.
         /// </summary>
         /// <param name="topic">The topic to delete.</param>
-        public Task DeleteTopic(TopicDescription topic)
+        public async Task DeleteTopic(TopicDescription topic)
         {
-            return serviceBusTopic.DeleteTopic(topic);
+            await serviceBusTopic.DeleteTopic(topic);
         }
 
         /// <summary>

--- a/src/Common/WindowsAzure/IServiceBusEntity.cs
+++ b/src/Common/WindowsAzure/IServiceBusEntity.cs
@@ -1,0 +1,21 @@
+﻿using ServiceBusExplorer.Helpers;
+using ServiceBusExplorer.Utilities.Helpers;
+
+namespace ServiceBusExplorer.WindowsAzure
+{
+    internal interface IServiceBusEntity
+    {
+        /// <summary>
+        /// Gets or sets the scheme of the URI.
+        /// </summary>
+        string Scheme { get; set; }
+        
+        WriteToLogDelegate WriteToLog { get; set; }
+
+        delegate void EventHandler(ServiceBusHelperEventArgs args);
+
+        public event EventHandler OnDelete;
+
+        public event EventHandler OnCreate;
+    }
+}

--- a/src/Common/WindowsAzure/IServiceBusQueue.cs
+++ b/src/Common/WindowsAzure/IServiceBusQueue.cs
@@ -1,44 +1,87 @@
-﻿using Microsoft.ServiceBus.Messaging;
-using ServiceBusExplorer.Helpers;
-using ServiceBusExplorer.Utilities.Helpers;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.ServiceBus.Messaging;
+using ServiceBusExplorer.Helpers;
 
 namespace ServiceBusExplorer.WindowsAzure
 {
-    public interface IServiceBusQueue
+    internal interface IServiceBusQueue : IServiceBusEntity
     {
+        /// <summary>
+        /// Creates a new queue in the service namespace with the given name.
+        /// </summary>
+        /// <param name="description">A QueueDescription object describing the attributes with which the new queue will be created.</param>
+        /// <returns>Returns a newly-created QueueDescription object.</returns>
         QueueDescription CreateQueue(QueueDescription description);
-        
+
+        /// <summary>.
+        /// Creates a new queue in the service namespace with the given name.
+        /// </summary>
+        /// <param name="path">Path of the queue relative to the service namespace base address.</param>
+        /// <returns>Returns a newly-created QueueDescription object.</returns>
         QueueDescription CreateQueue(string path);
-        
+
+        /// <summary>
+        /// Deletes the queue passed as a argument.
+        /// </summary>
+        /// <param name="queueDescription">The queue to delete.</param>
         Task DeleteQueue(QueueDescription queueDescription);
-        
+
+        /// <summary>
+        /// Deletes the queue described by the relative name of the service namespace base address.
+        /// </summary>
+        /// <param name="path">Path of the queue relative to the service namespace base address.</param>
         Task DeleteQueue(string path);
-        
+
+        /// <summary>
+        /// Deletes all the queues in the list.
+        /// <param name="queues">A list of queues to delete.</param>
+        /// </summary>
         Task DeleteQueues(IEnumerable<string> queues);
-        
+
+        /// <summary>
+        /// Retrieves the queue from the service namespace.
+        /// </summary>
+        /// <param name="path">Path of the queue relative to the service namespace base address.</param>
+        /// <returns>A QueueDescription handle to the queue, or null if the queue does not exist in the service namespace. </returns>
         QueueDescription GetQueue(string path);
-        
+
+        /// <summary>
+        /// Gets the uri of the deadletter queue for a given queue.
+        /// </summary>
+        /// <param name="queuePath">The name of a queue.</param>
+        /// <returns>the absolute uri of the deadletter queue.</returns>
         Uri GetQueueDeadLetterQueueUri(string queuePath);
-        
+
+        /// <summary>
+        /// Retrieves an enumerable collection of all queues in the service bus namespace.
+        /// </summary>
+        /// <param name="filter">OData filter.</param>
+        /// <returns>Returns an IEnumerable<QueueDescription/> collection of all queues in the service namespace, or
+        /// an empty collection if no queue exists in this service namespace.</returns>
         IEnumerable<QueueDescription> GetQueues(string filter, int timeoutInSeconds);
-        
+
+        /// <summary>
+        /// Gets the uri of a queue.
+        /// </summary>
+        /// <param name="queuePath">The name of a queue.</param>
+        /// <returns>The absolute uri of the queue.</returns>
         Uri GetQueueUri(string queuePath);
-        
+
+        /// <summary>
+        /// Renames a queue inside a namespace.
+        /// </summary>
+        /// <param name="path">The path to an existing queue.</param>
+        /// <param name="newPath">The new path to the renamed queue.</param>
+        /// <returns>Returns a QueueDescription with the new name.</returns>
         QueueDescription RenameQueue(string path, string newPath);
-        
+
+        /// <summary>
+        /// Updates a queue in the service namespace with the given name.
+        /// </summary>
+        /// <param name="description">A QueueDescription object describing the attributes with which the new queue will be updated.</param>
+        /// <returns>Returns an updated QueueDescription object.</returns>
         QueueDescription UpdateQueue(QueueDescription description);
-
-        delegate void EventHandler(ServiceBusHelperEventArgs args);
-
-        event EventHandler OnDelete;
-        
-        event EventHandler OnCreate;
-
-        WriteToLogDelegate WriteToLog { get; set; }
-        
-        string Scheme { get; set; }
     }
 }

--- a/src/Common/WindowsAzure/IServiceBusQueue.cs
+++ b/src/Common/WindowsAzure/IServiceBusQueue.cs
@@ -8,80 +8,26 @@ namespace ServiceBusExplorer.WindowsAzure
 {
     internal interface IServiceBusQueue : IServiceBusEntity
     {
-        /// <summary>
-        /// Creates a new queue in the service namespace with the given name.
-        /// </summary>
-        /// <param name="description">A QueueDescription object describing the attributes with which the new queue will be created.</param>
-        /// <returns>Returns a newly-created QueueDescription object.</returns>
         QueueDescription CreateQueue(QueueDescription description);
 
-        /// <summary>.
-        /// Creates a new queue in the service namespace with the given name.
-        /// </summary>
-        /// <param name="path">Path of the queue relative to the service namespace base address.</param>
-        /// <returns>Returns a newly-created QueueDescription object.</returns>
         QueueDescription CreateQueue(string path);
 
-        /// <summary>
-        /// Deletes the queue passed as a argument.
-        /// </summary>
-        /// <param name="queueDescription">The queue to delete.</param>
         Task DeleteQueue(QueueDescription queueDescription);
 
-        /// <summary>
-        /// Deletes the queue described by the relative name of the service namespace base address.
-        /// </summary>
-        /// <param name="path">Path of the queue relative to the service namespace base address.</param>
         Task DeleteQueue(string path);
 
-        /// <summary>
-        /// Deletes all the queues in the list.
-        /// <param name="queues">A list of queues to delete.</param>
-        /// </summary>
         Task DeleteQueues(IEnumerable<string> queues);
 
-        /// <summary>
-        /// Retrieves the queue from the service namespace.
-        /// </summary>
-        /// <param name="path">Path of the queue relative to the service namespace base address.</param>
-        /// <returns>A QueueDescription handle to the queue, or null if the queue does not exist in the service namespace. </returns>
         QueueDescription GetQueue(string path);
 
-        /// <summary>
-        /// Gets the uri of the deadletter queue for a given queue.
-        /// </summary>
-        /// <param name="queuePath">The name of a queue.</param>
-        /// <returns>the absolute uri of the deadletter queue.</returns>
         Uri GetQueueDeadLetterQueueUri(string queuePath);
 
-        /// <summary>
-        /// Retrieves an enumerable collection of all queues in the service bus namespace.
-        /// </summary>
-        /// <param name="filter">OData filter.</param>
-        /// <returns>Returns an IEnumerable<QueueDescription/> collection of all queues in the service namespace, or
-        /// an empty collection if no queue exists in this service namespace.</returns>
         IEnumerable<QueueDescription> GetQueues(string filter, int timeoutInSeconds);
 
-        /// <summary>
-        /// Gets the uri of a queue.
-        /// </summary>
-        /// <param name="queuePath">The name of a queue.</param>
-        /// <returns>The absolute uri of the queue.</returns>
         Uri GetQueueUri(string queuePath);
 
-        /// <summary>
-        /// Renames a queue inside a namespace.
-        /// </summary>
-        /// <param name="path">The path to an existing queue.</param>
-        /// <param name="newPath">The new path to the renamed queue.</param>
-        /// <returns>Returns a QueueDescription with the new name.</returns>
         QueueDescription RenameQueue(string path, string newPath);
 
-        /// <summary>
-        /// Updates a queue in the service namespace with the given name.
-        /// </summary>
-        /// <param name="description">A QueueDescription object describing the attributes with which the new queue will be updated.</param>
-        /// <returns>Returns an updated QueueDescription object.</returns>
         QueueDescription UpdateQueue(QueueDescription description);
     }
 }

--- a/src/Common/WindowsAzure/IServiceBusTopic.cs
+++ b/src/Common/WindowsAzure/IServiceBusTopic.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.ServiceBus.Messaging;
+using ServiceBusExplorer.Helpers;
+
+namespace ServiceBusExplorer.WindowsAzure
+{
+    internal interface IServiceBusTopic : IServiceBusEntity
+    {
+        /// <summary>
+        /// Creates a new topic in the service namespace with the given name.
+        /// </summary>
+        /// <param name="path">Path of the topic relative to the service namespace base address.</param>
+        /// <returns>Returns a newly-created TopicDescription object.</returns>    
+        TopicDescription CreateTopic(string path);
+
+        /// <summary>
+        /// Creates a new topic in the service namespace with the given name.
+        /// </summary>
+        /// <param name="topicDescription">A TopicDescription object describing the attributes with which the new topic will be created.</param>
+        /// <returns>Returns a newly-created TopicDescription object.</returns>
+        TopicDescription CreateTopic(TopicDescription topicDescription);
+
+        /// <summary>
+        /// Deletes the topic described by the relative name of the service namespace base address.
+        /// </summary>
+        /// <param name="path">Path of the topic relative to the service namespace base address.</param>
+        Task DeleteTopic(string path);
+
+        /// <summary>
+        /// Deletes the topic passed as a argument.
+        /// </summary>
+        /// <param name="topic">The topic to delete.</param>
+        Task DeleteTopic(TopicDescription topic);
+
+
+        /// <summary>
+        /// Deletes all the topics in the list.
+        /// <param name="topics">A list of topics to delete.</param>
+        /// </summary>
+        Task DeleteTopics(IEnumerable<string> topics);
+
+        /// <summary>
+        /// Retrieves the topic from the service namespace.
+        /// </summary>
+        /// <param name="path">Path of the topic relative to the service namespace base address.</param>
+        /// <returns>A TopicDescription handle to the topic, or null if the topic does not exist in the service namespace.</returns>
+        TopicDescription GetTopic(string path);
+
+        /// <summary>
+        /// Retrieves an enumerable collection of all topics in the service bus namespace.
+        /// </summary>
+        /// <param name="filter">OData filter.</param>
+        /// <returns>Returns an IEnumerable<TopicDescription/> collection of all topics in the service namespace.
+        ///          Returns an empty collection if no topic exists in this service namespace.</returns>
+        IEnumerable<TopicDescription> GetTopics(string filter, int timeoutInSeconds);
+
+        /// <summary>
+        /// Gets the uri of a topic.
+        /// </summary>
+        /// <param name="topicPath">The name of a topic.</param>
+        /// <returns>The absolute uri of the topic.</returns>
+        Uri GetTopicUri(string topicPath);
+
+        /// <summary>
+        /// Renames a topic inside a namespace.
+        /// </summary>
+        /// <param name="path">The path to an existing topic.</param>
+        /// <param name="newPath">The new path to the renamed topic.</param>
+        /// <returns>Returns a TopicDescription with the new name.</returns>
+        TopicDescription RenameTopic(string path, string newPath);
+
+        /// <summary>
+        /// Updates a topic in the service namespace with the given name.
+        /// </summary>
+        /// <param name="topicDescription">A TopicDescription object describing the attributes with which the new topic will be updated.</param>
+        /// <returns>Returns an updated TopicDescription object.</returns>
+        TopicDescription UpdateTopic(TopicDescription topicDescription);
+    }
+}

--- a/src/Common/WindowsAzure/IServiceBusTopic.cs
+++ b/src/Common/WindowsAzure/IServiceBusTopic.cs
@@ -8,74 +8,24 @@ namespace ServiceBusExplorer.WindowsAzure
 {
     internal interface IServiceBusTopic : IServiceBusEntity
     {
-        /// <summary>
-        /// Creates a new topic in the service namespace with the given name.
-        /// </summary>
-        /// <param name="path">Path of the topic relative to the service namespace base address.</param>
-        /// <returns>Returns a newly-created TopicDescription object.</returns>    
         TopicDescription CreateTopic(string path);
 
-        /// <summary>
-        /// Creates a new topic in the service namespace with the given name.
-        /// </summary>
-        /// <param name="topicDescription">A TopicDescription object describing the attributes with which the new topic will be created.</param>
-        /// <returns>Returns a newly-created TopicDescription object.</returns>
         TopicDescription CreateTopic(TopicDescription topicDescription);
 
-        /// <summary>
-        /// Deletes the topic described by the relative name of the service namespace base address.
-        /// </summary>
-        /// <param name="path">Path of the topic relative to the service namespace base address.</param>
         Task DeleteTopic(string path);
 
-        /// <summary>
-        /// Deletes the topic passed as a argument.
-        /// </summary>
-        /// <param name="topic">The topic to delete.</param>
         Task DeleteTopic(TopicDescription topic);
 
-
-        /// <summary>
-        /// Deletes all the topics in the list.
-        /// <param name="topics">A list of topics to delete.</param>
-        /// </summary>
         Task DeleteTopics(IEnumerable<string> topics);
 
-        /// <summary>
-        /// Retrieves the topic from the service namespace.
-        /// </summary>
-        /// <param name="path">Path of the topic relative to the service namespace base address.</param>
-        /// <returns>A TopicDescription handle to the topic, or null if the topic does not exist in the service namespace.</returns>
         TopicDescription GetTopic(string path);
 
-        /// <summary>
-        /// Retrieves an enumerable collection of all topics in the service bus namespace.
-        /// </summary>
-        /// <param name="filter">OData filter.</param>
-        /// <returns>Returns an IEnumerable<TopicDescription/> collection of all topics in the service namespace.
-        ///          Returns an empty collection if no topic exists in this service namespace.</returns>
         IEnumerable<TopicDescription> GetTopics(string filter, int timeoutInSeconds);
 
-        /// <summary>
-        /// Gets the uri of a topic.
-        /// </summary>
-        /// <param name="topicPath">The name of a topic.</param>
-        /// <returns>The absolute uri of the topic.</returns>
         Uri GetTopicUri(string topicPath);
 
-        /// <summary>
-        /// Renames a topic inside a namespace.
-        /// </summary>
-        /// <param name="path">The path to an existing topic.</param>
-        /// <param name="newPath">The new path to the renamed topic.</param>
-        /// <returns>Returns a TopicDescription with the new name.</returns>
         TopicDescription RenameTopic(string path, string newPath);
 
-        /// <summary>
-        /// Updates a topic in the service namespace with the given name.
-        /// </summary>
-        /// <param name="topicDescription">A TopicDescription object describing the attributes with which the new topic will be updated.</param>
-        /// <returns>Returns an updated TopicDescription object.</returns>
         TopicDescription UpdateTopic(TopicDescription topicDescription);
     }
 }

--- a/src/Common/WindowsAzure/ServiceBusEntity.cs
+++ b/src/Common/WindowsAzure/ServiceBusEntity.cs
@@ -1,0 +1,85 @@
+﻿using Microsoft.ServiceBus;
+using ServiceBusExplorer.Helpers;
+using ServiceBusExplorer.Utilities.Helpers;
+
+namespace ServiceBusExplorer.WindowsAzure
+{
+    internal abstract class ServiceBusEntity : IServiceBusEntity
+    {
+        protected const string PathCannotBeNull = "The path argument cannot be null or empty.";
+        protected const string NewPathCannotBeNull = "The new path argument cannot be null or empty.";
+        protected const string DescriptionCannotBeNull = "The description argument cannot be null.";
+        protected const string ServiceBusIsDisconnected = "The application is now disconnected from any service bus namespace.";
+
+        private const string DefaultScheme = "sb";
+        private const string CloudServiceBusPostfix = ".servicebus.windows.net";
+        private const string GermanyServiceBusPostfix = ".servicebus.cloudapi.de";
+        private const string ChinaServiceBusPostfix = ".servicebus.chinacloudapi.cn";
+        private const string TestServiceBusPostFix = ".servicebus.int7.windows-int.net";
+
+        private readonly string ns;
+        private string scheme = DefaultScheme;
+
+        public ServiceBusEntity(ServiceBusNamespace serviceBusNamespace, NamespaceManager namespaceManager)
+        {
+            this.ServiceBusNamespace = serviceBusNamespace;
+            this.NamespaceManager = namespaceManager;
+            ns = GetNamespace();
+        }
+
+        public string Scheme
+        {
+            get
+            {
+                return scheme;
+            }
+            set
+            {
+                scheme = value;
+            }
+        }
+
+        public WriteToLogDelegate WriteToLog { get; set; } = (message, async) => { };
+
+        public event IServiceBusEntity.EventHandler OnDelete;
+
+        public event IServiceBusEntity.EventHandler OnCreate;
+
+        protected ServiceBusNamespace ServiceBusNamespace { get; }
+
+        protected NamespaceManager NamespaceManager { get; }
+
+        protected string Namespace { get { return ns; } }
+
+        protected void OnCreated(ServiceBusHelperEventArgs args)
+        {
+            OnCreate?.Invoke(args);
+        }
+
+        protected void OnDeleted(ServiceBusHelperEventArgs args)
+        {
+            OnDelete?.Invoke(args);
+        }
+
+        protected bool IsCloudNamespace()
+        {
+            string uri;
+            var connectionStringType = ServiceBusNamespace.ConnectionStringType;
+            var namespaceUri = NamespaceManager.Address;
+            return connectionStringType == ServiceBusNamespaceType.Cloud ||
+                  (namespaceUri != null &&
+                   !string.IsNullOrWhiteSpace(uri = namespaceUri.ToString()) &&
+                   (uri.Contains(CloudServiceBusPostfix) ||
+                    uri.Contains(TestServiceBusPostFix) ||
+                    uri.Contains(GermanyServiceBusPostfix) ||
+                    uri.Contains(ChinaServiceBusPostfix)));
+        }
+
+        private string GetNamespace()
+        {
+            var namespaceUri = NamespaceManager.Address;
+            return IsCloudNamespace() ? namespaceUri.Host.Split('.')[0] : namespaceUri.Segments[namespaceUri.Segments.Length - 1];
+        }
+
+    }
+}

--- a/src/Common/WindowsAzure/ServiceBusEntity.cs
+++ b/src/Common/WindowsAzure/ServiceBusEntity.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.ServiceBus;
+using Microsoft.ServiceBus.Messaging;
+using ServiceBusExplorer.Enums;
 using ServiceBusExplorer.Helpers;
 using ServiceBusExplorer.Utilities.Helpers;
 
@@ -20,7 +22,7 @@ namespace ServiceBusExplorer.WindowsAzure
         private readonly string ns;
         private string scheme = DefaultScheme;
 
-        public ServiceBusEntity(ServiceBusNamespace serviceBusNamespace, NamespaceManager namespaceManager)
+        protected ServiceBusEntity(ServiceBusNamespace serviceBusNamespace, NamespaceManager namespaceManager)
         {
             this.ServiceBusNamespace = serviceBusNamespace;
             this.NamespaceManager = namespaceManager;
@@ -51,14 +53,21 @@ namespace ServiceBusExplorer.WindowsAzure
 
         protected string Namespace { get { return ns; } }
 
-        protected void OnCreated(ServiceBusHelperEventArgs args)
+        protected abstract EntityType EntityType { get; }
+
+        protected void OnCreated<T>(T entityInstance) where T : EntityDescription
         {
-            OnCreate?.Invoke(args);
+            OnCreate?.Invoke(new ServiceBusHelperEventArgs(entityInstance, EntityType));
         }
 
-        protected void OnDeleted(ServiceBusHelperEventArgs args)
+        protected void OnDeleted<T>(T entityInstance) where T : EntityDescription
         {
-            OnDelete?.Invoke(args);
+            OnDelete?.Invoke(new ServiceBusHelperEventArgs(entityInstance, EntityType));
+        }
+
+        protected void Log(string message)
+        {
+            WriteToLog?.Invoke(message);
         }
 
         protected bool IsCloudNamespace()

--- a/src/Common/WindowsAzure/ServiceBusEntity.cs
+++ b/src/Common/WindowsAzure/ServiceBusEntity.cs
@@ -20,7 +20,6 @@ namespace ServiceBusExplorer.WindowsAzure
         private const string TestServiceBusPostFix = ".servicebus.int7.windows-int.net";
 
         private readonly string ns;
-        private string scheme = DefaultScheme;
 
         protected ServiceBusEntity(ServiceBusNamespace serviceBusNamespace, NamespaceManager namespaceManager)
         {
@@ -29,17 +28,7 @@ namespace ServiceBusExplorer.WindowsAzure
             ns = GetNamespace();
         }
 
-        public string Scheme
-        {
-            get
-            {
-                return scheme;
-            }
-            set
-            {
-                scheme = value;
-            }
-        }
+        public string Scheme { get; set; } = DefaultScheme;
 
         public WriteToLogDelegate WriteToLog { get; set; } = (message, async) => { };
 

--- a/src/Common/WindowsAzure/ServiceBusQueue.cs
+++ b/src/Common/WindowsAzure/ServiceBusQueue.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.ServiceBus.Messaging;
 using ServiceBusExplorer.Enums;
 using ServiceBusExplorer.Helpers;
-using ServiceBusExplorer.Utilities.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -10,66 +9,26 @@ using System.Threading.Tasks;
 
 namespace ServiceBusExplorer.WindowsAzure
 {
-    internal sealed class ServiceBusQueue : IServiceBusQueue
+    internal sealed class ServiceBusQueue : ServiceBusEntity, IServiceBusQueue
     {
-        private const string DefaultScheme = "sb";
-        private const string CloudServiceBusPostfix = ".servicebus.windows.net";
-        private const string GermanyServiceBusPostfix = ".servicebus.cloudapi.de";
-        private const string ChinaServiceBusPostfix = ".servicebus.chinacloudapi.cn";
-        private const string TestServiceBusPostFix = ".servicebus.int7.windows-int.net";
         private const string QueueDescriptionCannotBeNull = "The queue description argument cannot be null.";
-        private const string PathCannotBeNull = "The path argument cannot be null or empty.";
-        private const string NewPathCannotBeNull = "The new path argument cannot be null or empty.";
-        private const string DescriptionCannotBeNull = "The description argument cannot be null.";
-        private const string ServiceBusIsDisconnected = "The application is now disconnected from any service bus namespace.";
         private const string QueueCreated = "The queue {0} has been successfully created.";
         private const string QueueDeleted = "The queue {0} has been successfully deleted.";
         private const string QueueRenamed = "The queue {0} has been successfully renamed to {1}.";
         private const string QueueUpdated = "The queue {0} has been successfully updated.";
      
-        private readonly Microsoft.ServiceBus.NamespaceManager namespaceManager;
-        private readonly Uri namespaceUri;
-        private readonly string ns;
-        private readonly string servicePath = string.Empty;        
-        private readonly ServiceBusNamespace serviceBusNamespace;
-        private string scheme = DefaultScheme;
+        private readonly string servicePath = string.Empty;      
 
         public ServiceBusQueue(ServiceBusNamespace serviceBusNamespace, Microsoft.ServiceBus.NamespaceManager namespaceManager)
+            : base(serviceBusNamespace, namespaceManager)
         {
-            this.serviceBusNamespace = serviceBusNamespace;
-            this.namespaceManager = namespaceManager;
-            ns = GetNamespace();
         }
 
-        public string Scheme
-        {
-            get
-            {
-                return scheme;
-            }
-            set
-            {
-                scheme = value;
-            }
-        }
-
-        public WriteToLogDelegate WriteToLog { get; set; } = (message, async) => { };
-
-        public event IServiceBusQueue.EventHandler OnDelete;
-        
-        public event IServiceBusQueue.EventHandler OnCreate;
-
-        /// <summary>
-        /// Retrieves an enumerable collection of all queues in the service bus namespace.
-        /// </summary>
-        /// <param name="filter">OData filter.</param>
-        /// <returns>Returns an IEnumerable<QueueDescription/> collection of all queues in the service namespace, or
-        /// an empty collection if no queue exists in this service namespace.</returns>
         public IEnumerable<QueueDescription> GetQueues(string filter, int timeoutInSeconds)
         {
-            if (namespaceManager != null)
+            if (NamespaceManager != null)
             {
-                if (string.IsNullOrEmpty(serviceBusNamespace.EntityPath))
+                if (string.IsNullOrEmpty(ServiceBusNamespace.EntityPath))
                 {
                     var taskList = new List<Task>();
                     //Documentation states AND is the only logical clause allowed in the filter (And FYI a maximum of only 3 filter expressions allowed)
@@ -87,7 +46,7 @@ namespace ServiceBusExplorer.WindowsAzure
                     }
                     foreach (var splitFilter in filters)
                     {
-                        var task = string.IsNullOrWhiteSpace(filter) ? namespaceManager.GetQueuesAsync() : namespaceManager.GetQueuesAsync(splitFilter);
+                        var task = string.IsNullOrWhiteSpace(filter) ? NamespaceManager.GetQueuesAsync() : NamespaceManager.GetQueuesAsync(splitFilter);
                         taskList.Add(task);
                         taskList.Add(Task.Delay(TimeSpan.FromSeconds(timeoutInSeconds)));
                         Task.WaitAny(taskList.ToArray());
@@ -111,34 +70,24 @@ namespace ServiceBusExplorer.WindowsAzure
             throw new ApplicationException(ServiceBusIsDisconnected);
         }
 
-        /// <summary>
-        /// Retrieves the queue from the service namespace.
-        /// </summary>
-        /// <param name="path">Path of the queue relative to the service namespace base address.</param>
-        /// <returns>A QueueDescription handle to the queue, or null if the queue does not exist in the service namespace. </returns>
         public QueueDescription GetQueue(string path)
         {
             if (string.IsNullOrWhiteSpace(path))
             {
                 throw new ArgumentException(PathCannotBeNull);
             }
-            if (namespaceManager != null)
+            if (NamespaceManager != null)
             {
-                return RetryHelper.RetryFunc(() => namespaceManager.GetQueue(path), WriteToLog);
+                return RetryHelper.RetryFunc(() => NamespaceManager.GetQueue(path), WriteToLog);
             }
             throw new ApplicationException(ServiceBusIsDisconnected);
         }
 
-        /// <summary>
-        /// Gets the uri of a queue.
-        /// </summary>
-        /// <param name="queuePath">The name of a queue.</param>
-        /// <returns>The absolute uri of the queue.</returns>
         public Uri GetQueueUri(string queuePath)
         {
             if (IsCloudNamespace())
             {
-                return Microsoft.ServiceBus.ServiceBusEnvironment.CreateServiceUri(scheme, ns, string.Concat(servicePath, queuePath));
+                return Microsoft.ServiceBus.ServiceBusEnvironment.CreateServiceUri(Scheme, Namespace, string.Concat(servicePath, queuePath));
             }
             // ReSharper disable RedundantIfElseBlock
             else
@@ -146,24 +95,19 @@ namespace ServiceBusExplorer.WindowsAzure
             {
                 var uriBuilder = new UriBuilder
                 {
-                    Host = namespaceUri.Host,
-                    Path = $"{namespaceUri.AbsolutePath}/{queuePath}",
+                    Host = NamespaceManager.Address.Host,
+                    Path = $"{NamespaceManager.Address.AbsolutePath}/{queuePath}",
                     Scheme = "sb",
                 };
                 return uriBuilder.Uri;
             }
         }
 
-        /// <summary>
-        /// Gets the uri of the deadletter queue for a given queue.
-        /// </summary>
-        /// <param name="queuePath">The name of a queue.</param>
-        /// <returns>the absolute uri of the deadletter queue.</returns>
         public Uri GetQueueDeadLetterQueueUri(string queuePath)
         {
             if (IsCloudNamespace())
             {
-                return Microsoft.ServiceBus.ServiceBusEnvironment.CreateServiceUri(scheme, ns, string.Concat(servicePath, QueueClient.FormatDeadLetterPath(queuePath)));
+                return Microsoft.ServiceBus.ServiceBusEnvironment.CreateServiceUri(Scheme, Namespace, string.Concat(servicePath, QueueClient.FormatDeadLetterPath(queuePath)));
             }
             // ReSharper disable RedundantIfElseBlock
             else
@@ -171,81 +115,62 @@ namespace ServiceBusExplorer.WindowsAzure
             {
                 var uriBuilder = new UriBuilder
                 {
-                    Host = namespaceUri.Host,
-                    Path = $"{namespaceUri.AbsolutePath}/{QueueClient.FormatDeadLetterPath(queuePath)}",
+                    Host = NamespaceManager.Address.Host,
+                    Path = $"{NamespaceManager.Address.AbsolutePath}/{QueueClient.FormatDeadLetterPath(queuePath)}",
                     Scheme = "sb",
                 };
                 return uriBuilder.Uri;
             }
         }
 
-        /// <summary>.
-        /// Creates a new queue in the service namespace with the given name.
-        /// </summary>
-        /// <param name="path">Path of the queue relative to the service namespace base address.</param>
-        /// <returns>Returns a newly-created QueueDescription object.</returns>
         public QueueDescription CreateQueue(string path)
         {
             if (string.IsNullOrWhiteSpace(path))
             {
                 throw new ArgumentException(PathCannotBeNull);
             }
-            if (namespaceManager != null)
+            if (NamespaceManager != null)
             {
-                var queue = RetryHelper.RetryFunc(() => namespaceManager.CreateQueue(path), WriteToLog);
+                var queue = RetryHelper.RetryFunc(() => NamespaceManager.CreateQueue(path), WriteToLog);
                 WriteToLog?.Invoke(string.Format(CultureInfo.CurrentCulture, QueueCreated, path));
-                OnCreate?.Invoke(new ServiceBusHelperEventArgs(queue, EntityType.Queue));
+                OnCreated(new ServiceBusHelperEventArgs(queue, EntityType.Queue));
                 return queue;
             }
             throw new ApplicationException(ServiceBusIsDisconnected);
         }
 
-        /// <summary>
-        /// Creates a new queue in the service namespace with the given name.
-        /// </summary>
-        /// <param name="description">A QueueDescription object describing the attributes with which the new queue will be created.</param>
-        /// <returns>Returns a newly-created QueueDescription object.</returns>
         public QueueDescription CreateQueue(QueueDescription description)
         {
             if (description == null)
             {
                 throw new ArgumentException(DescriptionCannotBeNull);
             }
-            if (namespaceManager != null)
+            if (NamespaceManager != null)
             {
-                var queue = RetryHelper.RetryFunc(() => namespaceManager.CreateQueue(description), WriteToLog);
+                var queue = RetryHelper.RetryFunc(() => NamespaceManager.CreateQueue(description), WriteToLog);
                 WriteToLog?.Invoke(string.Format(CultureInfo.CurrentCulture, QueueCreated, description.Path));
-                OnCreate?.Invoke(new ServiceBusHelperEventArgs(queue, EntityType.Queue));
+                OnCreated(new ServiceBusHelperEventArgs(queue, EntityType.Queue));
                 return queue;
             }
             throw new ApplicationException(ServiceBusIsDisconnected);
         }
 
-        /// <summary>
-        /// Updates a queue in the service namespace with the given name.
-        /// </summary>
-        /// <param name="description">A QueueDescription object describing the attributes with which the new queue will be updated.</param>
-        /// <returns>Returns an updated QueueDescription object.</returns>
         public QueueDescription UpdateQueue(QueueDescription description)
         {
             if (description == null)
             {
                 throw new ArgumentException(DescriptionCannotBeNull);
             }
-            if (namespaceManager != null)
+            if (NamespaceManager != null)
             {
-                var queue = RetryHelper.RetryFunc(() => namespaceManager.UpdateQueue(description), WriteToLog);
+                var queue = RetryHelper.RetryFunc(() => NamespaceManager.UpdateQueue(description), WriteToLog);
                 WriteToLog?.Invoke(string.Format(CultureInfo.CurrentCulture, QueueUpdated, description.Path));
-                OnCreate?.Invoke(new ServiceBusHelperEventArgs(queue, EntityType.Queue));
+                OnCreated(new ServiceBusHelperEventArgs(queue, EntityType.Queue));
                 return queue;
             }
             throw new ApplicationException(ServiceBusIsDisconnected);
         }
 
-        /// <summary>
-        /// Deletes all the queues in the list.
-        /// <param name="queues">A list of queues to delete.</param>
-        /// </summary>
         public async Task DeleteQueues(IEnumerable<string> queues)
         {
             if (queues == null)
@@ -256,21 +181,17 @@ namespace ServiceBusExplorer.WindowsAzure
             await Task.WhenAll(queues.Select(DeleteQueue));
         }
 
-        /// <summary>
-        /// Deletes the queue described by the relative name of the service namespace base address.
-        /// </summary>
-        /// <param name="path">Path of the queue relative to the service namespace base address.</param>
         public async Task DeleteQueue(string path)
         {
             if (string.IsNullOrWhiteSpace(path))
             {
                 throw new ArgumentException(PathCannotBeNull);
             }
-            if (namespaceManager != null)
+            if (NamespaceManager != null)
             {
-                await RetryHelper.RetryActionAsync(() => namespaceManager.DeleteQueueAsync(path), WriteToLog);
+                await RetryHelper.RetryActionAsync(() => NamespaceManager.DeleteQueueAsync(path), WriteToLog);
                 WriteToLog?.Invoke(string.Format(CultureInfo.CurrentCulture, QueueDeleted, path));
-                OnDelete?.Invoke(new ServiceBusHelperEventArgs(path, EntityType.Queue));
+                OnDeleted(new ServiceBusHelperEventArgs(path, EntityType.Queue));
             }
             else
             {
@@ -278,21 +199,17 @@ namespace ServiceBusExplorer.WindowsAzure
             }
         }
 
-        /// <summary>
-        /// Deletes the queue passed as a argument.
-        /// </summary>
-        /// <param name="queueDescription">The queue to delete.</param>
         public async Task DeleteQueue(QueueDescription queueDescription)
         {
             if (queueDescription == null)
             {
                 throw new ArgumentException(QueueDescriptionCannotBeNull);
             }
-            if (namespaceManager != null)
+            if (NamespaceManager != null)
             {
-                await RetryHelper.RetryActionAsync(() => namespaceManager.DeleteQueueAsync(queueDescription.Path), WriteToLog);
+                await RetryHelper.RetryActionAsync(() => NamespaceManager.DeleteQueueAsync(queueDescription.Path), WriteToLog);
                 WriteToLog?.Invoke(string.Format(CultureInfo.CurrentCulture, QueueDeleted, queueDescription.Path));
-                OnDelete?.Invoke(new ServiceBusHelperEventArgs(queueDescription, EntityType.Queue));
+                OnDeleted(new ServiceBusHelperEventArgs(queueDescription, EntityType.Queue));
             }
             else
             {
@@ -300,12 +217,6 @@ namespace ServiceBusExplorer.WindowsAzure
             }
         }
 
-        /// <summary>
-        /// Renames a queue inside a namespace.
-        /// </summary>
-        /// <param name="path">The path to an existing queue.</param>
-        /// <param name="newPath">The new path to the renamed queue.</param>
-        /// <returns>Returns a QueueDescription with the new name.</returns>
         public QueueDescription RenameQueue(string path, string newPath)
         {
             if (string.IsNullOrWhiteSpace(path))
@@ -316,12 +227,12 @@ namespace ServiceBusExplorer.WindowsAzure
             {
                 throw new ArgumentException(NewPathCannotBeNull);
             }
-            if (namespaceManager != null)
+            if (NamespaceManager != null)
             {
-                var queueDescription = RetryHelper.RetryFunc(() => namespaceManager.RenameQueue(path, newPath), WriteToLog);
+                var queueDescription = RetryHelper.RetryFunc(() => NamespaceManager.RenameQueue(path, newPath), WriteToLog);
                 WriteToLog?.Invoke(string.Format(CultureInfo.CurrentCulture, QueueRenamed, path, newPath));
-                OnDelete?.Invoke(new ServiceBusHelperEventArgs(new QueueDescription(path), EntityType.Queue));
-                OnCreate?.Invoke(new ServiceBusHelperEventArgs(queueDescription, EntityType.Queue));
+                OnDeleted(new ServiceBusHelperEventArgs(new QueueDescription(path), EntityType.Queue));
+                OnCreated(new ServiceBusHelperEventArgs(queueDescription, EntityType.Queue));
                 return queueDescription;
             }
             throw new ApplicationException(ServiceBusIsDisconnected);
@@ -330,7 +241,7 @@ namespace ServiceBusExplorer.WindowsAzure
         private QueueDescription GetQueueUsingEntityPath(int timeoutInSeconds)
         {
             var taskList = new List<Task>();
-            var getQueueTask = namespaceManager.GetQueueAsync(serviceBusNamespace.EntityPath);
+            var getQueueTask = NamespaceManager.GetQueueAsync(ServiceBusNamespace.EntityPath);
             taskList.Add(getQueueTask);
             taskList.Add(Task.Delay(TimeSpan.FromSeconds(timeoutInSeconds)));
             Task.WaitAny(taskList.ToArray());
@@ -346,26 +257,6 @@ namespace ServiceBusExplorer.WindowsAzure
                 }
             }
             throw new TimeoutException();
-        }
-
-        private string GetNamespace()
-        {
-            var namespaceUri = namespaceManager.Address;
-            return IsCloudNamespace() ? namespaceUri.Host.Split('.')[0] : namespaceUri.Segments[namespaceUri.Segments.Length - 1];
-        }
-
-        private bool IsCloudNamespace()
-        {
-            string uri;
-            var connectionStringType = serviceBusNamespace.ConnectionStringType;
-            var namespaceUri = namespaceManager.Address;
-            return connectionStringType == ServiceBusNamespaceType.Cloud ||
-                  (namespaceUri != null &&
-                   !string.IsNullOrWhiteSpace(uri = namespaceUri.ToString()) &&
-                   (uri.Contains(CloudServiceBusPostfix) ||
-                    uri.Contains(TestServiceBusPostFix) ||
-                    uri.Contains(GermanyServiceBusPostfix) ||
-                    uri.Contains(ChinaServiceBusPostfix)));
         }
     }
 }

--- a/src/Common/WindowsAzure/ServiceBusTopic.cs
+++ b/src/Common/WindowsAzure/ServiceBusTopic.cs
@@ -17,7 +17,6 @@ namespace ServiceBusExplorer.WindowsAzure
         private const string TopicRenamed = "The topic {0} has been successfully renamed to {1}.";
         private const string TopicUpdated = "The topic {0} has been successfully updated.";
 
-        private readonly string ns;
         private readonly string servicePath = string.Empty;
 
         public ServiceBusTopic(ServiceBusNamespace serviceBusNamespace, Microsoft.ServiceBus.NamespaceManager namespaceManager)
@@ -91,7 +90,7 @@ namespace ServiceBusExplorer.WindowsAzure
         {
             if (IsCloudNamespace())
             {
-                return Microsoft.ServiceBus.ServiceBusEnvironment.CreateServiceUri(Scheme, ns, string.Concat(servicePath, topicPath));
+                return Microsoft.ServiceBus.ServiceBusEnvironment.CreateServiceUri(Scheme, Namespace, string.Concat(servicePath, topicPath));
             }
             // ReSharper disable RedundantIfElseBlock
             else

--- a/src/Common/WindowsAzure/ServiceBusTopic.cs
+++ b/src/Common/WindowsAzure/ServiceBusTopic.cs
@@ -1,0 +1,246 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.ServiceBus.Messaging;
+using ServiceBusExplorer.Enums;
+using ServiceBusExplorer.Helpers;
+
+namespace ServiceBusExplorer.WindowsAzure
+{
+    internal sealed class ServiceBusTopic : ServiceBusEntity, IServiceBusTopic
+    {
+        private const string TopicDescriptionCannotBeNull = "The topic decsription argument cannot be null.";
+        private const string TopicCreated = "The topic {0} has been successfully created.";
+        private const string TopicDeleted = "The topic {0} has been successfully deleted.";
+        private const string TopicRenamed = "The topic {0} has been successfully renamed to {1}.";
+        private const string TopicUpdated = "The topic {0} has been successfully updated.";
+
+        private readonly string ns;
+        private readonly string servicePath = string.Empty;
+
+        public ServiceBusTopic(ServiceBusNamespace serviceBusNamespace, Microsoft.ServiceBus.NamespaceManager namespaceManager)
+            : base(serviceBusNamespace, namespaceManager)
+        {
+        }
+
+        public TopicDescription GetTopic(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException(PathCannotBeNull);
+            }
+
+            if (NamespaceManager != null)
+            {
+                return RetryHelper.RetryFunc(() => NamespaceManager.GetTopic(path), WriteToLog);
+            }
+
+            throw new ApplicationException(ServiceBusIsDisconnected);
+        }
+
+        public IEnumerable<TopicDescription> GetTopics(string filter, int timeoutInSeconds)
+        {
+            if (NamespaceManager != null)
+            {
+                //Documentation states AND is the only logical clause allowed in the filter
+                //https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.namespacemanager.gettopicsasync?view=azure-dotnet
+                //Split on ' OR ' and combine queues returned
+                var taskList = new List<Task>();
+                if (string.IsNullOrEmpty(ServiceBusNamespace.EntityPath))
+                {
+                    IEnumerable<TopicDescription> topics = new List<TopicDescription>();
+                    var filters = new List<string>();
+                    if (string.IsNullOrWhiteSpace(filter))
+                    {
+                        filters.Add(filter);
+                    }
+                    else
+                    {
+                        filters = filter.ToLowerInvariant().Split(new[] { " or " }, StringSplitOptions.None).ToList();
+                    }
+
+                    foreach (var splitFilter in filters)
+                    {
+                        var task = string.IsNullOrWhiteSpace(filter) ? NamespaceManager.GetTopicsAsync() : NamespaceManager.GetTopicsAsync(splitFilter);
+                        taskList.Add(task);
+                        taskList.Add(Task.Delay(TimeSpan.FromSeconds(timeoutInSeconds)));
+                        Task.WaitAny(taskList.ToArray());
+                        if (task.IsCompleted)
+                        {
+                            topics = topics.Union(task.Result);
+                            taskList.Clear();
+                        }
+                        else
+                        {
+                            throw new TimeoutException();
+                        }
+                    }
+                    return topics;
+                }
+
+                return new List<TopicDescription> {
+                    GetTopicUsingEntityPath(timeoutInSeconds)
+                };
+            }
+            throw new ApplicationException(ServiceBusIsDisconnected);
+        }
+
+        public Uri GetTopicUri(string topicPath)
+        {
+            if (IsCloudNamespace())
+            {
+                return Microsoft.ServiceBus.ServiceBusEnvironment.CreateServiceUri(Scheme, ns, string.Concat(servicePath, topicPath));
+            }
+            // ReSharper disable RedundantIfElseBlock
+            else
+            // ReSharper restore RedundantIfElseBlock
+            {
+                var uriBuilder = new UriBuilder
+                {
+                    Host = NamespaceManager.Address.Host,
+                    Path = $"{NamespaceManager.Address.AbsolutePath}/{topicPath}",
+                    Scheme = "sb",
+                };
+                return uriBuilder.Uri;
+            }
+        }
+
+        public TopicDescription CreateTopic(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException(PathCannotBeNull);
+            }
+            if (NamespaceManager != null)
+            {
+                var topic = RetryHelper.RetryFunc(() => NamespaceManager.CreateTopic(path), WriteToLog);
+                WriteToLog?.Invoke(string.Format(CultureInfo.CurrentCulture, TopicCreated, path));
+                OnCreated(new ServiceBusHelperEventArgs(topic, EntityType.Topic));
+                return topic;
+            }
+            throw new ApplicationException(ServiceBusIsDisconnected);
+        }
+
+        public TopicDescription CreateTopic(TopicDescription topicDescription)
+        {
+            if (topicDescription == null)
+            {
+                throw new ArgumentException(TopicDescriptionCannotBeNull);
+            }
+            if (NamespaceManager != null)
+            {
+                var topic = RetryHelper.RetryFunc(() => NamespaceManager.CreateTopic(topicDescription), WriteToLog);
+                WriteToLog?.Invoke(string.Format(CultureInfo.CurrentCulture, TopicCreated, topicDescription.Path));
+                OnCreated(new ServiceBusHelperEventArgs(topic, EntityType.Topic));
+                return topic;
+            }
+            throw new ApplicationException(ServiceBusIsDisconnected);
+        }
+
+        public TopicDescription UpdateTopic(TopicDescription topicDescription)
+        {
+            if (topicDescription == null)
+            {
+                throw new ArgumentException(TopicDescriptionCannotBeNull);
+            }
+            if (NamespaceManager != null)
+            {
+                var topic = RetryHelper.RetryFunc(() => NamespaceManager.UpdateTopic(topicDescription), WriteToLog);
+                WriteToLog?.Invoke(string.Format(CultureInfo.CurrentCulture, TopicUpdated, topicDescription.Path));
+                OnCreated(new ServiceBusHelperEventArgs(topic, EntityType.Topic));
+                return topic;
+            }
+            throw new ApplicationException(ServiceBusIsDisconnected);
+        }
+
+        public async Task DeleteTopics(IEnumerable<string> topics)
+        {
+            if (topics == null)
+            {
+                return;
+            }
+
+            await Task.WhenAll(topics.Select(DeleteTopic));
+        }
+
+        public async Task DeleteTopic(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException(PathCannotBeNull);
+            }
+            if (NamespaceManager != null)
+            {
+                await RetryHelper.RetryActionAsync(() => NamespaceManager.DeleteTopicAsync(path), WriteToLog);
+                WriteToLog?.Invoke(string.Format(CultureInfo.CurrentCulture, TopicDeleted, path));
+                OnDeleted(new ServiceBusHelperEventArgs(path, EntityType.Topic));
+            }
+            else
+            {
+                throw new ApplicationException(ServiceBusIsDisconnected);
+            }
+        }
+
+        public async Task DeleteTopic(TopicDescription topic)
+        {
+            if (topic == null)
+            {
+                throw new ArgumentException(TopicDescriptionCannotBeNull);
+            }
+            if (NamespaceManager != null)
+            {
+                await RetryHelper.RetryActionAsync(() => NamespaceManager.DeleteTopicAsync(topic.Path), WriteToLog);
+                WriteToLog?.Invoke(string.Format(CultureInfo.CurrentCulture, TopicDeleted, topic.Path));
+                OnDeleted(new ServiceBusHelperEventArgs(topic, EntityType.Topic));
+            }
+            else
+            {
+                throw new ApplicationException(ServiceBusIsDisconnected);
+            }
+        }
+
+        public TopicDescription RenameTopic(string path, string newPath)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException(PathCannotBeNull);
+            }
+            if (string.IsNullOrWhiteSpace(newPath))
+            {
+                throw new ArgumentException(NewPathCannotBeNull);
+            }
+            if (NamespaceManager != null)
+            {
+                var topicDescription = RetryHelper.RetryFunc(() => NamespaceManager.RenameTopic(path, newPath), WriteToLog);
+                WriteToLog?.Invoke(string.Format(CultureInfo.CurrentCulture, TopicRenamed, path, newPath));
+                OnDeleted(new ServiceBusHelperEventArgs(new TopicDescription(path), EntityType.Topic));
+                OnCreated(new ServiceBusHelperEventArgs(topicDescription, EntityType.Topic));
+                return topicDescription;
+            }
+            throw new ApplicationException(ServiceBusIsDisconnected);
+        }
+
+        private TopicDescription GetTopicUsingEntityPath(int timeoutInSeconds)
+        {
+            var taskList = new List<Task>();
+            var getTopicTask = NamespaceManager.GetTopicAsync(ServiceBusNamespace.EntityPath);
+            taskList.Add(getTopicTask);
+            taskList.Add(Task.Delay(TimeSpan.FromSeconds(timeoutInSeconds)));
+            Task.WaitAny(taskList.ToArray());
+            if (getTopicTask.IsCompleted)
+            {
+                try
+                {
+                    return getTopicTask.Result;
+                }
+                catch (AggregateException ex)
+                {
+                    throw ex.InnerExceptions.First();
+                }
+            }
+            throw new TimeoutException();
+        }
+    }
+}


### PR DESCRIPTION
Part 02 of refactoring the ServiceBusHelper class #686. This is a fairly straight-forward 'move code to different class' to simplify the changes.

This part is moving Topic 'management actions' - that is, actions for Topics that need the `Microsoft.ServiceBus.NamespaceManager` to work.

In addition:
- Added a base class `ServiceBusEntity` to share some code between Queue and Topic implementations.
- Changed two properties in `ServiceBusHelper` to have a `private set` to indicate it is not set from outside the class.
