### PR TITLE
#686: Move Subscription management functions to separate class

### DIFF
--- a/src/Common/WindowsAzure/IServiceBusSubscription.cs
+++ b/src/Common/WindowsAzure/IServiceBusSubscription.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.ServiceBus.Messaging;
+
+namespace ServiceBusExplorer.WindowsAzure
+{
+    internal interface IServiceBusSubscription : IServiceBusEntity
+    {
+        SubscriptionDescription CreateSubscription(TopicDescription topicDescription, SubscriptionDescription subscriptionDescription);
+
+        SubscriptionDescription CreateSubscription(TopicDescription topicDescription, SubscriptionDescription subscriptionDescription, RuleDescription ruleDescription);
+
+        void DeleteSubscription(string topicPath, string name);
+
+        Task DeleteSubscription(SubscriptionDescription subscriptionDescription);
+
+        Task DeleteSubscriptions(IEnumerable<SubscriptionDescription> subscriptionDescriptions);
+
+        SubscriptionDescription GetSubscription(string topicPath, string name);
+
+        Uri GetSubscriptionDeadLetterQueueUri(string topicPath, string name);
+
+        IEnumerable<SubscriptionDescription> GetSubscriptions(string topicPath);
+
+        IEnumerable<SubscriptionDescription> GetSubscriptions(string topicPath, string filter);
+
+        IEnumerable<SubscriptionDescription> GetSubscriptions(TopicDescription topic);
+
+        IEnumerable<SubscriptionDescription> GetSubscriptions(TopicDescription topic, string filter);
+
+        Uri GetSubscriptionUri(string topicPath, string name);
+
+        SubscriptionDescription UpdateSubscription(TopicDescription topicDescription, SubscriptionDescription subscriptionDescription);
+    }
+}

--- a/src/Common/WindowsAzure/ServiceBusEntity.cs
+++ b/src/Common/WindowsAzure/ServiceBusEntity.cs
@@ -10,7 +10,9 @@ namespace ServiceBusExplorer.WindowsAzure
     {
         protected const string PathCannotBeNull = "The path argument cannot be null or empty.";
         protected const string NewPathCannotBeNull = "The new path argument cannot be null or empty.";
+        protected const string NameCannotBeNull = "The name argument cannot be null or empty.";
         protected const string DescriptionCannotBeNull = "The description argument cannot be null.";
+        protected const string NamespaceManagerCannotBeNull = "The namespace manager argument cannot be null.";
         protected const string ServiceBusIsDisconnected = "The application is now disconnected from any service bus namespace.";
 
         private const string DefaultScheme = "sb";
@@ -43,6 +45,12 @@ namespace ServiceBusExplorer.WindowsAzure
         protected string Namespace { get { return ns; } }
 
         protected abstract EntityType EntityType { get; }
+
+        protected void OnCreated(ServiceBusHelperEventArgs args)
+        {
+            args.EntityType = EntityType;
+            OnCreate?.Invoke(args);
+        }
 
         protected void OnCreated<T>(T entityInstance) where T : EntityDescription
         {

--- a/src/Common/WindowsAzure/ServiceBusSubscription.cs
+++ b/src/Common/WindowsAzure/ServiceBusSubscription.cs
@@ -1,0 +1,306 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.ServiceBus;
+using Microsoft.ServiceBus.Messaging;
+using ServiceBusExplorer.Enums;
+using ServiceBusExplorer.Helpers;
+
+namespace ServiceBusExplorer.WindowsAzure
+{
+    internal sealed class ServiceBusSubscription : ServiceBusEntity, IServiceBusSubscription
+    {
+        private const string SubscriptionDescriptionCannotBeNull = "The subscription description argument cannot be null.";
+        private const string SubscriptionCreated = "The {0} subscription for the {1} topic has been successfully created.";
+        private const string SubscriptionDeleted = "The {0} subscription for the {1} topic has been successfully deleted.";
+        private const string SubscriptionUpdated = "The {0} subscription for the {1} topic has been successfully updated.";
+        private const string TopicDescriptionCannotBeNull = "The topic decsription argument cannot be null.";
+        private const string RuleDescriptionCannotBeNull = "The rule description argument cannot be null.";
+
+        private readonly string servicePath = string.Empty;
+
+        public ServiceBusSubscription(ServiceBusNamespace serviceBusNamespace, NamespaceManager namespaceManager) : base(serviceBusNamespace, namespaceManager)
+        {
+        }
+
+        protected override EntityType EntityType => EntityType.Subscription;
+
+        /// <summary>
+        /// Gets a subscription attached to the topic passed a parameter.
+        /// </summary>
+        /// <param name="topicPath">The name of a topic belonging to the current service namespace base.</param>
+        /// <param name="name">The name of the subscription to get.</param>
+        /// <returns>Returns the subscription with the specified name.</returns>
+        public SubscriptionDescription GetSubscription(string topicPath, string name)
+        {
+            if (NamespaceManager == null)
+            {
+                throw new ArgumentException(NamespaceManagerCannotBeNull);
+            }
+            if (string.IsNullOrWhiteSpace(topicPath))
+            {
+                throw new ArgumentException(PathCannotBeNull);
+            }
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException(NameCannotBeNull);
+            }
+            if (NamespaceManager != null)
+            {
+                return RetryHelper.RetryFunc(() => NamespaceManager.GetSubscription(topicPath, name), WriteToLog);
+            }
+            throw new ApplicationException(ServiceBusIsDisconnected);
+        }
+
+        /// <summary>
+        /// Retrieves an enumerated collection of subscriptions attached to the topic passed as a parameter.
+        /// </summary>
+        /// <param name="topic">A topic belonging to the current service namespace base.</param>
+        /// <returns>Returns an IEnumerable<SubscriptionDescription/> collection of subscriptions attached to the topic passed as a parameter.</returns>
+        public IEnumerable<SubscriptionDescription> GetSubscriptions(TopicDescription topic)
+        {
+            if (topic == null)
+            {
+                throw new ArgumentException(TopicDescriptionCannotBeNull);
+            }
+            if (NamespaceManager != null)
+            {
+                return RetryHelper.RetryFunc(() => NamespaceManager.GetSubscriptions(topic.Path), WriteToLog);
+            }
+            throw new ApplicationException(ServiceBusIsDisconnected);
+        }
+
+        /// <summary>
+        /// Retrieves an enumerated collection of subscriptions attached to the topic whose name is passed as a parameter.
+        /// </summary>
+        /// <param name="topicPath">The name of a topic belonging to the current service namespace base.</param>
+        /// <returns>Returns an IEnumerable<SubscriptionDescription/> collection of subscriptions attached to the topic passed as a parameter.</returns>
+        public IEnumerable<SubscriptionDescription> GetSubscriptions(string topicPath)
+        {
+            if (string.IsNullOrWhiteSpace(topicPath))
+            {
+                throw new ArgumentException(PathCannotBeNull);
+            }
+            if (NamespaceManager != null)
+            {
+                return RetryHelper.RetryFunc(() => NamespaceManager.GetSubscriptions(topicPath), WriteToLog);
+            }
+            throw new ApplicationException(ServiceBusIsDisconnected);
+        }
+
+        /// <summary>
+        /// Retrieves an enumerated collection of subscriptions attached to the topic passed as a parameter.
+        /// </summary>
+        /// <param name="topic">A topic belonging to the current service namespace base.</param>
+        /// <param name="filter">OData filter.</param>
+        /// <returns>Returns an IEnumerable<SubscriptionDescription/> collection of subscriptions attached to the topic passed as a parameter.</returns>
+        public IEnumerable<SubscriptionDescription> GetSubscriptions(TopicDescription topic, string filter)
+        {
+            if (topic == null)
+            {
+                throw new ArgumentException(TopicDescriptionCannotBeNull);
+            }
+            if (NamespaceManager != null)
+            {
+                return RetryHelper.RetryFunc(() => string.IsNullOrWhiteSpace(filter) ?
+                                                   NamespaceManager.GetSubscriptions(topic.Path) :
+                                                   NamespaceManager.GetSubscriptions(topic.Path, filter), WriteToLog);
+            }
+            throw new ApplicationException(ServiceBusIsDisconnected);
+        }
+
+        /// <summary>
+        /// Retrieves an enumerated collection of subscriptions attached to the topic whose name is passed as a parameter.
+        /// </summary>
+        /// <param name="topicPath">The name of a topic belonging to the current service namespace base.</param>
+        /// <param name="filter">OData filter.</param>
+        /// <returns>Returns an IEnumerable<SubscriptionDescription/> collection of subscriptions attached to the topic passed as a parameter.</returns>
+        public IEnumerable<SubscriptionDescription> GetSubscriptions(string topicPath, string filter)
+        {
+            if (string.IsNullOrWhiteSpace(topicPath))
+            {
+                throw new ArgumentException(PathCannotBeNull);
+            }
+            if (NamespaceManager != null)
+            {
+                return RetryHelper.RetryFunc(() => string.IsNullOrWhiteSpace(filter) ?
+                                                   NamespaceManager.GetSubscriptions(topicPath) :
+                                                   NamespaceManager.GetSubscriptions(topicPath, filter), WriteToLog);
+            }
+            throw new ApplicationException(ServiceBusIsDisconnected);
+        }
+
+        /// <summary>
+        /// Gets the uri of a subscription.
+        /// </summary>
+        /// <param name="topicPath">The name of the topic.</param>
+        /// <param name="name">The name of a subscription.</param>
+        /// <returns>The absolute uri of the subscription.</returns>
+        public Uri GetSubscriptionUri(string topicPath, string name)
+        {
+            if (IsCloudNamespace())
+            {
+                return Microsoft.ServiceBus.ServiceBusEnvironment.CreateServiceUri(Scheme, Namespace, string.Concat(servicePath, SubscriptionClient.FormatSubscriptionPath(topicPath, name)));
+            }
+            else
+            {
+                var uriBuilder = new UriBuilder
+                {
+                    Host = NamespaceManager.Address.Host,
+                    Path = $"{NamespaceManager.Address.AbsolutePath}/{SubscriptionClient.FormatSubscriptionPath(topicPath, name)}",
+                    Scheme = "sb",
+                };
+                return uriBuilder.Uri;
+            }
+        }
+
+        /// <summary>
+        /// Gets the uri of the deadletter queue for a given subscription.
+        /// </summary>
+        /// <param name="topicPath">The name of a topic.</param>
+        /// <param name="name">The name of a subscription.</param>
+        /// <returns>The absolute uri of the deadletter queue.</returns>
+        public Uri GetSubscriptionDeadLetterQueueUri(string topicPath, string name)
+        {
+            if (IsCloudNamespace())
+            {
+                return Microsoft.ServiceBus.ServiceBusEnvironment.CreateServiceUri(Scheme, Namespace, SubscriptionClient.FormatDeadLetterPath(topicPath, name));
+            }
+            else
+            {
+                var uriBuilder = new UriBuilder
+                {
+                    Host = NamespaceManager.Address.Host,
+                    Path = $"{NamespaceManager.Address.AbsolutePath}/{SubscriptionClient.FormatDeadLetterPath(topicPath, name)}",
+                    Scheme = "sb",
+                };
+                return uriBuilder.Uri;
+            }
+        }
+
+        /// <summary>
+        /// Adds a subscription to this topic, with a default pass-through filter added.
+        /// </summary>
+        /// <param name="topicDescription">A topic belonging to the current service namespace base.</param>
+        /// <param name="subscriptionDescription">Metadata of the subscription to be created.</param>
+        /// <returns>Returns a newly-created SubscriptionDescription object.</returns>
+        public SubscriptionDescription CreateSubscription(TopicDescription topicDescription, SubscriptionDescription subscriptionDescription)
+        {
+            if (topicDescription == null)
+            {
+                throw new ArgumentException(TopicDescriptionCannotBeNull);
+            }
+            if (subscriptionDescription == null)
+            {
+                throw new ArgumentException(DescriptionCannotBeNull);
+            }
+            var subscription = RetryHelper.RetryFunc(() => NamespaceManager.CreateSubscription(subscriptionDescription), WriteToLog);
+            Log(string.Format(CultureInfo.CurrentCulture, SubscriptionCreated, subscription.Name, topicDescription.Path));
+            OnCreated(new ServiceBusHelperEventArgs(new SubscriptionWrapper(subscription, topicDescription), EntityType.Subscription));
+            return subscription;
+        }
+
+        /// <summary>
+        /// Adds a subscription to this topic, with a default pass-through filter added.
+        /// </summary>
+        /// <param name="topicDescription">A topic belonging to the current service namespace base.</param>
+        /// <param name="subscriptionDescription">Metadata of the subscription to be created.</param>
+        /// <param name="ruleDescription">The metadata describing the properties of the rule to be associated with the subscription.</param>
+        /// <returns>Returns a newly-created SubscriptionDescription object.</returns>
+        public SubscriptionDescription CreateSubscription(TopicDescription topicDescription,
+                                                          SubscriptionDescription subscriptionDescription,
+                                                          RuleDescription ruleDescription)
+        {
+            if (topicDescription == null)
+            {
+                throw new ArgumentException(TopicDescriptionCannotBeNull);
+            }
+            if (subscriptionDescription == null)
+            {
+                throw new ArgumentException(DescriptionCannotBeNull);
+            }
+            if (ruleDescription == null)
+            {
+                throw new ArgumentException(RuleDescriptionCannotBeNull);
+            }
+            var subscription = RetryHelper.RetryFunc(() => NamespaceManager.CreateSubscription(subscriptionDescription, ruleDescription), WriteToLog);
+            Log(string.Format(CultureInfo.CurrentCulture, SubscriptionCreated, subscription.Name, topicDescription.Path));
+            OnCreated(new ServiceBusHelperEventArgs(new SubscriptionWrapper(subscription, topicDescription), EntityType));
+            return subscription;
+        }
+
+        /// <summary>
+        /// Updates a subscription to this topic.
+        /// </summary>
+        /// <param name="topicDescription">A topic belonging to the current service namespace base.</param>
+        /// <param name="subscriptionDescription">Metadata of the subscription to be updated.</param>
+        /// <returns>Returns an updated SubscriptionDescription object.</returns>
+        public SubscriptionDescription UpdateSubscription(TopicDescription topicDescription, SubscriptionDescription subscriptionDescription)
+        {
+            if (topicDescription == null)
+            {
+                throw new ArgumentException(TopicDescriptionCannotBeNull);
+            }
+            if (subscriptionDescription == null)
+            {
+                throw new ArgumentException(DescriptionCannotBeNull);
+            }
+            var subscription = RetryHelper.RetryFunc(() => NamespaceManager.UpdateSubscription(subscriptionDescription), WriteToLog);
+            Log(string.Format(CultureInfo.CurrentCulture, SubscriptionUpdated, subscription.Name, topicDescription.Path));
+            //OnCreate(new ServiceBusHelperEventArgs(new SubscriptionWrapper(subscription, topicDescription), EntityType.Subscription));
+            return subscription;
+        }
+
+        /// <summary>
+        /// Removes the subscriptions contained in the list passed as a argument.
+        /// </summary>
+        /// <param name="subscriptionDescriptions">The list containing subscriptions to remove.</param>
+        public Task DeleteSubscriptions(IEnumerable<SubscriptionDescription> subscriptionDescriptions)
+        {
+            if (subscriptionDescriptions == null)
+            {
+                throw new ArgumentException(SubscriptionDescriptionCannotBeNull);
+            }
+
+            return Task.WhenAll(subscriptionDescriptions.Select(DeleteSubscription));
+        }
+
+        /// <summary>
+        /// Removes the subscription described by name.
+        /// </summary>
+        /// <param name="topicPath">The name of a topic belonging to the current service namespace base.</param>
+        /// <param name="name">Name of the subscription.</param>
+        public void DeleteSubscription(string topicPath, string name)
+        {
+            // TODO: remove, not used
+            if (string.IsNullOrWhiteSpace(topicPath))
+            {
+                throw new ArgumentException(PathCannotBeNull);
+            }
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException(NameCannotBeNull);
+            }
+            RetryHelper.RetryAction(() => NamespaceManager.DeleteSubscription(topicPath, name), WriteToLog);
+            Log(string.Format(CultureInfo.CurrentCulture, SubscriptionDeleted, name, topicPath));
+            OnDeleted(new SubscriptionDescription(topicPath, name));
+        }
+
+        /// <summary>
+        /// Removes the subscription passed as a argument.
+        /// </summary>
+        /// <param name="subscriptionDescription">The subscription to remove.</param>
+        public async Task DeleteSubscription(SubscriptionDescription subscriptionDescription)
+        {
+            if (subscriptionDescription == null)
+            {
+                throw new ArgumentException(SubscriptionDescriptionCannotBeNull);
+            }
+            await RetryHelper.RetryActionAsync(() => NamespaceManager.DeleteSubscriptionAsync(subscriptionDescription.TopicPath, subscriptionDescription.Name), WriteToLog);
+            Log(string.Format(CultureInfo.CurrentCulture, SubscriptionDeleted, subscriptionDescription.Name, subscriptionDescription.TopicPath));
+            OnDeleted(subscriptionDescription);
+        }
+    }
+}


### PR DESCRIPTION
Part 03 of refactoring the ServiceBusHelper class #686. This is a fairly straight-forward 'move code to different class' to simplify the changes.

This part is moving Subscription 'management actions' - that is, actions for Subscriptions that need the Microsoft.ServiceBus.NamespaceManager to work.

In addition:
- Add a general OnCreated() method because some Subscription events use a custom type `SubscriptionWrapper` for  `ServiceBusHelperEventArgs.EntityInstance`, which in turn is used in various UI Controls