### PR TITLE
Ctrl+F in message text box no longer hijacked by TreeView filter (#873)

### DIFF
--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -7748,11 +7748,22 @@ namespace ServiceBusExplorer.Forms
         {
             if (keyData == (Keys.Control | Keys.F))
             {
+                if (GetFocusedControl(this) is FastColoredTextBoxNS.FastColoredTextBox)
+                {
+                    return base.ProcessCmdKey(ref msg, keyData);
+                }
                 filterTreeViewTextBox.Focus();
                 filterTreeViewTextBox.SelectAll();
                 return true;
             }
             return base.ProcessCmdKey(ref msg, keyData);
+        }
+
+        private static Control GetFocusedControl(Control control)
+        {
+            if (control is ContainerControl cc && cc.ActiveControl != null)
+                return GetFocusedControl(cc.ActiveControl);
+            return control;
         }
 
         #endregion


### PR DESCRIPTION
## Summary

Fixes #873 — `Ctrl+F` pressed while the message body (`FastColoredTextBox`) has focus no longer redirects to the TreeView filter box.

## Root cause

`ProcessCmdKey` in `MainForm` intercepted `Ctrl+F` unconditionally, including when a `FastColoredTextBox` (message text, deadletter text) had focus.

## Fix

Added a `GetFocusedControl` helper that walks the `ContainerControl` hierarchy to find the actual focused control. If it is a `FastColoredTextBox`, the key event is passed through to the control's native handler.

```csharp
protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
{
    if (keyData == (Keys.Control | Keys.F))
    {
        if (GetFocusedControl(this) is FastColoredTextBoxNS.FastColoredTextBox)
            return base.ProcessCmdKey(ref msg, keyData);

        filterTreeViewTextBox.Focus();
        filterTreeViewTextBox.SelectAll();
        return true;
    }
    return base.ProcessCmdKey(ref msg, keyData);
}

private static Control GetFocusedControl(Control control)
{
    if (control is ContainerControl cc && cc.ActiveControl != null)
        return GetFocusedControl(cc.ActiveControl);
    return control;
}
```

## Test plan

- [x] Ctrl+F with Message Text box focused → stays in text box (native find)
- [x] Ctrl+F with Deadletter Text box focused → stays in text box
- [x] Ctrl+F with focus elsewhere (tree, properties grid) → focuses TreeView filter box