### PR TITLE
Enable preview builds again

### DIFF
--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -21,12 +21,23 @@ jobs:
           $regex = [Regex]::New($env:VERSION_REGEX)
           $version = $regex.Match($wingetRelevantAsset.name).Groups[1].Value
 
+          if ($version -eq '') {
+            Write-Error "Version not found in asset name: $($wingetRelevantAsset.name)"
+            exit 1
+          } else {
+            Write-Host "Version found: $version"
+          }       
+
           $wingetPackage = "PaoloSalvatori.ServiceBusExplorer${{ github.event.release.prerelease && '.Preview' || '' }}"
+
+          # URL
+          $zipUrl = $wingetRelevantAsset.browser_download_url
+          write-host "URL: $zipUrl"
 
           # Get the latest wingetcreate file
           Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
 
           # Submit a PR for the package
-          .\wingetcreate.exe update $wingetPackage --submit --version $version --urls $wingetRelevantAsset.browser_download_url --token "${{ secrets.GITHUB_TOKEN }}"
+          .\wingetcreate.exe update $wingetPackage --submit --version $version --urls $zipUrl --token "${{ secrets.GITHUB_TOKEN }}" 
 
           

--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -6,7 +6,8 @@
     <TargetFramework>net472</TargetFramework>
     <LangVersion>latest</LangVersion>
     <OutputPath>bin\$(Configuration)\</OutputPath>
-	<AssemblyVersion>1.0.0.1</AssemblyVersion>
+    <AssemblyVersion>1.0.0.1</AssemblyVersion>
+    <NoWarn>7035</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>

--- a/src/EventGridExplorerLibrary/EventGridExplorerLibrary.csproj
+++ b/src/EventGridExplorerLibrary/EventGridExplorerLibrary.csproj
@@ -6,7 +6,8 @@
 		<AssemblyVersion>1.0.0.1</AssemblyVersion>
 		<RootNamespace>EventGridExplorerLibrary</RootNamespace>
 		<AssemblyName>ServiceBusExplorer.EventGridExplorerLibrary</AssemblyName>
-	</PropertyGroup>
+    <NoWarn>7035</NoWarn>
+  </PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 	  <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/src/EventHubs/EventHubs.csproj
+++ b/src/EventHubs/EventHubs.csproj
@@ -5,7 +5,8 @@
 		<AssemblyName>ServiceBusExplorer.EventHubs</AssemblyName>
 		<RootNamespace>ServiceBusExplorer.EventHubs</RootNamespace>
 		<AssemblyVersion>1.0.0.1</AssemblyVersion>
-	</PropertyGroup>
+    <NoWarn>7035</NoWarn>
+  </PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 	  <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 	</PropertyGroup>

--- a/src/NotificationHubs/NotificationHubs.csproj
+++ b/src/NotificationHubs/NotificationHubs.csproj
@@ -9,7 +9,8 @@
 		<Product>NotificationHubs</Product>
 		<Copyright>Copyright ©  2019</Copyright>
 		<OutputPath>bin\$(Configuration)\</OutputPath>
-	</PropertyGroup>
+    <NoWarn>7035</NoWarn>
+  </PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 		<DebugType>full</DebugType>
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/src/Relay/Relay.csproj
+++ b/src/Relay/Relay.csproj
@@ -4,7 +4,8 @@
 		<LangVersion>7.3</LangVersion>
 		<AssemblyName>ServiceBusExplorer.Relay</AssemblyName>
 		<AssemblyVersion>1.0.0.1</AssemblyVersion>
-	</PropertyGroup>
+    <NoWarn>7035</NoWarn>
+  </PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 	  <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 	</PropertyGroup>

--- a/src/ServiceBus/ServiceBus.csproj
+++ b/src/ServiceBus/ServiceBus.csproj
@@ -3,7 +3,8 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<AssemblyName>ServiceBusExplorer.ServiceBus</AssemblyName>
 		<AssemblyVersion>1.0.0.1</AssemblyVersion>
-	</PropertyGroup>
+    <NoWarn>7035</NoWarn>
+  </PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 	  <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 	</PropertyGroup>

--- a/src/ServiceBusExplorer.Tests/ServiceBusExplorer.Tests.csproj
+++ b/src/ServiceBusExplorer.Tests/ServiceBusExplorer.Tests.csproj
@@ -9,7 +9,8 @@
 		<Product>ServiceBusExplorer.Tests</Product>
 		<Copyright>Copyright © Microsoft 2016</Copyright>
 		<OutputPath>bin\$(Configuration)\</OutputPath>
-	</PropertyGroup>
+    <NoWarn>7035</NoWarn>
+  </PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 	  <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 	</PropertyGroup>

--- a/src/ServiceBusExplorer/ServiceBusExplorer.csproj
+++ b/src/ServiceBusExplorer/ServiceBusExplorer.csproj
@@ -40,7 +40,8 @@
 		<PackageProjectUrl>https://github.com/paolosalvatori/ServiceBusExplorer</PackageProjectUrl>
 		<PackageReleaseNotes>https://github.com/paolosalvatori/ServiceBusExplorer/releases</PackageReleaseNotes>
 		<PackageTags>servicebusexplorer azure azureservicebus servicebus explorer eventhub queue subscription relay notificationhub</PackageTags>
-	</PropertyGroup>
+    <NoWarn>7035</NoWarn>
+  </PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
 		<PlatformTarget>AnyCPU</PlatformTarget>
 		<DebugType>full</DebugType>

--- a/src/Utilities/Utilities.csproj
+++ b/src/Utilities/Utilities.csproj
@@ -6,6 +6,7 @@
 		<AssemblyName>ServiceBusExplorer.Utilities</AssemblyName>
 		<AssemblyVersion>1.0.0.1</AssemblyVersion>
 		<RootNamespace>ServiceBusExplorer.Utilities</RootNamespace>
+    <NoWarn>7035</NoWarn>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 	  <TreatWarningsAsErrors>True</TreatWarningsAsErrors>


### PR DESCRIPTION
There was a regression bug that stopped preview builds. This should enable it. 

Also sneaked in a minor change to the GitHub Workflows that publishes the package to WinGet. This will still not make it work though.