### PR TITLE
Add the same menu items for subscriptions as for queues

### DIFF
--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.Designer.cs
@@ -125,18 +125,18 @@
             this.saveSelectedMessageBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveSelectedMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveSelectedMessagesBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.sharedDeadletterContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.deadletterContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.repairAndResubmitSharedDeadletterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resubmitSharedDeadletterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resubmitSelectedSharedDeadletterInBatchModeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.selectAllSharedDeadletterMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-            this.saveSelectedSharedDeadletteredMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveSelectedSharedDeadletteredMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.deleteSelectedSharedDeadletterMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.deleteSelectedSharedDeadletterMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveSelectedDeadletteredMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveSelectedDeadletteredMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.deleteSelectedDeadletterMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.deleteSelectedDeadletterMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.messagesBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.sessionsBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.deadletterBindingSource = new System.Windows.Forms.BindingSource(this.components);
@@ -233,7 +233,7 @@
             this.grouperSessionState.SuspendLayout();
             this.grouperSessionProperties.SuspendLayout();
             this.messagesContextMenuStrip.SuspendLayout();
-            this.sharedDeadletterContextMenuStrip.SuspendLayout();
+            this.deadletterContextMenuStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.messagesBindingSource)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.sessionsBindingSource)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.deadletterBindingSource)).BeginInit();
@@ -2170,23 +2170,23 @@
             this.saveSelectedMessagesBodyAsFileToolStripMenuItem.Text = "Save Selected Messages Text as File";
             this.saveSelectedMessagesBodyAsFileToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedMessagesBodyAsFileToolStripMenuItem_Click);
             // 
-            // sharedDeadletterContextMenuStrip
+            // deadletterContextMenuStrip
             // 
-            this.sharedDeadletterContextMenuStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.sharedDeadletterContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.deadletterContextMenuStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
+            this.deadletterContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.repairAndResubmitSharedDeadletterToolStripMenuItem,
             this.resubmitSharedDeadletterToolStripMenuItem,
             this.resubmitSelectedSharedDeadletterInBatchModeToolStripMenuItem,
             this.selectAllSharedDeadletterMessagesToolStripMenuItem,
             this.toolStripSeparator2,
-            this.saveSelectedSharedDeadletteredMessageToolStripMenuItem,
-            this.saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem,
-            this.saveSelectedSharedDeadletteredMessagesToolStripMenuItem,
-            this.saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem,
-            this.deleteSelectedSharedDeadletterMessageToolStripMenuItem,
-            this.deleteSelectedSharedDeadletterMessagesToolStripMenuItem});
-            this.sharedDeadletterContextMenuStrip.Name = "registrationContextMenuStrip";
-            this.sharedDeadletterContextMenuStrip.Size = new System.Drawing.Size(306, 230);
+            this.saveSelectedDeadletteredMessageToolStripMenuItem,
+            this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem,
+            this.saveSelectedDeadletteredMessagesToolStripMenuItem,
+            this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem,
+            this.deleteSelectedDeadletterMessageToolStripMenuItem,
+            this.deleteSelectedDeadletterMessagesToolStripMenuItem});
+            this.deadletterContextMenuStrip.Name = "registrationContextMenuStrip";
+            this.deadletterContextMenuStrip.Size = new System.Drawing.Size(306, 230);
             // 
             // repairAndResubmitSharedDeadletterToolStripMenuItem
             // 
@@ -2223,47 +2223,47 @@
             this.toolStripSeparator2.Name = "toolStripSeparator2";
             this.toolStripSeparator2.Size = new System.Drawing.Size(302, 6);
             // 
-            // saveSelectedSharedDeadletteredMessageToolStripMenuItem
+            // saveSelectedDeadletteredMessageToolStripMenuItem
             // 
-            this.saveSelectedSharedDeadletteredMessageToolStripMenuItem.Name = "saveSelectedSharedDeadletteredMessageToolStripMenuItem";
-            this.saveSelectedSharedDeadletteredMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.saveSelectedSharedDeadletteredMessageToolStripMenuItem.Text = "Save Selected Message";
-            this.saveSelectedSharedDeadletteredMessageToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedSharedDeadletteredMessageToolStripMenuItem_Click);
+            this.saveSelectedDeadletteredMessageToolStripMenuItem.Name = "saveSelectedDeadletteredMessageToolStripMenuItem";
+            this.saveSelectedDeadletteredMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.saveSelectedDeadletteredMessageToolStripMenuItem.Text = "Save Selected Message";
+            this.saveSelectedDeadletteredMessageToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedSharedDeadletteredMessageToolStripMenuItem_Click);
             // 
-            // saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem
+            // saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem
             // 
-            this.saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem.Name = "saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem";
-            this.saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem.Text = "Save Selected Message Text as File";
-            this.saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem_Click);
+            this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem.Name = "saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem";
+            this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem.Text = "Save Selected Message Text as File";
+            this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem_Click);
             // 
-            // saveSelectedSharedDeadletteredMessagesToolStripMenuItem
+            // saveSelectedDeadletteredMessagesToolStripMenuItem
             // 
-            this.saveSelectedSharedDeadletteredMessagesToolStripMenuItem.Name = "saveSelectedSharedDeadletteredMessagesToolStripMenuItem";
-            this.saveSelectedSharedDeadletteredMessagesToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.saveSelectedSharedDeadletteredMessagesToolStripMenuItem.Text = "Save Selected Messages";
-            this.saveSelectedSharedDeadletteredMessagesToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedSharedDeadletteredMessagesToolStripMenuItem_Click);
+            this.saveSelectedDeadletteredMessagesToolStripMenuItem.Name = "saveSelectedDeadletteredMessagesToolStripMenuItem";
+            this.saveSelectedDeadletteredMessagesToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.saveSelectedDeadletteredMessagesToolStripMenuItem.Text = "Save Selected Messages";
+            this.saveSelectedDeadletteredMessagesToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedSharedDeadletteredMessagesToolStripMenuItem_Click);
             // 
-            // saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem
+            // saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem
             // 
-            this.saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem.Name = "saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem";
-            this.saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem.Text = "Save Selected Messages Text as File";
-            this.saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem_Click);
+            this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem.Name = "saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem";
+            this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem.Text = "Save Selected Messages Text as File";
+            this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem_Click);
             // 
-            // deleteSelectedSharedDeadletterMessageToolStripMenuItem
+            // deleteSelectedDeadletterMessageToolStripMenuItem
             // 
-            this.deleteSelectedSharedDeadletterMessageToolStripMenuItem.Name = "deleteSelectedSharedDeadletterMessageToolStripMenuItem";
-            this.deleteSelectedSharedDeadletterMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.deleteSelectedSharedDeadletterMessageToolStripMenuItem.Text = "Delete Selected Message";
-            this.deleteSelectedSharedDeadletterMessageToolStripMenuItem.Click += new System.EventHandler(this.deleteSelectedSharedDeadLetterMessageToolStripMenuItem_Click);
+            this.deleteSelectedDeadletterMessageToolStripMenuItem.Name = "deleteSelectedDeadletterMessageToolStripMenuItem";
+            this.deleteSelectedDeadletterMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.deleteSelectedDeadletterMessageToolStripMenuItem.Text = "Delete Selected Message";
+            this.deleteSelectedDeadletterMessageToolStripMenuItem.Click += new System.EventHandler(this.deleteSelectedSharedDeadLetterMessageToolStripMenuItem_Click);
             // 
-            // deleteSelectedSharedDeadletterMessagesToolStripMenuItem
+            // deleteSelectedDeadletterMessagesToolStripMenuItem
             // 
-            this.deleteSelectedSharedDeadletterMessagesToolStripMenuItem.Name = "deleteSelectedSharedDeadletterMessagesToolStripMenuItem";
-            this.deleteSelectedSharedDeadletterMessagesToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
-            this.deleteSelectedSharedDeadletterMessagesToolStripMenuItem.Text = "Delete Selected Messages";
-            this.deleteSelectedSharedDeadletterMessagesToolStripMenuItem.Click += new System.EventHandler(this.deleteSelectedSharedDeadLetterMessagesToolStripMenuItem_Click);
+            this.deleteSelectedDeadletterMessagesToolStripMenuItem.Name = "deleteSelectedDeadletterMessagesToolStripMenuItem";
+            this.deleteSelectedDeadletterMessagesToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.deleteSelectedDeadletterMessagesToolStripMenuItem.Text = "Delete Selected Messages";
+            this.deleteSelectedDeadletterMessagesToolStripMenuItem.Click += new System.EventHandler(this.deleteSelectedSharedDeadLetterMessagesToolStripMenuItem_Click);
             // 
             // btnPurgeMessages
             // 
@@ -2394,7 +2394,7 @@
             this.grouperSessionState.PerformLayout();
             this.grouperSessionProperties.ResumeLayout(false);
             this.messagesContextMenuStrip.ResumeLayout(false);
-            this.sharedDeadletterContextMenuStrip.ResumeLayout(false);
+            this.deadletterContextMenuStrip.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.messagesBindingSource)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.sessionsBindingSource)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.deadletterBindingSource)).EndInit();
@@ -2470,7 +2470,7 @@
         private System.Windows.Forms.ContextMenuStrip messagesContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem repairAndResubmitMessageToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem resubmitSelectedMessagesInBatchModeToolStripMenuItem;
-        private System.Windows.Forms.ContextMenuStrip sharedDeadletterContextMenuStrip;
+        private System.Windows.Forms.ContextMenuStrip deadletterContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem repairAndResubmitSharedDeadletterToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem resubmitSelectedSharedDeadletterInBatchModeToolStripMenuItem;
         private System.Windows.Forms.PictureBox pictFindMessages;
@@ -2485,8 +2485,8 @@
         private System.Windows.Forms.SaveFileDialog saveFileDialog;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
-        private System.Windows.Forms.ToolStripMenuItem saveSelectedSharedDeadletteredMessageToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem saveSelectedSharedDeadletteredMessagesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveSelectedDeadletteredMessageToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveSelectedDeadletteredMessagesToolStripMenuItem;
         private System.Windows.Forms.Button btnPurgeDeadletterQueueMessages;
         private System.Windows.Forms.Button btnPurgeMessages;
         private System.Windows.Forms.TabPage tabPageTransferDeadletter;
@@ -2497,8 +2497,8 @@
         private System.Windows.Forms.PictureBox pictureBox1;
         private System.Windows.Forms.DataGridView transferDeadletterDataGridView;
         private System.Windows.Forms.BindingSource transferDeadletterBindingSource;
-        private System.Windows.Forms.ToolStripMenuItem deleteSelectedSharedDeadletterMessageToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem deleteSelectedSharedDeadletterMessagesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem deleteSelectedDeadletterMessageToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem deleteSelectedDeadletterMessagesToolStripMenuItem;
         private Grouper grouperMessageText;
         private FastColoredTextBoxNS.FastColoredTextBox txtMessageText;
         private System.Windows.Forms.SplitContainer messagePropertiesSplitContainer;
@@ -2519,8 +2519,8 @@
         private Grouper grouperTransferDeadletterCustomProperties;
         private System.Windows.Forms.ToolStripMenuItem saveSelectedMessageBodyAsFileToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveSelectedMessagesBodyAsFileToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem;
         private TimeSpanControl tsAutoDeleteOnIdle;
         private TimeSpanControl tsDefaultMessageTimeToLive;
         private TimeSpanControl tsLockDuration;

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -4379,17 +4379,17 @@ namespace ServiceBusExplorer.Controls
 
             repairAndResubmitSharedDeadletterToolStripMenuItem.Visible = !multipleSelectedRows;
             resubmitSharedDeadletterToolStripMenuItem.Visible = !multipleSelectedRows;
-            saveSelectedSharedDeadletteredMessageToolStripMenuItem.Visible = !multipleSelectedRows;
-            saveSelectedSharedDeadletteredMessageBodyAsFileToolStripMenuItem.Visible = !multipleSelectedRows;
-            deleteSelectedSharedDeadletterMessageToolStripMenuItem.Visible = !multipleSelectedRows;
+            saveSelectedDeadletteredMessageToolStripMenuItem.Visible = !multipleSelectedRows;
+            saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem.Visible = !multipleSelectedRows;
+            deleteSelectedDeadletterMessageToolStripMenuItem.Visible = !multipleSelectedRows;
 
 
             resubmitSelectedSharedDeadletterInBatchModeToolStripMenuItem.Visible = multipleSelectedRows;
-            saveSelectedSharedDeadletteredMessagesToolStripMenuItem.Visible = multipleSelectedRows;
-            saveSelectedSharedDeadletteredMessagesBodyAsFileToolStripMenuItem.Visible = multipleSelectedRows;
-            deleteSelectedSharedDeadletterMessagesToolStripMenuItem.Visible = multipleSelectedRows;
+            saveSelectedDeadletteredMessagesToolStripMenuItem.Visible = multipleSelectedRows;
+            saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem.Visible = multipleSelectedRows;
+            deleteSelectedDeadletterMessagesToolStripMenuItem.Visible = multipleSelectedRows;
 
-            sharedDeadletterContextMenuStrip.Show(Cursor.Position);
+            deadletterContextMenuStrip.Show(Cursor.Position);
         }
 
         void RepairAndResubmitSharedDeadletterMessage(DataGridViewCellEventArgs e)

--- a/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleQueueControl.cs
@@ -4121,11 +4121,8 @@ namespace ServiceBusExplorer.Controls
                 foreach (var body in bodies)
                 {
                     count++;
-                    var fileNameParts = saveFileDialog.FileName.Split('.').ToList();
-                    var fileExtension = fileNameParts.Last();
-                    fileNameParts.RemoveAt(fileNameParts.IndexOf(fileExtension));
-                    fileNameParts.Add($"({count}).{fileExtension}");
-                    var fileName = string.Join(".", fileNameParts);
+                    var fileName = PathHelper.GetNumberedFileName(saveFileDialog.FileName, count);
+
                     if (File.Exists(fileName))
                     {
                         File.Delete(fileName);
@@ -4303,11 +4300,8 @@ namespace ServiceBusExplorer.Controls
                 foreach (var body in bodies)
                 {
                     count++;
-                    var fileNameParts = saveFileDialog.FileName.Split('.').ToList();
-                    var fileExtension = fileNameParts.Last();
-                    fileNameParts.RemoveAt(fileNameParts.IndexOf(fileExtension));
-                    fileNameParts.Add($"({count}).{fileExtension}");
-                    var fileName = string.Join(".", fileNameParts);
+                    var fileName = PathHelper.GetNumberedFileName(saveFileDialog.FileName, count);
+
                     if (File.Exists(fileName))
                     {
                         File.Delete(fileName);

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.Designer.cs
@@ -118,8 +118,11 @@
             this.resubmitMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resubmitSelectedMessagesInBatchModeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.selectAllMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveSelectedMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveSelectedMessageBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveSelectedMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveSelectedMessagesBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.btnPurgeMessages = new System.Windows.Forms.Button();
             this.mainTabControl.SuspendLayout();
             this.tabPageDescription.SuspendLayout();
@@ -1760,12 +1763,15 @@
             this.messagesContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.repairAndResubmitMessageToolStripMenuItem,
             this.resubmitMessageToolStripMenuItem,
+            this.selectAllMessagesToolStripMenuItem,
             this.resubmitSelectedMessagesInBatchModeToolStripMenuItem,
             this.toolStripSeparator1,
             this.saveSelectedMessageToolStripMenuItem,
-            this.saveSelectedMessagesToolStripMenuItem});
+            this.saveSelectedMessageBodyAsFileToolStripMenuItem,
+            this.saveSelectedMessagesToolStripMenuItem,
+            this.saveSelectedMessagesBodyAsFileToolStripMenuItem});
             this.messagesContextMenuStrip.Name = "registrationContextMenuStrip";
-            this.messagesContextMenuStrip.Size = new System.Drawing.Size(306, 120);
+            this.messagesContextMenuStrip.Size = new System.Drawing.Size(306, 208);
             // 
             // repairAndResubmitMessageToolStripMenuItem
             // 
@@ -1794,6 +1800,14 @@
             this.toolStripSeparator1.Name = "toolStripSeparator1";
             this.toolStripSeparator1.Size = new System.Drawing.Size(302, 6);
             // 
+            // selectAllMessagesToolStripMenuItem
+            // 
+            this.selectAllMessagesToolStripMenuItem.Name = "selectAllMessagesToolStripMenuItem";
+            this.selectAllMessagesToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A)));
+            this.selectAllMessagesToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.selectAllMessagesToolStripMenuItem.Text = "Select All Messages";
+            this.selectAllMessagesToolStripMenuItem.Click += new System.EventHandler(this.selectAllMessagesToolStripMenuItem_Click);
+            // 
             // saveSelectedMessageToolStripMenuItem
             // 
             this.saveSelectedMessageToolStripMenuItem.Name = "saveSelectedMessageToolStripMenuItem";
@@ -1801,12 +1815,26 @@
             this.saveSelectedMessageToolStripMenuItem.Text = "Save Selected Message";
             this.saveSelectedMessageToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedMessageToolStripMenuItem_Click);
             // 
+            // saveSelectedMessageBodyAsFileToolStripMenuItem
+            // 
+            this.saveSelectedMessageBodyAsFileToolStripMenuItem.Name = "saveSelectedMessageBodyAsFileToolStripMenuItem";
+            this.saveSelectedMessageBodyAsFileToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.saveSelectedMessageBodyAsFileToolStripMenuItem.Text = "Save Selected Message Text as File";
+            this.saveSelectedMessageBodyAsFileToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedMessageBodyAsFileToolStripMenuItem_Click);
+            // 
             // saveSelectedMessagesToolStripMenuItem
             // 
             this.saveSelectedMessagesToolStripMenuItem.Name = "saveSelectedMessagesToolStripMenuItem";
             this.saveSelectedMessagesToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.saveSelectedMessagesToolStripMenuItem.Text = "Save Selected Messages";
             this.saveSelectedMessagesToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedMessagesToolStripMenuItem_Click);
+            // 
+            // saveSelectedMessagesBodyAsFileToolStripMenuItem
+            // 
+            this.saveSelectedMessagesBodyAsFileToolStripMenuItem.Name = "saveSelectedMessagesBodyAsFileToolStripMenuItem";
+            this.saveSelectedMessagesBodyAsFileToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.saveSelectedMessagesBodyAsFileToolStripMenuItem.Text = "Save Selected Messages Text as File";
+            this.saveSelectedMessagesBodyAsFileToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedMessagesBodyAsFileToolStripMenuItem_Click);
             // 
             // btnPurgeMessages
             // 
@@ -2000,12 +2028,15 @@
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripMenuItem saveSelectedDeadletteredMessageToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveSelectedDeadletteredMessagesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem selectAllMessagesToolStripMenuItem;
         private System.Windows.Forms.ContextMenuStrip messagesContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem repairAndResubmitMessageToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem resubmitSelectedMessagesInBatchModeToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private System.Windows.Forms.ToolStripMenuItem saveSelectedMessageToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveSelectedMessageBodyAsFileToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveSelectedMessagesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveSelectedMessagesBodyAsFileToolStripMenuItem;
         private System.Windows.Forms.Button btnPurgeMessages;
         private System.Windows.Forms.Button btnPurgeDeadletterQueueMessages;
         private System.Windows.Forms.ToolStripMenuItem deleteSelectedMessageToolStripMenuItem;
@@ -2027,7 +2058,8 @@
         private TimeSpanControl tsLockDuration;
         private System.Windows.Forms.PropertyGrid messageCustomPropertyGrid;
         private System.Windows.Forms.PropertyGrid deadletterCustomPropertyGrid;
-        private System.Windows.Forms.ToolStripMenuItem resubmitDeadletterToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem resubmitMessageToolStripMenuItem;
-    }
-}
+                 private System.Windows.Forms.ToolStripMenuItem resubmitDeadletterToolStripMenuItem;
+                 private System.Windows.Forms.ToolStripMenuItem resubmitMessageToolStripMenuItem;
+
+            }
+        }

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.Designer.cs
@@ -110,7 +110,9 @@
             this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.saveSelectedDeadletteredMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveSelectedDeadletteredMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.deleteSelectedMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.deleteSelectedMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.messagesContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
@@ -1696,11 +1698,13 @@
             this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem,
             this.toolStripSeparator2,
             this.saveSelectedDeadletteredMessageToolStripMenuItem,
+            this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem,
             this.saveSelectedDeadletteredMessagesToolStripMenuItem,
+            this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem,
             this.deleteSelectedMessageToolStripMenuItem,
             this.deleteSelectedMessagesToolStripMenuItem});
             this.deadletterContextMenuStrip.Name = "registrationContextMenuStrip";
-            this.deadletterContextMenuStrip.Size = new System.Drawing.Size(306, 186);
+            this.deadletterContextMenuStrip.Size = new System.Drawing.Size(306, 230);
             // 
             // repairAndResubmitSharedDeadletterToolStripMenuItem
             // 
@@ -1736,6 +1740,13 @@
             this.saveSelectedDeadletteredMessageToolStripMenuItem.Text = "Save Selected Message";
             this.saveSelectedDeadletteredMessageToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedDeadletteredMessageToolStripMenuItem_Click);
             // 
+            // saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem
+            // 
+            this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem.Name = "saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem";
+            this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem.Text = "Save Selected Message Text as File";
+            this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem_Click);
+            // 
             // saveSelectedDeadletteredMessagesToolStripMenuItem
             // 
             this.saveSelectedDeadletteredMessagesToolStripMenuItem.Name = "saveSelectedDeadletteredMessagesToolStripMenuItem";
@@ -1743,16 +1754,23 @@
             this.saveSelectedDeadletteredMessagesToolStripMenuItem.Text = "Save Selected Messages";
             this.saveSelectedDeadletteredMessagesToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedDeadletteredMessagesToolStripMenuItem_Click);
             // 
-            // deleteSelectedSharedDeadletterMessageToolStripMenuItem
+            // saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem
             // 
-            this.deleteSelectedMessageToolStripMenuItem.Name = "deleteSelectedSharedDeadletterMessageToolStripMenuItem";
+            this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem.Name = "saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem";
+            this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem.Text = "Save Selected Messages Text as File";
+            this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem.Click += new System.EventHandler(this.saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem_Click);
+            // 
+            // deleteSelectedDeadletterMessageToolStripMenuItem
+            // 
+            this.deleteSelectedMessageToolStripMenuItem.Name = "deleteSelectedDeadletterMessageToolStripMenuItem";
             this.deleteSelectedMessageToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.deleteSelectedMessageToolStripMenuItem.Text = "Delete Selected Message";
             this.deleteSelectedMessageToolStripMenuItem.Click += new System.EventHandler(this.deleteSelectedMessageToolStripMenuItem_Click);
             // 
-            // deleteSelectedSharedDeadletterMessagesToolStripMenuItem
+            // deleteSelectedDeadletterMessagesToolStripMenuItem
             // 
-            this.deleteSelectedMessagesToolStripMenuItem.Name = "deleteSelectedSharedDeadletterMessagesToolStripMenuItem";
+            this.deleteSelectedMessagesToolStripMenuItem.Name = "deleteSelectedDeadletterMessagesToolStripMenuItem";
             this.deleteSelectedMessagesToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.deleteSelectedMessagesToolStripMenuItem.Text = "Delete Selected Messages";
             this.deleteSelectedMessagesToolStripMenuItem.Click += new System.EventHandler(this.deleteSelectedMessagesToolStripMenuItem_Click);
@@ -2027,7 +2045,9 @@
         private System.Windows.Forms.ToolStripMenuItem resubmitSelectedDeadletterInBatchModeToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripMenuItem saveSelectedDeadletteredMessageToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveSelectedDeadletteredMessagesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem selectAllMessagesToolStripMenuItem;
         private System.Windows.Forms.ContextMenuStrip messagesContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem repairAndResubmitMessageToolStripMenuItem;

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.Designer.cs
@@ -108,6 +108,7 @@
             this.repairAndResubmitDeadletterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resubmitDeadletterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.selectAllDeadletterMessagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.saveSelectedDeadletteredMessageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -1696,6 +1697,7 @@
             this.repairAndResubmitDeadletterToolStripMenuItem,
             this.resubmitDeadletterToolStripMenuItem,
             this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem,
+            this.selectAllDeadletterMessagesToolStripMenuItem,
             this.toolStripSeparator2,
             this.saveSelectedDeadletteredMessageToolStripMenuItem,
             this.saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem,
@@ -1727,6 +1729,14 @@
             this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
             this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem.Text = "Resubmit Selected Messages In Batch Mode";
             this.resubmitSelectedDeadletterInBatchModeToolStripMenuItem.Click += new System.EventHandler(this.resubmitSelectedDeadletterMessagesInBatchModeToolStripMenuItem_Click);
+            // 
+            // selectAllDeadletterMessagesToolStripMenuItem
+            // 
+            this.selectAllDeadletterMessagesToolStripMenuItem.Name = "selectAllDeadletterMessagesToolStripMenuItem";
+            this.selectAllDeadletterMessagesToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A)));
+            this.selectAllDeadletterMessagesToolStripMenuItem.Size = new System.Drawing.Size(305, 22);
+            this.selectAllDeadletterMessagesToolStripMenuItem.Text = "Select All Messages";
+            this.selectAllDeadletterMessagesToolStripMenuItem.Click += new System.EventHandler(this.selectAllDeadletterMessagesToolStripMenuItem_Click);
             // 
             // toolStripSeparator2
             // 
@@ -2043,6 +2053,7 @@
         private System.Windows.Forms.ContextMenuStrip deadletterContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem repairAndResubmitDeadletterToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem resubmitSelectedDeadletterInBatchModeToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem selectAllDeadletterMessagesToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripMenuItem saveSelectedDeadletteredMessageToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem;

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.Designer.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.Designer.cs
@@ -2089,8 +2089,7 @@
         private TimeSpanControl tsLockDuration;
         private System.Windows.Forms.PropertyGrid messageCustomPropertyGrid;
         private System.Windows.Forms.PropertyGrid deadletterCustomPropertyGrid;
-                 private System.Windows.Forms.ToolStripMenuItem resubmitDeadletterToolStripMenuItem;
-                 private System.Windows.Forms.ToolStripMenuItem resubmitMessageToolStripMenuItem;
-
-            }
-        }
+        private System.Windows.Forms.ToolStripMenuItem resubmitDeadletterToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem resubmitMessageToolStripMenuItem;
+    }
+}

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -2416,10 +2416,12 @@ namespace ServiceBusExplorer.Controls
             repairAndResubmitDeadletterToolStripMenuItem.Visible = !multipleSelectedRows;
             resubmitDeadletterToolStripMenuItem.Visible = !multipleSelectedRows;
             saveSelectedDeadletteredMessageToolStripMenuItem.Visible = !multipleSelectedRows;
+            saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem.Visible = !multipleSelectedRows;
             deleteSelectedMessageToolStripMenuItem.Visible = !multipleSelectedRows;
 
             resubmitSelectedDeadletterInBatchModeToolStripMenuItem.Visible = multipleSelectedRows;
             saveSelectedDeadletteredMessagesToolStripMenuItem.Visible = multipleSelectedRows;
+            saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem.Visible = multipleSelectedRows;
             deleteSelectedMessagesToolStripMenuItem.Visible = multipleSelectedRows;
 
             deadletterContextMenuStrip.Show(Cursor.Position);
@@ -3047,6 +3049,99 @@ namespace ServiceBusExplorer.Controls
                     var bodies = brokeredMessages.Select(bm => serviceBusHelper.GetMessageText(bm,
                          MainForm.SingletonMainForm.UseAscii, out _));
                     writer.Write(MessageSerializationHelper.Serialize(brokeredMessages, bodies, doNotSerializeBody: true));
+                }
+            }
+            catch (Exception ex)
+            {
+                HandleException(ex);
+            }
+        }
+
+        private void saveSelectedDeadletteredMessageBodyAsFileToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                if (currentDeadletterMessageRowIndex < 0)
+                {
+                    return;
+                }
+                var bindingList = deadletterBindingSource.DataSource as BindingList<BrokeredMessage>;
+                if (bindingList == null)
+                {
+                    return;
+                }
+                if (string.IsNullOrWhiteSpace(txtDeadletterText.Text))
+                {
+                    return;
+                }
+                saveFileDialog.RestoreDirectory = true;
+                saveFileDialog.Title = SaveAsTitle;
+                saveFileDialog.DefaultExt = TxtExtension;
+                saveFileDialog.Filter = AllFilesFilter;
+                saveFileDialog.FileName = CreateFileNameAutoRecognize();
+                if (saveFileDialog.ShowDialog() != DialogResult.OK ||
+                    string.IsNullOrWhiteSpace(saveFileDialog.FileName))
+                {
+                    return;
+                }
+                if (File.Exists(saveFileDialog.FileName))
+                {
+                    File.Delete(saveFileDialog.FileName);
+                }
+                using (var writer = new StreamWriter(saveFileDialog.FileName))
+                {
+                    writer.Write(txtDeadletterText.Text);
+                }
+            }
+            catch (Exception ex)
+            {
+                HandleException(ex);
+            }
+        }
+
+        private void saveSelectedDeadletteredMessagesBodyAsFileToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                if (deadletterDataGridView.SelectedRows.Count <= 0)
+                {
+                    return;
+                }
+                var messages = deadletterDataGridView.SelectedRows.Cast<DataGridViewRow>().Select(r => r.DataBoundItem as BrokeredMessage);
+                IEnumerable<BrokeredMessage> brokeredMessages = messages as BrokeredMessage[] ?? messages.ToArray();
+                if (!brokeredMessages.Any())
+                {
+                    return;
+                }
+                saveFileDialog.RestoreDirectory = true;
+                saveFileDialog.Title = SaveAsTitle;
+                saveFileDialog.DefaultExt = TxtExtension;
+                saveFileDialog.Filter = AllFilesFilter;
+                saveFileDialog.FileName = CreateFileNameAutoRecognize();
+                if (saveFileDialog.ShowDialog() != DialogResult.OK ||
+                    string.IsNullOrWhiteSpace(saveFileDialog.FileName))
+                {
+                    return;
+                }
+                var bodies = brokeredMessages.Select(bm => serviceBusHelper.GetMessageText(bm,
+                    MainForm.SingletonMainForm.UseAscii, out _));
+                var count = 0;
+                foreach (var body in bodies)
+                {
+                    count++;
+                    var fileNameParts = saveFileDialog.FileName.Split('.').ToList();
+                    var fileExtension = fileNameParts.Last();
+                    fileNameParts.RemoveAt(fileNameParts.IndexOf(fileExtension));
+                    fileNameParts.Add($"({count}).{fileExtension}");
+                    var fileName = string.Join(".", fileNameParts);
+                    if (File.Exists(fileName))
+                    {
+                        File.Delete(fileName);
+                    }
+                    using (var writer = new StreamWriter(fileName))
+                    {
+                        writer.Write(body);
+                    }
                 }
             }
             catch (Exception ex)

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -162,7 +162,10 @@ namespace ServiceBusExplorer.Controls
         private const string SaveAsTitle = "Save File As";
         private const string JsonExtension = "json";
         private const string JsonFilter = "JSON Files|*.json|Text Documents|*.txt";
+        private const string TxtExtension = "txt";
+        private const string AllFilesFilter = "Text Documents|*.txt|JSON Files|*.json|XML Files|*.xml|All Files (*.*)|*.*";
         private const string MessageFileFormat = "BrokeredMessage_{0}_{1}.json";
+        private const string MessageFileFormatAutoRecognize = "BrokeredMessage_{0}_{1}.txt";
 
 
         //***************************
@@ -2290,8 +2293,10 @@ namespace ServiceBusExplorer.Controls
             repairAndResubmitMessageToolStripMenuItem.Visible = !multipleSelectedRows;
             resubmitMessageToolStripMenuItem.Visible = !multipleSelectedRows;
             saveSelectedMessageToolStripMenuItem.Visible = !multipleSelectedRows;
+            saveSelectedMessageBodyAsFileToolStripMenuItem.Visible = !multipleSelectedRows;
             resubmitSelectedMessagesInBatchModeToolStripMenuItem.Visible = multipleSelectedRows;
             saveSelectedMessagesToolStripMenuItem.Visible = multipleSelectedRows;
+            saveSelectedMessagesBodyAsFileToolStripMenuItem.Visible = multipleSelectedRows;
             messagesContextMenuStrip.Show(Cursor.Position);
         }
 
@@ -2871,6 +2876,104 @@ namespace ServiceBusExplorer.Controls
             }
         }
 
+        private void saveSelectedMessageBodyAsFileToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                if (currentMessageRowIndex < 0)
+                {
+                    return;
+                }
+                var bindingList = messagesBindingSource.DataSource as BindingList<BrokeredMessage>;
+                if (bindingList == null)
+                {
+                    return;
+                }
+                if (string.IsNullOrWhiteSpace(txtMessageText.Text))
+                {
+                    return;
+                }
+                saveFileDialog.RestoreDirectory = true;
+                saveFileDialog.Title = SaveAsTitle;
+                saveFileDialog.DefaultExt = TxtExtension;
+                saveFileDialog.Filter = AllFilesFilter;
+                saveFileDialog.FileName = CreateFileNameAutoRecognize();
+                if (saveFileDialog.ShowDialog() != DialogResult.OK ||
+                    string.IsNullOrWhiteSpace(saveFileDialog.FileName))
+                {
+                    return;
+                }
+                if (File.Exists(saveFileDialog.FileName))
+                {
+                    File.Delete(saveFileDialog.FileName);
+                }
+                using (var writer = new StreamWriter(saveFileDialog.FileName))
+                {
+                    writer.Write(txtMessageText.Text);
+                }
+            }
+            catch (Exception ex)
+            {
+                HandleException(ex);
+            }
+        }
+
+        private void saveSelectedMessagesBodyAsFileToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                if (messagesDataGridView.SelectedRows.Count <= 0)
+                {
+                    return;
+                }
+                var messages = messagesDataGridView.SelectedRows.Cast<DataGridViewRow>().Select(r => r.DataBoundItem as BrokeredMessage);
+                IEnumerable<BrokeredMessage> brokeredMessages = messages as BrokeredMessage[] ?? messages.ToArray();
+                if (!brokeredMessages.Any())
+                {
+                    return;
+                }
+                saveFileDialog.RestoreDirectory = true;
+                saveFileDialog.Title = SaveAsTitle;
+                saveFileDialog.DefaultExt = TxtExtension;
+                saveFileDialog.Filter = AllFilesFilter;
+                saveFileDialog.FileName = CreateFileNameAutoRecognize();
+                if (saveFileDialog.ShowDialog() != DialogResult.OK ||
+                    string.IsNullOrWhiteSpace(saveFileDialog.FileName))
+                {
+                    return;
+                }
+                var bodies = brokeredMessages.Select(bm => serviceBusHelper.GetMessageText(bm,
+                    MainForm.SingletonMainForm.UseAscii, out _));
+                var count = 0;
+                foreach (var body in bodies)
+                {
+                    count++;
+                    var fileNameParts = saveFileDialog.FileName.Split('.').ToList();
+                    var fileExtension = fileNameParts.Last();
+                    fileNameParts.RemoveAt(fileNameParts.IndexOf(fileExtension));
+                    fileNameParts.Add($"({count}).{fileExtension}");
+                    var fileName = string.Join(".", fileNameParts);
+                    if (File.Exists(fileName))
+                    {
+                        File.Delete(fileName);
+                    }
+                    using (var writer = new StreamWriter(fileName))
+                    {
+                        writer.Write(body);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                HandleException(ex);
+            }
+        }
+
+        private void selectAllMessagesToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            messagesDataGridView.SelectAll();
+        }
+
         private void saveSelectedDeadletteredMessageToolStripMenuItem_Click(object sender, EventArgs e)
         {
             try
@@ -2957,6 +3060,13 @@ namespace ServiceBusExplorer.Controls
             return string.Format(MessageFileFormat,
                                  CultureInfo.CurrentCulture.TextInfo.ToTitleCase(serviceBusHelper.Namespace),
                                  DateTime.Now.ToString(CultureInfo.InvariantCulture).Replace('/', '-').Replace(':', '-'));
+        }
+
+        private string CreateFileNameAutoRecognize()
+        {
+            return string.Format(MessageFileFormatAutoRecognize,
+                CultureInfo.CurrentCulture.TextInfo.ToTitleCase(serviceBusHelper.Namespace),
+                DateTime.Now.ToString(CultureInfo.InvariantCulture).Replace('/', '-').Replace(':', '-'));
         }
 
         private async void btnPurgeMessages_Click(object sender, EventArgs e)

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -2955,15 +2955,13 @@ namespace ServiceBusExplorer.Controls
                 foreach (var body in bodies)
                 {
                     count++;
-                    var fileNameParts = saveFileDialog.FileName.Split('.').ToList();
-                    var fileExtension = fileNameParts.Last();
-                    fileNameParts.RemoveAt(fileNameParts.IndexOf(fileExtension));
-                    fileNameParts.Add($"({count}).{fileExtension}");
-                    var fileName = string.Join(".", fileNameParts);
+                    var fileName = PathHelper.GetNumberedFileName(saveFileDialog.FileName, count);
+
                     if (File.Exists(fileName))
                     {
                         File.Delete(fileName);
                     }
+
                     using (var writer = new StreamWriter(fileName))
                     {
                         writer.Write(body);
@@ -3134,15 +3132,13 @@ namespace ServiceBusExplorer.Controls
                 foreach (var body in bodies)
                 {
                     count++;
-                    var fileNameParts = saveFileDialog.FileName.Split('.').ToList();
-                    var fileExtension = fileNameParts.Last();
-                    fileNameParts.RemoveAt(fileNameParts.IndexOf(fileExtension));
-                    fileNameParts.Add($"({count}).{fileExtension}");
-                    var fileName = string.Join(".", fileNameParts);
+                    var fileName = PathHelper.GetNumberedFileName(saveFileDialog.FileName, count);
+
                     if (File.Exists(fileName))
                     {
                         File.Delete(fileName);
                     }
+
                     using (var writer = new StreamWriter(fileName))
                     {
                         writer.Write(body);

--- a/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
+++ b/src/ServiceBusExplorer/Controls/HandleSubscriptionControl.cs
@@ -2442,6 +2442,11 @@ namespace ServiceBusExplorer.Controls
             await ResubmitSelectedDeadletterMessages();
         }
 
+        private void selectAllDeadletterMessagesToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            deadletterDataGridView.SelectAll();
+        }
+
         private async Task ResubmitSelectedDeadletterMessages()
         {
             try

--- a/src/Utilities/Helpers/PathHelper.cs
+++ b/src/Utilities/Helpers/PathHelper.cs
@@ -1,0 +1,22 @@
+﻿#region Using Directives
+
+using System.IO;
+
+#endregion
+
+
+namespace ServiceBusExplorer.Utilities.Helpers
+{
+    public static class PathHelper
+    {
+        public static string GetNumberedFileName(string fileName, int count)
+        {
+            var directory = Path.GetDirectoryName(fileName);
+            var baseName = Path.GetFileNameWithoutExtension(fileName);
+            var extension = Path.GetExtension(fileName);
+            var fileNameWithCount = Path.Combine(directory ?? string.Empty, $"{baseName}({count}){extension}");
+
+            return fileNameWithCount;
+        }
+    }
+}


### PR DESCRIPTION
There are several menu items that are missing from the message grid for dead-letter queue messages in subscriptions. This PR brings makes them available for subscriptions too. 

Removed the word 'shared' from some menu items variable names since they weren't shared. 

This causes some code duplication, but that will be handled in a separate PR.