### PR TITLE
#686: Move Rule management functions to separate class

### DIFF
--- a/src/Common/Helpers/ServiceBusHelper.cs
+++ b/src/Common/Helpers/ServiceBusHelper.cs
@@ -742,7 +742,7 @@ namespace ServiceBusExplorer
 
             if (!TestNamespaceHostIsContactable(serviceBusNamespace))
             {
-                throw new Exception($"Could not contact host in connection string: {serviceBusNamespace.ConnectionString}.");
+                throw new Exception($"Could not contact host in connection string: { serviceBusNamespace.ConnectionString }.");
             }
 
             var func = (() =>
@@ -800,7 +800,6 @@ namespace ServiceBusExplorer
                 // instances of the QueueClient, TopicClient and SubscriptionClient classes.
                 MessagingFactory = MessagingFactory.CreateFromConnectionString(ConnectionStringWithoutEntityPath);
                 WriteToLogIf(traceEnabled, MessageFactorySuccessfullyCreated);
-
                 return true;
             });
             return RetryHelper.RetryFunc(func, writeToLog);
@@ -1755,7 +1754,7 @@ namespace ServiceBusExplorer
         /// <returns>The absolute uri of the queue.</returns>
         public Uri GetQueueUri(string queuePath)
         {
-            return serviceBusQueue.GetQueueUri(queuePath);
+           return serviceBusQueue.GetQueueUri(queuePath);
         }
 
         /// <summary>
@@ -4388,7 +4387,7 @@ namespace ServiceBusExplorer
         {
             var body = brokeredMessage.GetBody<byte[]>();
             if (compress)
-                return DecompressAsString(body);
+               return DecompressAsString(body);
             return Encoding.UTF8.GetString(body);
         }
 

--- a/src/Common/WindowsAzure/IServiceBusRule.cs
+++ b/src/Common/WindowsAzure/IServiceBusRule.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using Microsoft.ServiceBus.Messaging;
+using ServiceBusExplorer.Helpers;
+
+namespace ServiceBusExplorer.WindowsAzure
+{
+    internal interface IServiceBusRule : IServiceBusEntity
+    {
+        RuleDescription AddRule(SubscriptionDescription subscriptionDescription, RuleDescription ruleDescription);
+        
+        IEnumerable<RuleDescription> GetRules(string topicPath, string name);
+        
+        IEnumerable<RuleDescription> GetRules(SubscriptionDescription subscription);
+        
+        void RemoveRule(SubscriptionDescription subscriptionDescription, RuleDescription rule);
+        
+        void RemoveRule(SubscriptionDescription subscriptionDescription, string name);
+        
+        void RemoveRules(IEnumerable<RuleWrapper> wrappers);
+    }
+}

--- a/src/Common/WindowsAzure/ServiceBusEntity.cs
+++ b/src/Common/WindowsAzure/ServiceBusEntity.cs
@@ -57,6 +57,12 @@ namespace ServiceBusExplorer.WindowsAzure
             OnCreate?.Invoke(new ServiceBusHelperEventArgs(entityInstance, EntityType));
         }
 
+        protected void OnDeleted(ServiceBusHelperEventArgs args)
+        {
+            args.EntityType = EntityType;
+            OnDelete?.Invoke(args);
+        }
+
         protected void OnDeleted<T>(T entityInstance) where T : EntityDescription
         {
             OnDelete?.Invoke(new ServiceBusHelperEventArgs(entityInstance, EntityType));

--- a/src/Common/WindowsAzure/ServiceBusRule.cs
+++ b/src/Common/WindowsAzure/ServiceBusRule.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Microsoft.ServiceBus;
+using Microsoft.ServiceBus.Messaging;
+using ServiceBusExplorer.Enums;
+using ServiceBusExplorer.Helpers;
+
+namespace ServiceBusExplorer.WindowsAzure
+{
+    internal sealed class ServiceBusRule : ServiceBusEntity, IServiceBusRule
+    {
+        private const string SubscriptionDescriptionCannotBeNull = "The subscription description argument cannot be null.";
+        private const string RuleDescriptionCannotBeNull = "The rule description argument cannot be null.";
+        private const string RuleCannotBeNull = "The rule argument cannot be null.";
+        private const string RuleCreated = "The {0} rule for the {1} subscription has been successfully created.";
+        private const string RuleDeleted = "The {0} rule for the {1} subscription has been successfully deleted.";
+
+        private readonly MessagingFactory messagingFactory;
+
+        public ServiceBusRule(ServiceBusNamespace serviceBusNamespace, NamespaceManager namespaceManager)
+            : base(serviceBusNamespace, namespaceManager)
+        {
+            var builder = new ServiceBusConnectionStringBuilder(serviceBusNamespace.ConnectionString)
+            {
+                EntityPath = string.Empty
+            };
+            messagingFactory = MessagingFactory.CreateFromConnectionString(builder.ToString());
+        }
+
+        protected override EntityType EntityType => EntityType.Rule;
+
+        /// <summary>
+        /// Retrieves an enumerated collection of rules attached to the subscription passed as a parameter.
+        /// </summary>
+        /// <param name="subscription">A subscription belonging to the current service namespace base.</param>
+        /// <returns>Returns an IEnumerable<SubscriptionDescription/> collection of rules attached to the subscription passed as a parameter.</returns>
+        public IEnumerable<RuleDescription> GetRules(SubscriptionDescription subscription)
+        {
+            if (subscription == null)
+            {
+                throw new ArgumentException(SubscriptionDescriptionCannotBeNull);
+            }
+            if (NamespaceManager != null)
+            {
+                return RetryHelper.RetryFunc(() => NamespaceManager.GetRules(subscription.TopicPath, subscription.Name), WriteToLog);
+            }
+            throw new ApplicationException(ServiceBusIsDisconnected);
+        }
+
+        /// <summary>
+        /// Retrieves an enumerated collection of rules attached to the subscription passed as a parameter.
+        /// </summary>
+        /// <param name="topicPath">The name of a topic belonging to the current service namespace base.</param>
+        /// <param name="name">The name of a subscription belonging to the topic passed as a parameter.</param>
+        /// <returns>Returns an IEnumerable<SubscriptionDescription/> collection of rules attached to the subscription passed as a parameter.</returns>
+        public IEnumerable<RuleDescription> GetRules(string topicPath, string name)
+        {
+            if (string.IsNullOrWhiteSpace(topicPath))
+            {
+                throw new ArgumentException(PathCannotBeNull);
+            }
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException(NameCannotBeNull);
+            }
+            if (NamespaceManager != null)
+            {
+                return RetryHelper.RetryFunc(() => NamespaceManager.GetRules(topicPath, name), WriteToLog);
+            }
+            throw new ApplicationException(ServiceBusIsDisconnected);
+        }
+
+        /// <summary>
+        /// Adds a rule to this subscription, with a default pass-through filter added.
+        /// </summary>
+        /// <param name="subscriptionDescription">The subscription to add the rule to.</param>
+        /// <param name="ruleDescription">Metadata of the rule to be created.</param>
+        /// <returns>Returns a newly-created RuleDescription object.</returns>
+        public RuleDescription AddRule(SubscriptionDescription subscriptionDescription, RuleDescription ruleDescription)
+        {
+            if (subscriptionDescription == null)
+            {
+                throw new ArgumentException(SubscriptionDescriptionCannotBeNull);
+            }
+            if (ruleDescription == null)
+            {
+                throw new ArgumentException(RuleDescriptionCannotBeNull);
+            }
+            var subscriptionClient = RetryHelper.RetryFunc(() => messagingFactory.CreateSubscriptionClient(subscriptionDescription.TopicPath,
+                                                                                                           subscriptionDescription.Name),
+                                                                                                           WriteToLog);
+            RetryHelper.RetryAction(() => subscriptionClient.AddRule(ruleDescription), WriteToLog);
+            var func = (() => NamespaceManager.GetRules(subscriptionDescription.TopicPath, subscriptionDescription.Name));
+            var rules = RetryHelper.RetryFunc(func, WriteToLog);
+            var rule = rules.FirstOrDefault(r => r.Name == ruleDescription.Name);
+            Log(string.Format(CultureInfo.CurrentCulture, RuleCreated, ruleDescription.Name, subscriptionDescription.Name));
+            OnCreated(new ServiceBusHelperEventArgs(new RuleWrapper(rule, subscriptionDescription), EntityType));
+            return rule;
+        }
+
+        /// <summary>
+        /// Removes the rules contained in the list passed as a argument.
+        /// </summary>
+        /// <param name="wrappers">The list containing the ruleWrappers of the rules to remove.</param>
+        public void RemoveRules(IEnumerable<RuleWrapper> wrappers)
+        {
+            if (wrappers == null)
+            {
+                throw new ArgumentException(RuleDescriptionCannotBeNull);
+            }
+            foreach (var wrapper in wrappers)
+            {
+                RemoveRule(wrapper.SubscriptionDescription, wrapper.RuleDescription);
+            }
+        }
+
+        /// <summary>
+        /// Removes the rule described by name.
+        /// </summary>
+        /// <param name="subscriptionDescription">The subscription to add the rule to.</param>
+        /// <param name="name">Name of the rule.</param>
+        public void RemoveRule(SubscriptionDescription subscriptionDescription, string name)
+        {
+            if (subscriptionDescription == null)
+            {
+                throw new ArgumentException(SubscriptionDescriptionCannotBeNull);
+            }
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException(NameCannotBeNull);
+            }
+            var subscriptionClient = messagingFactory.CreateSubscriptionClient(subscriptionDescription.TopicPath,
+                                                                               subscriptionDescription.Name);
+            RetryHelper.RetryAction(() => subscriptionClient.RemoveRule(name), WriteToLog);
+            Log(string.Format(CultureInfo.CurrentCulture, RuleDeleted, name, subscriptionClient.Name));
+            OnDeleted(new ServiceBusHelperEventArgs(name, EntityType.Rule));
+        }
+
+        /// <summary>
+        /// Removes the rule passed as a argument.
+        /// </summary>
+        /// <param name="subscriptionDescription">A subscription belonging to the current service namespace base.</param>
+        /// <param name="rule">The rule to remove.</param>
+        public void RemoveRule(SubscriptionDescription subscriptionDescription, RuleDescription rule)
+        {
+            if (subscriptionDescription == null)
+            {
+                throw new ArgumentException(SubscriptionDescriptionCannotBeNull);
+            }
+            if (rule == null)
+            {
+                throw new ArgumentException(RuleCannotBeNull);
+            }
+            var subscriptionClient = messagingFactory.CreateSubscriptionClient(subscriptionDescription.TopicPath,
+                                                                               subscriptionDescription.Name);
+            RetryHelper.RetryAction(() => subscriptionClient.RemoveRule(rule.Name), WriteToLog);
+            Log(string.Format(CultureInfo.CurrentCulture, RuleDeleted, rule.Name, subscriptionClient.Name));
+            OnDeleted(new ServiceBusHelperEventArgs(new RuleWrapper(rule, subscriptionDescription), EntityType.Rule));
+        }
+    }
+}


### PR DESCRIPTION
Part 04 of refactoring the ServiceBusHelper class #686. This is a fairly straight-forward 'move code to different class' to simplify the changes.

This part is moving Rules 'management actions' - that is, actions for Rules that need the `Microsoft.ServiceBus.NamespaceManager` to work, or add/remove actions on Rules which can only be done via `MessagingFactory`.

In addition:
* Add a general OnDeleted() method because some Rule events use a custom type `RuleWrapper` for `ServiceBusHelperEventArgs.EntityInstance`, which in turn is used in various UI Controls