### PR TITLE
In debug version inform user do not ask for new version

### DIFF
--- a/src/ServiceBusExplorer/Forms/MainForm.cs
+++ b/src/ServiceBusExplorer/Forms/MainForm.cs
@@ -414,6 +414,11 @@ namespace ServiceBusExplorer.Forms
 
         void DisplayNewVersionInformation()
         {
+#if DEBUG
+            linkLabelNewVersionAvailable.Visible = true;
+            linkLabelNewVersionAvailable.Enabled = false;
+            linkLabelNewVersionAvailable.Text = $"Debug Version";
+#else
             if (!VersionProvider.IsLatestVersion(out var releaseInfo, WriteToLog))
             {
                 linkLabelNewVersionAvailable.Visible = true;
@@ -423,6 +428,7 @@ namespace ServiceBusExplorer.Forms
             {
                 linkLabelNewVersionAvailable.Visible = false;
             }
+#endif
         }
 
         private void UpdateSavedConnectionsMenu()
@@ -490,7 +496,7 @@ namespace ServiceBusExplorer.Forms
             argumentName = argument;
             argumentValue = value;
         }
-        #endregion
+#endregion
 
         #region Event Handlers
         private void duplicateSubscriptionMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
In main Form when in debug mode, it always ask for to update

<img width="904" height="436" alt="image" src="https://github.com/user-attachments/assets/710683c3-48b7-44d4-a4fd-d89b7e33bbe3" />

After

<img width="904" height="437" alt="image" src="https://github.com/user-attachments/assets/21bcdf88-d198-4768-a983-ce3ac3782896" />
